### PR TITLE
fifth-pass code review: 16 findings fixed, plus resource embedding

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -63,6 +63,18 @@
  ;; before that namespace is required.
  :jolt/native [{:name "libc (POSIX sockets)" :process true}]
 
+ ;; Bake resources/ into the binary, so io/resource resolves with no files on
+ ;; disk and a built harness runs from any cwd.
+ ;;
+ ;; `jolt build` links code and deps, not data: without this the binary
+ ;; resolved gates.edn, phases.edn, wordlists.edn, prompts/, manifests/ and
+ ;; cells/ RELATIVE TO THE WORKING DIRECTORY, so it booted from the project
+ ;; root and died anywhere else with "Cannot open <nil> as a Reader" — a
+ ;; nil resource handed to slurp, from the first reload-config! in
+ ;; system/start!. Every "works interpreted and inside an AOT binary" comment
+ ;; on an io/resource seam in src was true only by accident of cwd.
+ :jolt/build {:embed ["resources"]}
+
  :nrepl/middleware [nrepl.middleware/default-middleware]
 
  :aliases {:test {:extra-paths ["test" "gui"]

--- a/gui/samizdat/gui/graph.clj
+++ b/gui/samizdat/gui/graph.clj
@@ -187,10 +187,18 @@
   `w`x`h` viewport with `pad` pixels of margin, preserving aspect. A
   single-node (degenerate) bounding box maps to the viewport center."
   [positions w h pad]
+  ;; `(reduce min ())` is `(min)`, an arity error — an empty graph threw here
+  ;; rather than framing nothing. The only caller guards with `(seq positions)`,
+  ;; so this was latent, but a pure function the headless suite is meant to
+  ;; cover should not depend on its caller for that. The empty box is
+  ;; degenerate at the origin, which `max 1e-9` below maps to the viewport
+  ;; centre. NOT a seeded fold: `(reduce min 0.0 xs)` would drag the origin
+  ;; into every non-empty bounding box and shift the framing of every graph
+  ;; that does not straddle it.
   (let [xs (map first (vals positions))
         ys (map second (vals positions))
-        [x0 x1] [(reduce min xs) (reduce max xs)]
-        [y0 y1] [(reduce min ys) (reduce max ys)]
+        [x0 x1] (if (seq xs) [(reduce min xs) (reduce max xs)] [0.0 0.0])
+        [y0 y1] (if (seq ys) [(reduce min ys) (reduce max ys)] [0.0 0.0])
         dx (max 1e-9 (- x1 x0))
         dy (max 1e-9 (- y1 y0))
         s (min (/ (- w (* 2 pad)) dx)

--- a/src/samizdat/agent/arbiter.clj
+++ b/src/samizdat/agent/arbiter.clj
@@ -35,14 +35,15 @@
   whose predictions never settle is not steering anything, and that is
   measurable rather than arguable."
   (:require [samizdat.agent.gates :as gates]
-            [samizdat.agent.state :as state]))
+            [samizdat.agent.state :as state]
+            [samizdat.util :as util]))
 
 (defn eligible
   "Every gate whose precondition holds and whose budget is not spent, in
   priority order. Exposed so a test can assert what the arbiter passed over,
   not only what it chose."
   [ctx]
-  (->> gates/gates
+  (->> (gates/gates)
        (filter (fn [g] (and ((:when g) ctx)
                             (not (gates/budget-exceeded? g (:branch ctx))))))
        (sort-by :priority)))
@@ -97,8 +98,11 @@
   "Schemas for the tools a gate may FORCE via native tool_choice, from
   gates.edn :forceable-tools (tier 3b: data). Only the terminal tools —
   forcing a mid-task tool would be the harness deciding rather than
-  steering. Minimal: enough for the provider to accept the function."
-  (:forceable-tools (gates/config)))
+  steering. Minimal: enough for the provider to accept the function.
+
+  Read through the config generation rather than snapshotted at namespace
+  load, so reload-config! reaches it like every other derived table."
+  (util/generation-cache gates/gen #(:forceable-tools (gates/config))))
 
 (defn force-tool-for
   "The native-tool spec to FORCE for a decision naming a forceable tool, or nil.
@@ -109,7 +113,7 @@
   on GLM cannot rely on that. See samizdat.llm.adapter.openai."
   [decision]
   (when-let [t (:tool decision)]
-    (get forceable t)))
+    (get (forceable) t)))
 
 ;; --- settling predictions ---------------------------------------------------
 
@@ -133,6 +137,14 @@
   []
   (distinct (mapcat seq (vals (gates/tool-vocab :settle-called)))))
 
+(def settled-by-rule
+  "The gates `settle` decides with a rule of its own rather than by asking
+  which tool was called — so they are the ones legitimately absent from the
+  :settle-called vocabulary. Kept beside the `case` below and asserted
+  against it by the coherence test, so a gate that falls out of both is
+  caught at test time rather than by settling :unmet forever."
+  #{:stuck :prologue-cap :progress-stalled :human-directive})
+
 (defn settle
   "Decide whether an open prediction came true, given what the branch did.
 
@@ -145,7 +157,13 @@
   [{:keys [gate turn window]} {:keys [current-turn tools-called branch-before branch-after]}]
   (let [settle-called (gates/tool-vocab :settle-called)
         expired? (>= (- current-turn turn) window)
-        tools-met? (fn [g] (boolean (some (get settle-called g) tools-called)))]
+        ;; `#{}` rather than nil for a gate the vocabulary does not name:
+        ;; `(some nil tools-called)` calls nil as a predicate and throws, so a
+        ;; gate added to gates.edn :gates without a :settle-called entry took
+        ;; the settle path down with it on its first firing. Adding a gate is
+        ;; supposed to be a data edit; a missing vocabulary now settles :unmet
+        ;; at the window instead, and the coherence test names the omission.
+        tools-met? (fn [g] (boolean (some (get settle-called g #{}) tools-called)))]
     (cond
       (case gate
         ;; Now that the gate withholds rather than suggests (vf-49o), what

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -37,16 +37,20 @@
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            [mycelium.core :as myc]
             [samizdat.agent.critic :as critic]
             [samizdat.agent.gates :as gates]
+            [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.agent.loop :as branch-loop]
             [samizdat.agent.state :as state]
             [samizdat.prompt :as prompt]
+            [samizdat.repl :as repl]
             [samizdat.store.artifacts :as artifacts]
             [samizdat.store.failures :as failures]
             [samizdat.store.interventions :as interventions]
             [samizdat.store.journal :as journal]
-            [samizdat.store.runs :as runs])
+            [samizdat.store.runs :as runs]
+            [samizdat.workflow :as workflow])
   (:refer-clojure :exclude [run!]))
 
 (defn- crossover-block
@@ -454,15 +458,28 @@
            alive (count (filter state/active? bs))]
        (case kind
          "cull"
-         (if (<= alive 1)
-           (do (interventions/resolve! conn run-id (:id d) :rejected
-                                       "refused: it is the last branch running" turn)
-               bs)
-           (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
-               (mapv #(if (and (matches? %) (state/active? %))
-                        (assoc % :status :culled :inactive-reason "culled by a human")
-                        %)
-                     bs)))
+         ;; What the directive would actually kill, not just how many are
+         ;; alive. An UNTARGETED cull matches every branch, so on a beam of
+         ;; three it emptied the run outright — the guard below only ever
+         ;; caught the alive=1 case, and the outcome it exists to prevent
+         ;; (ending the run in a way the person almost certainly did not
+         ;; intend) arrived by the other door. Refuse whenever nothing would
+         ;; be left running, and say which case it was.
+         (let [doomed (count (filter #(and (matches? %) (state/active? %)) bs))]
+           (if (>= doomed alive)
+             (do (interventions/resolve!
+                  conn run-id (:id d) :rejected
+                  (if (<= alive 1)
+                    "refused: it is the last branch running"
+                    (str "refused: this would cull all " alive " running branches"
+                         " and end the run — name a branch_id to cull one"))
+                  turn)
+                 bs)
+             (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
+                 (mapv #(if (and (matches? %) (state/active? %))
+                          (assoc % :status :culled :inactive-reason "culled by a human")
+                          %)
+                       bs))))
 
          "retract"
          ;; Applied here rather than at submit time so it lands on a turn
@@ -496,6 +513,43 @@
    branches
    directives))
 
+(defn advance-branch
+  "One turn for one branch.
+
+  The seam where the two drivers became one. The beam used to call
+  branch-loop/run-turn directly while the manifest driver ran the same steps
+  as mycelium cells, and nothing in the production path ever reached the
+  manifest — `:run :loop` was documented, parsed, and read by no live code, so
+  the critic, feature, team and decompose loops existed only under the test
+  suite. The beam now drives the run's compiled PER-TURN manifest slice
+  (workflow/turn-manifest), which for the factory loop composes exactly the
+  steps run-turn composed.
+
+  run-turn remains the fallback for a ctx carrying no workflow — the benches
+  and any caller that wants the bare composition.
+
+  A structural failure is this branch's problem, not the beam's: it abandons
+  the branch with the reason, the same shape as a throw. The manifest driver
+  threw here and ended the whole run, which is right for a single-branch
+  driver and wrong for one branch of five."
+  [ctx b turn]
+  (if-let [wf (:turn-workflow ctx)]
+    (let [data (myc/run-compiled wf ctx {:branch b :turn turn})
+          fail (fn [why]
+                 (log/warn "branch" (:id b) "turn" turn "loop workflow failed:" why)
+                 (assoc b :status :abandoned
+                        :inactive-reason (str "loop workflow failed: " why)))]
+      (cond
+        (myc/error? data) (fail (pr-str (myc/workflow-error data)))
+        ;; A turn that came back carrying no branch is a manifest whose slice
+        ;; dropped the key — an edit the compile cannot catch, since :branch is
+        ;; data rather than structure. Abandoning ONE branch with a legible
+        ;; reason beats returning nil into the scheduler, where it would
+        ;; surface several rounds later as an NPE on somebody else's turn.
+        (nil? (:branch data)) (fail "the turn returned no :branch")
+        :else (:branch data)))
+    (branch-loop/run-turn ctx b turn)))
+
 (defn- advance-all
   "One turn for every active branch, concurrently, each under a hard deadline.
 
@@ -503,13 +557,20 @@
   one failing engine session must not cost the other four their work. A branch
   that hangs loses only its own turn. Phase 1 proved five concurrent swipl
   sessions hold, which is what makes this real parallelism rather than a loop
-  wearing futures."
+  wearing futures.
+
+  The deadline is skipped for a NON-ITERATING manifest (team, feature,
+  decompose): there a `turn` is the branch's entire job rather than one model
+  call, so the turn deadline would abandon the run partway through the work it
+  was asked to do. Those runs stop by the abort flag, which is the stop path
+  that never depended on cooperation anyway."
   [ctx branches turn]
-  (let [deadline (or (:turn-deadline-ms ctx) default-turn-deadline-ms)
+  (let [deadline (when (get ctx :iterating-loop? true)
+                   (or (:turn-deadline-ms ctx) default-turn-deadline-ms))
         pending (mapv (fn [b]
                         [b (future
                              (try
-                               (branch-loop/run-turn ctx b turn)
+                               (advance-branch ctx b turn)
                                (catch Throwable e
                                  (log/warn "branch" (:id b) "died on turn" turn
                                            ":" (ex-message e))
@@ -518,7 +579,7 @@
                                         (str "branch error: " (ex-message e))))))])
                       branches)]
     (mapv (fn [[b fut]]
-            (let [r (deref fut deadline ::timeout)]
+            (let [r (if deadline (deref fut deadline ::timeout) @fut)]
               (if (= ::timeout r)
                 (do (log/warn "branch" (:id b) "exceeded the turn deadline on turn" turn)
                     ;; Not a verification failure: the branch did not get an
@@ -616,7 +677,7 @@
   Returns {:status :completed|:aborted|:exhausted :run-id :branches ...}.
   Teardown lives here rather than in the callers, so every engine session is
   disposed no matter how the run ended."
-  [{:keys [conn run-id max-turns abort sessions] :as ctx} branches start-turn]
+  [{:keys [conn run-id max-turns abort sessions repl-session] :as ctx} branches start-turn]
   (let [live-branches (atom branches)]
     (try
       (loop [branches branches, turn start-turn]
@@ -743,7 +804,15 @@
         ;; still collect, and per-branch disposal still runs through
         ;; dispose-branch-engines!, so the coding tools' sessions (nREPL,
         ;; subprocesses) plug their disposal back in here.
-        (doseq [b @live-branches] (dispose-branch-engines! b))))))
+        (doseq [b @live-branches] (dispose-branch-engines! b))
+        ;; The run's eval namespace does not outlive the run
+        ;; (code-review-2026-08 #6). Best effort, and only for a session this
+        ;; ctx actually carries: a resume that entered here without one has
+        ;; nothing to close.
+        (when repl-session
+          (try (repl/close-session repl-session)
+               (catch Throwable e
+                 (log/warn "closing the run's eval session failed:" (ex-message e)))))))))
 
 (defn run!
   "Run a beam to completion.
@@ -754,7 +823,22 @@
   [{:keys [conn config llm-adapter llm-config problem max-turns beam-width
            abort on-start seed-run quarantine] :as opts}]
   (let [max-turns (or max-turns (get-in config [:run :max-turns]) 40)
-        width (or beam-width (get-in config [:run :beam-width]) 5)
+        ;; Which loop drives this run, compiled to its per-turn slice. Before
+        ;; on-start, and so before POST /v1/runs returns, because the run row
+        ;; records the width this decides and a compile failure must refuse
+        ;; the request rather than surface as a dead run. It costs one cell
+        ;; load and one manifest compile — well under the open-branch! cost
+        ;; the comment below is about.
+        loop-nm (workflow/active-loop-name config)
+        {loop-version :version turn-wf :compiled iterating? :iterating?}
+        (workflow/compile-turn-loop conn loop-nm)
+        ;; A non-iterating manifest (team, feature, decompose) is a whole-run
+        ;; workflow: one "turn" is the branch's entire job, and it fans out
+        ;; internally. Running five of those concurrently would multiply the
+        ;; whole job rather than explore five lines of one, so the beam is
+        ;; width 1 there regardless of what was asked for.
+        requested-width (or beam-width (get-in config [:run :beam-width]) 5)
+        width (if iterating? requested-width 1)
         ;; Seeding forces sharing on for this run regardless of the config
         ;; flag: seeds enter through the shared log's context blocks, and
         ;; seeds nobody reads would be dead rows.
@@ -783,9 +867,30 @@
         ;; paths discard one: the tool-level catch, the turn deadline, and a
         ;; turn that throws. See tools/register-session! (vf-cfp).
         engine-sessions (atom [])
+        ;; The three ctx keys the manifest driver set and this one did not.
+        ;; Every consumer defends with `(or root ".")` or a nil check, so the
+        ;; omission was silent: `:run :root` was documented and ignored, every
+        ;; run's file tools resolved against the serve process's cwd, and
+        ;; `eval` fell through to repl/default-session — one process-wide
+        ;; namespace, never closed, shared by every run on the box. That is
+        ;; the leak code-review-2026-08 #6 fixed on the other driver only.
+        root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
         ctx {:conn conn :run-id run-id :config config :problem problem
              :llm-adapter llm-adapter :llm-config llm-config
              :max-turns max-turns :beam? (> width 1) :beam-width width
+             :root root
+             ;; The compiled per-turn manifest advance-branch drives, and
+             ;; whether it is a per-turn loop at all (which decides the turn
+             ;; deadline; see advance-all).
+             :turn-workflow turn-wf
+             :iterating-loop? iterating?
+             ;; What this run changed, for the ship gate's focused verify and
+             ;; for a finalization critic reading the run's own diff.
+             :git-baseline (gitdiff/baseline root)
+             ;; One eval namespace per RUN: defs the agent makes with `eval`
+             ;; persist across its turns and die with the run. run-rounds
+             ;; closes it in the same finally that disposes the sessions.
+             :repl-session (repl/new-session)
              :sessions sessions
              :engine-sessions engine-sessions
              :abort abort}]
@@ -801,6 +906,16 @@
     ;; journal poller handles that, and it is the honest picture — the branches
     ;; genuinely do not exist yet.
     (when on-start (on-start run-id))
+    ;; Which loop drove this run, durably: an agent reading a surprising run
+    ;; back needs to know which version of itself produced it.
+    (journal/note! conn run-id :loop-workflow
+                   {:data {:name loop-nm :version loop-version
+                           :iterating? iterating?
+                           :beam-width width
+                           :requested-beam-width requested-width}})
+    (when (not= width requested-width)
+      (log/info "loop" loop-nm "is a whole-run workflow; beam width forced to 1"
+                "(asked for" (str requested-width ")")))
     (let [initial (mapv #(open-branch! ctx (str "B" (inc %)) nil nil 0) (range width))]
       (run-rounds ctx initial 1))))
 

--- a/src/samizdat/agent/gates.clj
+++ b/src/samizdat/agent/gates.clj
@@ -37,7 +37,8 @@
             [clojure.string :as str]
             [samizdat.agent.state :as state]
             [samizdat.agent.supervisor :as supervisor]
-            [samizdat.prompt :as sp]))
+            [samizdat.prompt :as sp]
+            [samizdat.util :as util]))
 
 (defn load-config
   "Gate thresholds from resources/gates.edn. Read through io/resource so the
@@ -47,10 +48,24 @@
 
 (defonce ^:private config-cache (atom nil))
 
+;; Bumped by reload-config!, watched by everything COMPILED from the config
+;; (the gate table below, ship.clj's rungs, arbiter's forceable schemas). A
+;; reload used to swap the config atom and leave every derived table frozen at
+;; namespace load; the generation is what makes reload mean what it says.
+(defonce ^:private generation (atom 0))
+
+(defn gen
+  "The config's generation. Derived tables cache against this."
+  []
+  @generation)
+
 (defn config []
   (or @config-cache (reset! config-cache (load-config))))
 
-(defn reload-config! [] (reset! config-cache (load-config)))
+(defn reload-config! []
+  (reset! config-cache (load-config))
+  (swap! generation inc)
+  nil)
 
 (defn threshold [k]
   (get-in (config) [k :value]))
@@ -86,16 +101,24 @@
   "Compile an EDN form into (fn [ctx] form) with the gate-context keys bound
   as plain locals — the environment both :when and :message-form build on.
   prompt/threshold/state and the required namespaces resolve at compile, in
-  this namespace; the config atom is still read at FIRE time."
+  this namespace; the config atom is still read at FIRE time.
+
+  `*ns*` is bound explicitly because `eval` resolves the form's free symbols
+  against whatever namespace is current when it runs. That used to be this
+  one for free: the table was a top-level `def`, so the compile happened at
+  namespace load. Now that it is memoized and compiled on FIRST USE, the
+  caller could be anything — jolt.main, a test namespace — and `threshold`,
+  `prompt`, `state/…` and `supervisor/…` resolve in none of them."
   [form]
-  (eval `(fn [~'ctx]
+  (binding [*ns* (the-ns 'samizdat.agent.gates)]
+    (eval `(fn [~'ctx]
            (let [~'directive            (get ~'ctx :directive)
                  ~'done-block           (get ~'ctx :done-block)
                  ~'branch               (get ~'ctx :branch)
                  ~'max-turns            (get ~'ctx :max-turns)
                  ~'branch-count         (get ~'ctx :branch-count)
                  ~'safe-state-coverage  (get ~'ctx :safe-state-coverage)]
-             ~form))))
+             ~form)))))
 
 (defn- compile-when
   [form]
@@ -121,11 +144,24 @@
          :prediction (let [p (:prediction entry)] (fn [_] p))))
 
 (def gates
-  "The steer table, compiled from gates.edn :gates at load — all data since
-  tier 3b. Priorities, not table order, decide arbitration."
-  (mapv compile-gate (:gates (config))))
+  "The steer table, compiled from gates.edn :gates — all data since tier 3b.
+  Priorities, not table order, decide arbitration.
 
-(def by-name (into {} (map (juxt :gate identity)) gates))
+  A FUNCTION, not a value: the compile is memoized against the config
+  generation, so `reload-config!` genuinely re-reads and re-compiles the
+  table. As a top-level `def` it was compiled once at namespace load and a
+  reload changed only the thresholds the forms read at fire time — editing a
+  gate's :when, adding a gate, or removing one needed a process restart, in
+  the one namespace whose whole premise is that the steer policy is data."
+  (util/generation-cache gen #(mapv compile-gate (:gates (config)))))
+
+(def ^:private by-name*
+  (util/generation-cache gen #(into {} (map (juxt :gate identity)) (gates))))
+
+(defn by-name
+  "The compiled gate `k`, or nil."
+  [k]
+  (get (by-name*) k))
 
 (defn crossed-fractions
   "Which turn-budget notice thresholds this branch has now passed. The loop
@@ -143,7 +179,7 @@
 (defn describe
   "The gate table, for docs and for /v1/harness/gates."
   []
-  (for [g gates]
+  (for [g (gates)]
     {:gate (:gate g) :priority (:priority g)
      :budget (:budget g)
      :budget-kind (some-> (:budget g) (#(get-in (config) [% :kind])))

--- a/src/samizdat/agent/judge.clj
+++ b/src/samizdat/agent/judge.clj
@@ -33,6 +33,11 @@
             [samizdat.agent.gates :as gates]
             [samizdat.prompt :as prompt]))
 
+;; The judge's preamble is read from resources/prompts/judge.md on each use
+;; rather than snapshotted into a def at namespace load. The docstring called
+;; it runtime-editable and the def made it exactly not that; a slurp per
+;; finalization is nothing next to the model call it is part of.
+
 ;; The judge's prompt files read through the shared samizdat.prompt seam
 ;; (tier 2b) — every gate message reads through the same one.
 
@@ -166,10 +171,11 @@
       (claim-block answer rows)
       (source-block answer rows tool-surface)))
 
-(def preamble
+(defn preamble
   "The judge's standing instructions, from resources/prompts/judge.md (tier
   2b — runtime-editable). Calibrated, not trigger-happy. A unified judge:
   it decides completeness AND reviews the run's own diff for defects."
+  []
   (prompt/prompt "judge"))
 
 (defn critic-prompt
@@ -183,7 +189,7 @@
               (str diff) "\n```"))
        "\n\n## Transcript\n\n" (one-line transcript 12000)
        "\n\n## The answer it wants to ship\n\n" (str answer)
-       "\n\nIs this task complete and correct? " preamble))
+       "\n\nIs this task complete and correct? " (preamble)))
 
 (defn blocking-findings
   "The findings a review blocks on — those tagged [critical] or [high]. Returns

--- a/src/samizdat/agent/phases.clj
+++ b/src/samizdat/agent/phases.clj
@@ -20,7 +20,21 @@
 
 (def ^:private cache (atom (load-phases)))
 
-(defn reload! [] (reset! cache (load-phases)))
+;; Watched by the winner rubric, which state.clj COMPILES from :finished-key.
+;; Without it reload! swapped this atom and left the compiled rubric frozen at
+;; namespace load — the one part of phases.edn that is forms rather than
+;; lookups was the one part a reload could not reach.
+(def ^:private generation (atom 0))
+
+(defn gen
+  "The phase table's generation. Derived tables cache against this."
+  []
+  @generation)
+
+(defn reload! []
+  (reset! cache (load-phases))
+  (swap! generation inc)
+  nil)
 
 (defn table
   "The whole phases.edn map — :initial-phase, :phases, :transitions,

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -104,10 +104,13 @@
   (:require [clojure.data.json :as json]
             [samizdat.agent.beam :as beam]
             [samizdat.agent.gates :as gates]
+            [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.agent.loop :as branch-loop]
             [samizdat.agent.state :as state]
+            [samizdat.repl :as repl]
             [samizdat.store.journal :as journal]
-            [samizdat.store.runs :as runs]))
+            [samizdat.store.runs :as runs]
+            [samizdat.workflow :as workflow]))
 
 (defn- parse-json [s]
   (when s
@@ -256,9 +259,29 @@
           artifacts (group-by :branch_id (journal/artifacts conn run-id))
           firings (group-by :branch_id (journal/gate-firings conn run-id))
           sessions (atom [])
+          ;; Same three keys run! sets. A resumed run works on the same tree
+          ;; and needs the same file root; the eval session is genuinely new,
+          ;; because the old process's namespace died with it and nothing in
+          ;; the journal can rebuild an in-image binding.
+          root (or (get-in config [:run :root]) (System/getProperty "user.dir"))
+          ;; The same compiled per-turn manifest run! drives, recompiled here:
+          ;; a resume enters run-rounds directly, so without this it would
+          ;; silently fall back to the bare composition and finish a critic or
+          ;; feature run on the factory loop.
+          loop-nm (workflow/active-loop-name config)
+          {turn-wf :compiled iterating? :iterating?}
+          (workflow/compile-turn-loop conn loop-nm)
           ctx {:conn conn :run-id run-id :config config :problem (:problem run)
                :llm-adapter llm-adapter :llm-config llm-config
                :max-turns max-turns :beam? (> width 1) :beam-width width
+               :root root
+               :turn-workflow turn-wf
+               :iterating-loop? iterating?
+               ;; Baselined at the RESUME, so a critic reviewing the resumed
+               ;; run sees what the resumption changed. What the dead process
+               ;; changed is already committed to the tree it starts from.
+               :git-baseline (gitdiff/baseline root)
+               :repl-session (repl/new-session)
                :sessions sessions
                :abort abort}
           branches (mapv (fn [row]

--- a/src/samizdat/agent/state.clj
+++ b/src/samizdat/agent/state.clj
@@ -30,7 +30,8 @@
   (:require [clojure.set]
             [clojure.string :as str]
             [samizdat.agent.phases :as phases]
-            [samizdat.agent.wordlists :as wordlists]))
+            [samizdat.agent.wordlists :as wordlists]
+            [samizdat.util :as util]))
 
 (defn new-branch
   [{:keys [id parent-id problem prolog messages created-at-turn]}]
@@ -157,8 +158,18 @@
 ;; references something that does not exist.
 
 (def ^:private key-fns
-  (mapv (fn [form] (eval `(fn [~'branch] ~form)))
-        (phases/finished-key-forms)))
+  ;; Memoized against the phase table's generation, not compiled once at
+  ;; namespace load: system/start! calls phases/reload! precisely so a rubric
+  ;; edit takes effect, and a top-level def made that call a no-op for the
+  ;; rubric while working for every plain lookup beside it.
+  (util/generation-cache
+   phases/gen
+   ;; `*ns*` bound for the same reason as gates/compile-form: compiled on
+   ;; first use now, and `confirmed-artifacts` resolves here and nowhere the
+   ;; first caller might be.
+   #(binding [*ns* (the-ns 'samizdat.agent.state)]
+      (mapv (fn [form] (eval `(fn [~'branch] ~form)))
+            (phases/finished-key-forms)))))
 
 (defn finished-key
   "The ranking tuple for a done-eligible branch, best-first component order.
@@ -189,26 +200,41 @@
   - id: ascending, a stable arbitrary tie-break so the ranking never
     depends on vector order."
   [branch]
-  (mapv #(% branch) key-fns))
+  (mapv #(% branch) (key-fns)))
+
+(defn compare-finished-keys
+  "Compare two ranking tuples, best first. Component-wise in key order, so a
+  relaxation never outranks a direct proof no matter how many artifacts it
+  carries; the first component that differs decides.
+
+  Generic over the tuple's SHAPE, which is the point: the rubric is
+  phases.edn data (drg-4026 #30), and a version of this that destructured
+  five named components and negated four of them was data-driven in name
+  only — dropping a component from the rubric threw on `(- nil)` and adding
+  one silently left it out of the ranking. The direction is read off the
+  values instead: a numeric component is bigger-is-better (every rubric
+  component counts evidence), anything else is an ascending tie-break (the
+  id). Both are what the five-component rubric meant.
+
+  Not a chain of `(or (compare …) …)`: `compare` returns 0 on a tie and 0 is
+  truthy, so the chain never falls through to the next component."
+  [a b]
+  (reduce (fn [_ [x y]]
+            (let [c (if (and (number? x) (number? y))
+                      (compare y x)
+                      (compare x y))]
+              (if (zero? c) 0 (reduced c))))
+          0
+          (map vector a b)))
 
 (defn rank-finished
   "Rank done-eligible branches best first, by `finished-key`.
 
   Expects branches holding :final-answer (the caller has filtered); the
   ranking reads only the evidence they carry, never the order they arrived
-  in. Components compare in key order, so a relaxation never outranks a
-  direct proof no matter how many artifacts it carries.
-
-  Implemented as sort-by over a normalized key — numeric components negated
-  so bigger-is-better becomes ascending, the id left as-is — rather than a
-  hand-rolled comparator. The obvious `(or (compare ...) ...)` chain is a
-  bug: `compare` returns 0 on ties and 0 is truthy, so the chain never
-  falls through to the next component."
+  in."
   [branches]
-  (sort-by (fn [b]
-             (let [[non-relax slow diversity confirmed id] (finished-key b)]
-               [(- non-relax) (- slow) (- diversity) (- confirmed) id]))
-           branches))
+  (sort-by finished-key compare-finished-keys branches))
 
 (defn record-mechanics
   "Fold one turn's fence signals into the branch's mechanics counters."
@@ -462,8 +488,19 @@
       real-progress? (assoc :turns-since-progress 0 :any-progress? true)
       (not real-progress?) (update :turns-since-progress inc))))
 
-(defn add-artifact [branch artifact]
-  (update branch :artifacts conj artifact))
+(defn add-artifact
+  "Bank an artifact on the branch, stamping its tier into :tiers-seen.
+
+  The stamp closes a live/replay disagreement. Nothing on the live path ever
+  wrote :tiers-seen — the proof tools that did left with the proof harness —
+  while resume/rebuild-branch reconstructs it as `(set (keep :tier artifacts))`.
+  So the winner rubric's slow-seen component read 0 for a running branch and 1
+  for the same branch after a crash and resume, which is exactly the kind of
+  snapshot-versus-replay drift this namespace's docstring says cannot happen.
+  Deriving it here from the artifact makes the two agree by construction."
+  [branch artifact]
+  (cond-> (update branch :artifacts conj artifact)
+    (:tier artifact) (update :tiers-seen (fnil conj #{}) (:tier artifact))))
 
 (defn add-turn
   "Record one turn on the branch. `entry` carries :turn, :tool, :category, and

--- a/src/samizdat/agent/tools/ship.clj
+++ b/src/samizdat/agent/tools/ship.clj
@@ -12,7 +12,8 @@
             [samizdat.agent.state :as state]
             [samizdat.agent.verify :as verify]
             [samizdat.agent.wordlists :as wordlists]
-            [samizdat.store.journal :as journal]))
+            [samizdat.store.journal :as journal]
+            [samizdat.util :as util]))
 
 
 
@@ -40,31 +41,36 @@
 ;; Tier 1c: both the framing stopwords and the tool-version pattern are
 ;; wordlists.edn data — retunable at runtime without a rebuild. The section
 ;; comments recording why words are on the list moved with the words.
-(def ^:private stopwords (wordlists/wordlist :answer-framing))
+;; Both memoized against the wordlists' generation rather than realized at
+;; namespace load: system/start! calls wordlists/reload! so a list edit takes
+;; effect, and a top-level def turned that call into a no-op here.
+(def ^:private stopwords
+  (util/generation-cache wordlists/gen #(wordlists/wordlist :answer-framing)))
 
 (def ^:private tool-version-re
-  (re-pattern (wordlists/wordlist :tool-version)))
+  (util/generation-cache wordlists/gen
+                         #(re-pattern (wordlists/wordlist :tool-version))))
 
 (defn answer-tokens
   "Substantive tokens from a proposed answer: numbers and words that are not
   stopwords. Numbers matter most — an answer naming a size, a bound, or a
   witness has to have that number in the evidence."
   [text]
-  (->> (str/split (str/lower-case (str/replace (or text "") tool-version-re " "))
+  (->> (str/split (str/lower-case (str/replace (or text "") (tool-version-re) " "))
                   #"[^a-z0-9_.-]+")
        ;; `.` and `-` stay INSIDE the split class so 3.5 and cross-check survive
        ;; as one token, which means a sentence-final period rides along with the
        ;; last word. Trim the edges, keep the interior.
        (map #(str/replace % #"^[.-]+|[.-]+$" ""))
        (remove str/blank?)
-       (remove stopwords)
+       (remove (stopwords))
        ;; A hyphenated compound is one token, so `engine-confirmed` survived a
        ;; list holding every one of its parts. A compound with a substantive
        ;; half — `optimal-flow` — is not exempt.
        (remove #(and (str/includes? % "-")
                      (let [parts (remove str/blank? (str/split % #"-"))]
                        (and (seq parts)
-                            (every? (fn [p] (or (stopwords p) (< (count p) 4)))
+                            (every? (fn [p] (or ((stopwords) p) (< (count p) 4)))
                                     parts)))))
        (filter #(or (re-matches #"[0-9]+(\.[0-9]+)?" %) (>= (count %) 4)))
        distinct))
@@ -164,23 +170,35 @@
 ;; at fire time. Adding a rung is a data edit.
 
 (defn- compile-rung-form
+  "`*ns*` bound for the same reason as gates/compile-form: the rungs are now
+  compiled on first use rather than at namespace load, and `str/blank?` and
+  `engages-problem?` resolve in this namespace and nowhere the caller might
+  happen to be."
   [form]
-  (eval `(fn [~'ctx]
-           (let [~'answer            (get ~'ctx :answer)
-                 ~'problem           (get ~'ctx :problem)
-                 ~'evidence          (get ~'ctx :evidence)
-                 ~'uncovered-numbers (get ~'ctx :uncovered-numbers)]
-             ~form))))
+  (binding [*ns* (the-ns 'samizdat.agent.tools.ship)]
+    (eval `(fn [~'ctx]
+             (let [~'answer            (get ~'ctx :answer)
+                   ~'problem           (get ~'ctx :problem)
+                   ~'evidence          (get ~'ctx :evidence)
+                   ~'uncovered-numbers (get ~'ctx :uncovered-numbers)]
+               ~form)))))
 
 (def ship-gates
-  "The lexical ship rungs, compiled from gates.edn :ship-gates at load."
-  (mapv (fn [rung]
-          (assoc rung
-                 :when (compile-rung-form (:when rung))
-                 :message (if (:message-form rung)
-                            (compile-rung-form (:message-form rung))
-                            (:message rung))))
-        (gates/threshold :ship-gates)))
+  "The lexical ship rungs, compiled from gates.edn :ship-gates.
+
+  A function, memoized against the config generation, so adding or retuning a
+  rung is the data edit the docstring in gates.edn promises. As a top-level
+  def the rungs were compiled once at namespace load and `reload-config!`
+  could not touch them."
+  (util/generation-cache
+   gates/gen
+   #(mapv (fn [rung]
+            (assoc rung
+                   :when (compile-rung-form (:when rung))
+                   :message (if (:message-form rung)
+                              (compile-rung-form (:message-form rung))
+                              (:message rung))))
+          (gates/threshold :ship-gates))))
 
 (defn ship-gate-block
   "The first lexical ship rung that fires on this evidence, or nil. Pure —
@@ -190,7 +208,7 @@
           (when ((:when rung) evidence)
             (let [m (:message rung)]
               (if (fn? m) (m evidence) m))))
-        ship-gates))
+        (ship-gates)))
 
 ;; --- shipping ---------------------------------------------------------------
 
@@ -267,16 +285,46 @@
                              :sources (vec (distinct (keep :branch_id elsewhere)))}}))
     (if block
       (base/fail branch (str "`done` refused.\n\n" block) :done-block block)
-      {:branch (assoc branch :final-answer answer :status :done)
-       :category :success
-       :progress? true
-       :done? true
-       :answer answer
-       ;; The green point the safe-state rung rewinds to (loop.clj tool-step
-    ;; consumes this): done with the suite actually passing is the branch's
-    ;; last known-good state.
-    :verified-green? (boolean (:green? vresult))
-    :result (str "Answer accepted.\n\n" answer)})))
+      (cond->
+       {:branch (assoc branch :final-answer answer :status :done)
+        :category :success
+        :progress? true
+        :done? true
+        :answer answer
+        ;; The green point the safe-state rung rewinds to (loop.clj tool-step
+        ;; consumes this): done with the suite actually passing is the branch's
+        ;; last known-good state.
+        :verified-green? (boolean (:green? vresult))
+        :result (str "Answer accepted.\n\n" answer)}
+
+        ;; A green ship-verify IS this loop's confirmed artifact.
+        ;;
+        ;; The proof engines produced :confirmed artifacts and left with the
+        ;; proof harness, and nothing replaced them — so `confirmed-artifacts`
+        ;; was empty on every run, by construction, and everything keyed on it
+        ;; was dead code that still read like live policy: the milestone,
+        ;; branch-out and emergency-review gates could not fire, `shareable?`
+        ;; admitted nothing so the shared pool stayed empty (and with it
+        ;; corroborating-artifacts and seed-from-run!), the figure-coverage
+        ;; ship rung had no evidence to check figures against, two of the
+        ;; winner rubric's five components were always 0, and arbiter's
+        ;; `progressed?` — which is how prologue-cap and progress-stalled
+        ;; settle — could never be true.
+        ;;
+        ;; A test run the harness itself spawned and observed exit 0 is the
+        ;; coding loop's exact analogue of an engine confirmation: machine-
+        ;; checked, not self-reported, and produced by the same
+        ;; verify-before-you-ship discipline. So emit one.
+        ;;
+        ;; :tier :slow because a real test run is not a one-shot syntax check
+        ;; — it is the cross-check the rubric's slow-seen component means.
+        (:green? vresult)
+        (assoc :artifact {:kind :test
+                          :claim answer
+                          :code cmd
+                          :verdict :pass
+                          :claim-status :confirmed
+                          :tier :slow})))))
 
 (defmethod base/run-tool "give_up" [{:keys [branch] :as ctx}]
   (let [reason (or (base/arg ctx :reason) "no reason given")]

--- a/src/samizdat/agent/verify.clj
+++ b/src/samizdat/agent/verify.clj
@@ -19,12 +19,15 @@
   (:require [clojure.string :as str]
             [samizdat.agent.gates :as gates]
             [samizdat.engine.proc :as proc]
-            [samizdat.security.secrets :as secrets]))
+            [samizdat.security.secrets :as secrets]
+            [samizdat.util :as util]))
 
-(defn- conventions []
+(defn- conventions
   "The focused-verify conventions, from gates.edn :focused-verify (drg-4026
   #47/48) — read at fire time so a project retunes them at runtime."
+  []
   (gates/threshold :focused-verify))
+
 
 (defn test-file?
   "Whether a changed path is a test/spec file — the evidence that a change was
@@ -139,10 +142,9 @@
   is model-bound, so it passes the redaction boundary before it is returned."
   [root cmd timeout-ms]
   (try
-    (let [root* (str/replace (str root) "'" "'\\\\''")
-          r (proc/run {:timeout-ms (or timeout-ms 600000)
+    (let [r (proc/run {:timeout-ms (or timeout-ms 600000)
                        :env (secrets/scrubbed-process-env)}
-                      "sh" "-c" (str "cd '" root* "' && " cmd))
+                      "sh" "-c" (str "cd " (util/sh-quote root) " && " cmd))
           known (secrets/known-values (into {} (System/getenv)))]
       {:green? (and (not (:timeout r)) (zero? (or (:exit r) 1)))
        :timeout? (boolean (:timeout r))

--- a/src/samizdat/agent/wordlists.clj
+++ b/src/samizdat/agent/wordlists.clj
@@ -23,7 +23,20 @@
 
 (def ^:private cache (atom (load-wordlists)))
 
-(defn reload! [] (reset! cache (load-wordlists)))
+;; Watched by ship.clj, which turns :answer-framing into a set and
+;; :tool-version into a compiled Pattern at namespace load. Without a
+;; generation those two were frozen and reload! moved nothing that mattered.
+(def ^:private generation (atom 0))
+
+(defn gen
+  "The wordlists' generation. Derived values cache against this."
+  []
+  @generation)
+
+(defn reload! []
+  (reset! cache (load-wordlists))
+  (swap! generation inc)
+  nil)
 
 (defn wordlist
   "Wordlist `k` (:claim-relevance, :answer-framing, :tool-version) from

--- a/src/samizdat/api/control.clj
+++ b/src/samizdat/api/control.clj
@@ -198,8 +198,14 @@
             (log/error "resume failed:" (ex-message e))
             (swap! active dissoc run-id)
             {:status :error :error (ex-message e)})))
+      ;; The budget this resume is running under, from what the caller asked
+      ;; for, falling back to the row as it stood BEFORE the future started.
+      ;; Reading the row here unconditionally raced the resume that is
+      ;; rewriting it: the answer was whichever thread won, and an explicit
+      ;; max_turns extension was reported as the old budget more often than
+      ;; not.
       {:body {:run_id run-id :status "resuming"
-              :max_turns (:max_turns (runs/get-run conn run-id))}})))
+              :max_turns (or max-turns (:max_turns (runs/get-run conn run-id)))}})))
 (defn- grant-pattern
   "The pattern from a grant payload. Accepts a map (what body-json yields), a
   bare string, or nil. Blank is not a pattern — an unset form posts empty

--- a/src/samizdat/cell_prelude.clj
+++ b/src/samizdat/cell_prelude.clj
@@ -19,8 +19,17 @@
   reuses it. A preload, not a dependency — nothing here is called; the `require`
   is the whole point. Add a namespace here whenever a new shipped cell reaches
   for one that nothing in src already pulls in."
-  (:require [samizdat.agent.gitdiff]
+  (:require [samizdat.agent.decompose]
+            [samizdat.agent.gitdiff]
             [samizdat.agent.judge]
             [samizdat.agent.planner]
             [samizdat.agent.telemetry]
             [samizdat.engine.proc]))
+
+;; decompose was the one shipped-cell dependency nothing in src reached, so it
+;; was never compiled into a `jolt build` image and cells/decompose.clj's
+;; load-string fell through to "Could not locate samizdat/agent/decompose on
+;; the source roots". Invisible until now for two reasons: a built binary did
+;; not boot outside the project root at all, and inside it the source tree was
+;; sitting there for the fallback to find. cells-test walks every shipped
+;; cell's requires against this list so the next one is caught at test time.

--- a/src/samizdat/cells.clj
+++ b/src/samizdat/cells.clj
@@ -88,6 +88,34 @@
          (filter #(str/ends-with? % ".clj"))
          sort)))
 
+(def shipped-cells
+  "The cell files that ship with the harness, as RESOURCE names.
+
+  Enumerated rather than globbed, and read through io/resource, so the shipped
+  cells load from a built binary that has no resources/ on disk (deps.edn
+  :jolt/build :embed bakes them in). A classpath has no directory listing and
+  an embedded resource has no filesystem path for `.getPath` to name, so the
+  glob above finds nothing there and the kernel registered ZERO cells — which
+  surfaces as `Cell :loop/assemble not found in registry` the moment a run
+  tries to compile its loop. Same reasoning as workflow/factory-manifest-names;
+  both are pinned against their directory by a test so the list cannot drift.
+
+  Lowest precedence: a project's .samizdat/cells override still loads after
+  these and wins, and in a source checkout the dir scan reads the very same
+  files, so a shipped cell edited in place is picked up from disk."
+  ["cells/critic.clj" "cells/decompose.clj" "cells/feature.clj"
+   "cells/loop.clj" "cells/team.clj"])
+
+(defn- shipped-sources
+  "The shipped cells as {:id :content} — read from the classpath (embedded or
+  not). Skips any whose dir scan already produced it, so a source checkout
+  loads each file once and from disk."
+  [covered]
+  (for [r shipped-cells
+        :let [url (io/resource r)]
+        :when (and url (not (contains? covered (last (str/split r #"/")))))]
+    {:id r :content (slurp url) :file? false}))
+
 (defn- defcell-ids
   "The cell ids a cell file defines, by reading its `defcell` forms — so a
   reload attributes a cell to its file even though re-registration is not a
@@ -102,8 +130,11 @@
        (filter keyword?)
        vec))
 
-(defn- load-file!
-  "Load one cell file into the live image; return the cell ids it defines.
+(defn- load-source!
+  "Load one cell SOURCE into the live image; return the cell ids it defines.
+
+  Takes {:id :content} rather than a path, because a shipped cell may come
+  from an embedded resource with no file behind it.
 
   The load is wrapped in a *ns* binding: a cell file begins with an `(ns …)`
   form, and load-string's evaluation of it switches *ns* and does not restore
@@ -111,11 +142,10 @@
   a second load. Binding *ns* to itself reverts it on exit, so the loader is
   repeatable (the reload the mutation protocol needs) and leaves the caller's
   namespace untouched."
-  [path]
-  (let [content (slurp path)]
-    (binding [*ns* *ns*]
-      (load-string content))
-    (defcell-ids content)))
+  [{:keys [content]}]
+  (binding [*ns* *ns*]
+    (load-string content))
+  (defcell-ids content))
 
 (defn load-cells!
   "Load every cell file under the given dirs (default `default-dirs`) into the
@@ -125,13 +155,20 @@
   ([] (load-cells! default-dirs))
   ([dirs]
    (let [snapshot (cell/registry-snapshot)
-         files (mapcat cell-files dirs)]
+         files (mapcat cell-files dirs)
+         ;; Shipped resources FIRST and only where the dir scan did not
+         ;; already produce that file, so a source checkout loads each cell
+         ;; once from disk and a built binary with no resources/ dir still
+         ;; gets the loop's cells (deps.edn :jolt/build :embed).
+         sources (concat (shipped-sources
+                          (set (map #(last (str/split (str %) #"/")) files)))
+                         (for [p files] {:id p :content (slurp p) :file? true}))]
      (try
-       (let [loaded (reduce (fn [acc path]
-                              (into acc (for [id (load-file! path)]
-                                          [id {:source path}])))
+       (let [loaded (reduce (fn [acc src]
+                              (into acc (for [id (load-source! src)]
+                                          [id {:source (:id src)}])))
                             {}
-                            files)]
+                            sources)]
          ;; Drop any cell we loaded before that is gone from the new set (a
          ;; deleted cell file / removed defcell), WITHOUT clearing the shared
          ;; registry — other code and tests hold cells here that are not ours.
@@ -141,7 +178,13 @@
          ;; Remember the good on-disk content, so the mutation protocol can
          ;; roll a later bad edit back to exactly this. Only reached on
          ;; success, so it never records a half-loaded state.
-         (reset! loaded-content (into {} (map (juxt identity slurp)) files))
+         ;; Only the sources backed by a real file: the mutation protocol
+         ;; restores by spitting content back to the path, and an embedded
+         ;; resource has no path to spit to (nor any way for the agent to
+         ;; have edited it).
+         (reset! loaded-content
+                 (into {} (for [src sources :when (:file? src)]
+                            [(:id src) (:content src)])))
          loaded)
           (catch Throwable e
             (cell/registry-restore! snapshot)

--- a/src/samizdat/config.clj
+++ b/src/samizdat/config.clj
@@ -181,6 +181,20 @@
                   ;; pin its own via .samizdat/config.edn, and the agent can add
                   ;; or tune manifests at runtime with the `manifest` tool.
                   :loop       (env "HARNESS_LOOP")
+                  ;; The ship gate's test rung, ON by default. `done` is a hard
+                  ;; gate on a green test (b1a4b88) — but verify-on? needs a
+                  ;; :verify-cmd or this flag, and neither had a default, so the
+                  ;; headline gate was inert on every run that did not ship a
+                  ;; .samizdat/config.edn. Focused rather than the whole suite:
+                  ;; it runs only the test namespaces the branch touched, so a
+                  ;; project with no configured command still pays seconds, and
+                  ;; a branch that changed no test file is refused by the TDD
+                  ;; rung before anything is spawned.
+                  :verify-focused? (not= "0" (or (env "HARNESS_VERIFY_FOCUSED") "1"))
+                  ;; The TDD half: a change with no test file in it is refused.
+                  ;; Read with a default of true at the use site already; named
+                  ;; here so it is visible and switchable.
+                  :require-test? (not= "0" (or (env "HARNESS_REQUIRE_TEST") "1"))
                   ;; Cross-branch sharing of engine-confirmed artifacts. Off by
                   ;; default: shared lemmas may cost the beam its diversity, and
                   ;; whether they earn it is exactly what sweep-widths measures.

--- a/src/samizdat/llm/fence.clj
+++ b/src/samizdat/llm/fence.clj
@@ -300,6 +300,15 @@
 
 (def ^:private think-re #"(?s)<think>.*?</think>")
 
+;; An opener whose closer never came, to end of text. A reply truncated
+;; mid-thought (finish_reason "length") emits `<think>` and stops, and the
+;; balanced pattern above then matches nothing — so the whole reasoning
+;; stream stayed in the text, inside the prefilled fence, and corrupted the
+;; JSON with exactly the stray parens and quotes the strip exists to remove.
+;; Applied only after the balanced pass, so a well-formed reply is untouched
+;; and nothing after a real `</think>` is ever swallowed.
+(def ^:private open-think-re #"(?s)<think>.*\z")
+
 (defn- strip-think
   "Remove <think>…</think> reasoning blocks before parsing. A reasoning model
   puts its thinking in the content, and after a prefilled `` ```tool-call `` it
@@ -308,7 +317,9 @@
   read (the durable transcript still keeps the full text, stripped only on the
   way to the wire)."
   [s]
-  (str/replace (str s) think-re ""))
+  (-> (str s)
+      (str/replace think-re "")
+      (str/replace open-think-re "")))
 
 (defn- parse-tool-call* [response]
   (let [fenced (extract-fences response)

--- a/src/samizdat/security/policy.clj
+++ b/src/samizdat/security/policy.clj
@@ -270,10 +270,17 @@
   symbolic refs, spawn with a scrubbed environment, and redact the output
   before it returns. Returns a tool-result map.
 
-  `ctx` carries :conn :run-id and :args {:command …}; :env defaults to the
-  process environment. This is the one place the perm, scrub, and redact nodes
-  of the security model meet."
-  [{:keys [conn run-id args] :as ctx}]
+  `ctx` carries :conn :run-id :root and :args {:command …}; :env defaults to
+  the process environment. This is the one place the perm, scrub, and redact
+  nodes of the security model meet.
+
+  The command runs in the run's `:root`, like every other tool. It used to run
+  wherever the harness process happened to be: the file tools resolve paths
+  under the root and the ship gate's verify `cd`s into it, so a run targeting
+  another checkout had `shell` reading and building a different tree than
+  `read_file` and `done` — with the same relative paths naming different
+  files. Absent root, the process cwd, which is what it always did."
+  [{:keys [conn run-id args root] :as ctx}]
   (let [command (str (:command args))
         env (or (:env ctx) (into {} (System/getenv)))
         session (if (and conn run-id) (grants/for-run conn run-id) {:grants []})
@@ -300,9 +307,15 @@
             ;; subprocess cannot read a secret the parent holds even by
             ;; expanding $VAR itself. env -i semantics (see proc/run :env).
             child-env (secrets/scrub-env env)
+            ;; Prefixed rather than passed as a :dir, because proc/run has no
+            ;; working-directory option and `bash -c` is already the shell we
+            ;; are handing the command to. The root is single-quoted through
+            ;; the shared helper; `resolved` is the model's own command and is
+            ;; deliberately NOT quoted — running it as written is the tool.
             r (proc/run {:timeout-ms (or (:timeout-ms ctx) 120000)
                          :env child-env}
-                        "bash" "-c" resolved)
+                        "bash" "-c"
+                        (str "cd " (util/sh-quote (or root ".")) " && " resolved))
             out (if (:timeout r)
                   (str "[timed out after " (:ms r) "ms]")
                   (str (:out r)
@@ -313,7 +326,11 @@
             ;; command's output (a test summary, an exit line) is as load-
             ;; bearing as the start.
             redacted (util/truncate-middle (secrets/redact out known) max-output-chars)]
-        {:category (if (and (not (:timeout r)) (zero? (or (:exit r) 0)))
+        ;; A missing exit code is a spawn that did not report one, which is
+        ;; not evidence the command succeeded. `(or (:exit r) 0)` read it as
+        ;; success, the opposite of what run-verify does with the same shape;
+        ;; both now fail closed.
+        {:category (if (and (not (:timeout r)) (zero? (or (:exit r) 1)))
                      :success :failure)
          :progress? true
          :result redacted

--- a/src/samizdat/util.clj
+++ b/src/samizdat/util.clj
@@ -21,7 +21,52 @@
 
   The first code samizdat wrote about itself: truncate-middle was authored by
   the harness in a supervised self-modification run, then wired into the shell
-  tool's output truncation.")
+  tool's output truncation."
+  (:require [clojure.string :as str]))
+
+(defn sh-quote
+  "`s` as a single-quoted shell word, safe to interpolate into `sh -c`.
+
+  The POSIX escape for a quote inside a single-quoted string is `'\\''`:
+  close, escaped quote, reopen. verify/run-verify spelled it `'\\\\''`, one
+  backslash too many — that closes the quote, emits a literal backslash,
+  opens and closes an empty string, and leaves the REST of the command
+  inside an unterminated quote. A project root holding a `'` turned every
+  verify run into a shell syntax error, and the branch was told its tests
+  were red forever.
+
+  Here rather than in either caller because both the ship gate's verify and
+  the shell tool have the same root to quote, and a second hand-rolled
+  version is how the first one drifted."
+  [s]
+  (str "'" (str/replace (str s) "'" "'\\''") "'"))
+
+(defn generation-cache
+  "Wrap `f` as a no-arg fn whose result is recomputed only when `gen-fn`
+  reports a new generation. The seam between a reloadable resource and the
+  things COMPILED from it.
+
+  The pattern this replaces: a top-level `(def gates (mapv compile-gate …))`
+  reading a cache atom at namespace load. system/start! called reload! on
+  every one of those caches, and the comment said long-lived sessions would
+  pick up edits without a restart — but only the scalar readers did. The
+  compiled gate table, the ship rungs, the forceable-tool schemas, the winner
+  rubric, the stopword sets and the judge preamble were all frozen at first
+  load, so exactly the parts the docstrings advertised as retunable-without-a-
+  rebuild were the parts a reload could not touch.
+
+  A counter rather than a content hash: bumping is what `reload!` already
+  means, and it costs nothing on the read path. Racing readers may compute
+  `f` twice and the last writer wins — both results are derived from the same
+  generation, so they agree."
+  [gen-fn f]
+  (let [cache (atom nil)]
+    (fn []
+      (let [g (gen-fn)
+            c @cache]
+        (if (and c (= g (:gen c)))
+          (:val c)
+          (:val (reset! cache {:gen g :val (f)})))))))
 
 (defn truncate-middle
   "If `s` is longer than `max-len`, return it shortened to exactly `max-len`

--- a/src/samizdat/workflow.clj
+++ b/src/samizdat/workflow.clj
@@ -26,15 +26,22 @@
   driving. Activation is serialized by construction — each run loads and
   compiles once, at start.
 
-  The beam still composes its turns directly (karamazov-ioo.20 tracks its
-  migration); both drivers share the step implementations in
-  samizdat.agent.loop, so this manifest and the beam cannot drift apart on
-  behavior — only on composition."
+  The beam drives this manifest too (karamazov-ioo.20, done): it compiles the
+  per-turn SLICE of the run's loop — `turn-manifest` below — and runs one
+  branch through it per scheduling round, owning the scheduling, culling,
+  forking and finishing the manifest's :finish would otherwise do for a single
+  branch. So there is one driver and one definition of a turn.
+
+  It was not always so, and the gap was invisible: the beam called
+  samizdat.agent.loop's steps directly, `run!` here was reached only from
+  tests, and `:run :loop` was documented in config, parsed from HARNESS_LOOP,
+  and read by nothing on the production path — the critic, team, feature and
+  decompose manifests could not run outside the suite. `run!` remains as the
+  single-branch driver a role's sub-loop uses (see `compiled-manifest`)."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [jolt.fs :as fs]
             [mycelium.core :as myc]
             [mycelium.cell :as cell]
             [mycelium.compose :as compose]
@@ -131,6 +138,91 @@
       :definition (read-definition (:edn row))
       :compiled (compile-loop (read-definition (:edn row)))})))
 
+;; --- the per-turn slice, for the beam ---------------------------------------
+;;
+;; A loop manifest describes a WHOLE run: the per-turn chain, a back edge from
+;; :route to :start, and a :finish that closes the branch and run rows. The
+;; beam needs the per-turn chain alone — it owns scheduling, culling, forking
+;; and finishing across many branches, and a driver that runs one branch to
+;; completion cannot be scheduled against four others.
+;;
+;; Rather than maintain a second per-turn manifest per loop (two files to keep
+;; in agreement, which is how the two drivers drifted apart in the first
+;; place), the slice is DERIVED: every edge that would loop back to the start
+;; node or hand off to :loop/finish instead goes to :end. What remains is one
+;; turn, and the beam does the rest. The cells, the dispatches and the
+;; constraints are untouched, so a manifest edit reaches both drivers.
+
+(def start-node
+  "The manifest's entry node. A convention every shipped manifest follows and
+  mycelium's own compile assumes."
+  :start)
+
+(defn finish-nodes
+  "Nodes whose cell is :loop/finish — the whole-run teardown the beam owns."
+  [definition]
+  (set (keep (fn [[node cell]] (when (= :loop/finish cell) node))
+             (:cells definition))))
+
+(defn iterating?
+  "Whether one pass through this manifest's slice is one TURN — a single model
+  call the beam can schedule against four siblings — or a whole-run workflow
+  that does its own looping inside one call.
+
+  Two conditions, and both are needed. The slice must contain :llm/infer, so
+  that a pass is one model call: `orchestrator` loops back to its start node,
+  but that node is an entire nested worker RUN, and treating it as a turn
+  would put a multi-minute job under the 900s turn deadline and run five of
+  them at once. And the chain must loop back to the start node, so that a pass
+  is a turn rather than the whole job: `team`, `feature` and `decompose` run
+  straight through.
+
+  loop / critic / review / worker / reviewer / supervisor iterate; team,
+  feature, decompose and orchestrator do not. The answer decides the beam's
+  width and whether the per-turn deadline applies."
+  [definition]
+  (let [cells (set (vals (:cells definition)))
+        loops-back? (some (fn [[_ to]]
+                            (if (map? to)
+                              (some #(= start-node %) (vals to))
+                              (= start-node to)))
+                          (:edges definition))]
+    (boolean (and (contains? cells :llm/infer) loops-back?))))
+
+(defn turn-manifest
+  "`definition` reduced to ONE turn: edges back to the start node and edges
+  into :loop/finish are redirected to :end, and the finish node is dropped
+  (mycelium's reachability check refuses an orphan).
+
+  Returns a definition that compiles and runs exactly like the original up to
+  the turn boundary, and then stops."
+  [definition]
+  (let [finish (finish-nodes definition)
+        terminal (conj finish start-node)
+        retarget (fn [to] (if (contains? terminal to) :end to))]
+    (-> definition
+        (assoc :cells (into {} (remove (comp finish key)) (:cells definition)))
+        (assoc :edges
+               (into {}
+                     (for [[from to] (:edges definition)
+                           ;; The finish node's own outgoing edge goes with it.
+                           :when (not (contains? finish from))]
+                       [from (if (map? to)
+                               (into {} (map (juxt key (comp retarget val))) to)
+                               (retarget to))]))))))
+
+(defn compile-turn-loop
+  "Load the named manifest and compile BOTH forms: the whole-run definition
+  (for provenance and for `iterating?`) and its per-turn slice, which is what
+  the beam drives. Returns {:name :version :definition :iterating? :compiled}."
+  [conn name]
+  (let [{:keys [version definition]} (load-loop! conn name)]
+    {:name name
+     :version version
+     :definition definition
+     :iterating? (iterating? definition)
+     :compiled (compile-loop (turn-manifest definition))}))
+
 (defn compiled-manifest
   "Compile the named factory manifest to a runnable sub-loop. The seam a role
   cell uses to run a role's own loop (worker for an implementor, reviewer for a
@@ -157,8 +249,20 @@
   [name]
   (some-> (io/resource (str "prompts/" name ".md")) slurp))
 
-(defn- manifest-name-from-path [p]
-  (-> (str p) (str/replace #".*/" "") (str/replace #"\.edn$" "")))
+(def ^:private factory-manifest-names
+  "The manifests that ship with the harness.
+
+  A literal list, resolved against `io/resource` rather than globbed off a
+  cwd-relative `resources/manifests`. Everything else in this namespace
+  already reads manifests through io/resource — the glob was the one holdout,
+  and it was the same bug review3 #11 fixed for the cells dir: a binary (or a
+  process started anywhere but the project root) found no directory, caught
+  the exception, and served the supervisor a catalogue with the factory half
+  silently missing. There is no portable listing for classpath resources, so
+  the set is enumerated and `catalog` drops any name that does not resolve —
+  a manifest deleted from resources/ falls out rather than 404ing."
+  ["loop" "critic" "orchestrator" "review" "reviewer" "supervisor"
+   "worker" "team" "feature" "decompose"])
 
 (defn catalog
   "The workflows available to select or adapt: every factory manifest and every
@@ -167,8 +271,8 @@
   or author a new one — the compiled menu the self-healing loop chooses from.
   A manifest with no :description still lists, with an empty one."
   [conn]
-  (let [factory (->> (try (fs/glob "resources/manifests" "*.edn") (catch Throwable _ nil))
-                     (map manifest-name-from-path)
+  (let [factory (->> factory-manifest-names
+                     (filter #(io/resource (manifest-resource %)))
                      set)
         stored (->> (try (workflows/names conn) (catch Throwable _ nil))
                     ;; workflows/names yields rows ({:name :version :versions}),

--- a/test/samizdat/agent_test.clj
+++ b/test/samizdat/agent_test.clj
@@ -190,7 +190,7 @@
 
 (deftest gate-config-is-coherent
   (testing "every gate with a budget names a threshold that exists"
-    (doseq [g gates/gates :when (:budget g)]
+    (doseq [g (gates/gates) :when (:budget g)]
       (is (some? (gates/threshold (:budget g)))
           (str (:gate g) " names a budget with no entry in gates.edn"))))
 
@@ -202,8 +202,28 @@
     (is (< (gates/threshold :stuck-threshold) (gates/threshold :cull-threshold))))
 
   (testing "priorities are unique, or the arbiter's choice is arbitrary"
-    (let [ps (map :priority gates/gates)]
+    (let [ps (map :priority (gates/gates))]
       (is (= (count ps) (count (distinct ps))))))
+
+  (testing "every gate can be settled — a vocabulary entry or a rule of its own"
+    ;; The budget check above has a sibling this lacked: a gate added to
+    ;; gates.edn :gates with no :tool-vocab :settle-called entry and no
+    ;; explicit clause in arbiter/settle used to hand `nil` to `some` as a
+    ;; predicate and throw on its first firing. `settle` now defaults to #{},
+    ;; so the failure mode is a prediction that can only expire — quieter and
+    ;; still wrong. Name it here instead.
+    (let [vocab (gates/tool-vocab :settle-called)]
+      (doseq [g (gates/gates)]
+        (is (or (contains? vocab (:gate g))
+                (contains? arbiter/settled-by-rule (:gate g)))
+            (str (:gate g) " has no :settle-called vocabulary and no rule in"
+                 " arbiter/settle — its prediction can only ever expire")))))
+
+  (testing "arbiter/settled-by-rule names only gates that exist"
+    (let [known (set (map :gate (gates/gates)))]
+      (doseq [g arbiter/settled-by-rule]
+        (is (contains? known g)
+            (str g " is claimed as rule-settled but is not a gate")))))
 
   (testing "the capability tier may not tune a verification or progress guard"
     ;; PR 740's rule: a signal may only tune a guard that fires on the same
@@ -233,7 +253,7 @@
   ;; here rather than silently three generations later.
   (let [b (branch-with)
         every-tool (vec (tools/tool-names))]
-    (doseq [{:keys [gate]} gates/gates]
+    (doseq [{:keys [gate]} (gates/gates)]
       (is (= :met (arbiter/settle {:gate gate :turn 1 :window 3}
                                   {:current-turn 2
                                    :tools-called every-tool
@@ -1280,7 +1300,7 @@
              :done-block "blocked because ..."
              :directive {:payload "a human said so"}
              :safe-state-coverage {:ok true}}]
-    (doseq [g gates/gates]
+    (doseq [g (gates/gates)]
       (testing (str (:gate g))
         (let [msg ((:message g) ctx)]
           (is (string? msg))
@@ -1599,13 +1619,13 @@
   ;; wrong as a blanket default.
   (testing "a gate whose prediction names exactly one tool carries it"
     (doseq [g [:branch-out :repopulate]]
-      (is (= "branch_theses" (:tool (get gates/by-name g)))
+      (is (= "branch_theses" (:tool (gates/by-name g)))
           (str g " predicts 'the branch calls branch_theses' and should say so"))))
   (testing "a gate naming a choice or a behaviour carries none"
     ;; milestone predicts "review or done", stuck predicts a change of
     ;; technique. Forcing either would be the harness picking, not steering.
     (doseq [g [:milestone :stuck :progress-stalled :turn-budget]]
-      (is (nil? (:tool (get gates/by-name g)))
+      (is (nil? (:tool (gates/by-name g)))
           (str g " names no single tool and must not force one"))))
   (testing "the prefill is the opening fence, plus the name when there is one"
     (is (= "```tool-call\n{\"name\": \"branch_theses\""
@@ -1689,7 +1709,7 @@
   (let [refl (gates/by-name :reflection)]
     (testing "it is the lowest-priority gate"
       (is (= 13 (:priority refl)))
-      (is (= 13 (apply max (map :priority gates/gates)))
+      (is (= 13 (apply max (map :priority (gates/gates))))
           "nothing sits below reflection, so a real steer always outranks it"))
     (testing "fires on a turn that is a multiple of 15, while active"
       (is ((:when refl) {:branch (branch-with :turns (vec (repeat 15 {})))}))
@@ -1806,7 +1826,7 @@
     (doseq [g [:human-directive :done-blocked :safe-state :stuck
                :progress-stalled :studying]]
       (is (contains? data g) (str g " is a gates.edn entry")))
-    (is (= (count gates/gates) (count (:gates (gates/config))))
+    (is (= (count (gates/gates)) (count (:gates (gates/config))))
         "every gate comes from data — no closure half remains")
     (is (= "done-block passthrough"
            ((:message (gates/by-name :done-blocked))
@@ -1856,13 +1876,13 @@
   (is (= :begin-reframe (:effect (gates/by-name :stuck))))
   (is (= :notified-fractions (:effect (gates/by-name :turn-budget))))
   (is (every? (complement :effect)
-              (remove #(contains? #{:stuck :turn-budget} (:gate %)) gates/gates))
+              (remove #(contains? #{:stuck :turn-budget} (:gate %)) (gates/gates)))
       "no other gate claims a branch effect")
   ;; decide carries :effect from the chosen gate's data
-  (with-redefs [gates/gates [{:gate :test-gate :priority 0 :effect :e
+  (with-redefs [gates/gates (constantly [{:gate :test-gate :priority 0 :effect :e
                               :when (fn [_] true)
                               :message (fn [_] "m")
-                              :prediction (fn [_] nil)}]]
+                              :prediction (fn [_] nil)}])]
     (is (= :e (:effect (arbiter/decide {})))))
   ;; apply-effects dispatches on :effect, not the gate's name
   (let [b (branch-with)]

--- a/test/samizdat/cells_test.clj
+++ b/test/samizdat/cells_test.clj
@@ -43,6 +43,44 @@
 
 ;; --- loading ----------------------------------------------------------------
 
+(deftest shipped-cells-match-what-ships
+  ;; The shipped cells are enumerated as resource names rather than globbed:
+  ;; `jolt build` bakes resources/ into the binary (deps.edn :jolt/build
+  ;; :embed), and an embedded resource has no filesystem path for the glob to
+  ;; walk — so a built binary run outside the project root registered zero
+  ;; cells and every run died with "Cell :loop/assemble not found in
+  ;; registry". An enumerated list cannot drift on its own, so pin it.
+  (let [on-disk (->> (fs/glob "resources/cells" "**.clj")
+                     (map #(str "cells/" (last (clojure.string/split (str %) #"/"))))
+                     set)]
+    (is (seq on-disk) "resources/cells is readable from the test's cwd")
+    (is (= on-disk (set cells/shipped-cells))
+        (str "cells/shipped-cells and resources/cells disagree; missing: "
+             (sort (remove (set cells/shipped-cells) on-disk))
+             ", listed but absent: "
+             (sort (remove on-disk (set cells/shipped-cells))))))
+  (testing "every shipped name resolves on the classpath"
+    (doseq [r cells/shipped-cells]
+      (is (some? (clojure.java.io/resource r)) (str r " does not resolve")))))
+
+(deftest every-shipped-cell-require-is-reachable-without-load-string
+  ;; A shipped cell is load-stringed, so a namespace it requires that NOTHING
+  ;; in src reaches is absent from a `jolt build` image and the cell dies with
+  ;; "Could not locate … on the source roots". samizdat.cell-prelude exists to
+  ;; pull those onto the compile graph; samizdat.agent.decompose had fallen
+  ;; off it. Walk the requires rather than trusting the list stays current.
+  (let [required (->> cells/shipped-cells
+                      (keep clojure.java.io/resource)
+                      (mapcat #(re-seq #"\[(samizdat\.[a-z0-9.-]+)" (slurp %)))
+                      (map second)
+                      set)]
+    (is (seq required) "the shipped cells were readable")
+    (doseq [ns-name required]
+      (is (some? (find-ns (symbol ns-name)))
+          (str ns-name " is required by a shipped cell but is not loaded — add"
+               " it to samizdat.cell-prelude or it will be missing from a"
+               " built binary")))))
+
 (deftest loads-every-cell-file-in-a-dir
   (let [d (str @tmp "/cells")]
     (cell-file! d :gen/a "(fn [_ data] (assoc data :a 1))")

--- a/test/samizdat/judge_test.clj
+++ b/test/samizdat/judge_test.clj
@@ -125,7 +125,7 @@
   ;; FINDINGS:/severity-tag formats, so the move pins them: the def IS the
   ;; file's contents.
   (let [file (slurp (io/resource "prompts/judge.md"))]
-    (is (= file judge/preamble))
+    (is (= file (judge/preamble)))
     (is (str/includes? file "VERDICT: COMPLETE"))
     (is (str/includes? file "FINDINGS:"))
     (is (str/includes? file "[critical]")))

--- a/test/samizdat/manifest_test.clj
+++ b/test/samizdat/manifest_test.clj
@@ -32,6 +32,72 @@
   (let [conn (db/open! ":memory:")]
     (f conn)))
 
+(deftest factory-manifest-names-match-what-ships
+  ;; wf/catalog used to glob a cwd-relative "resources/manifests", which found
+  ;; nothing from a built binary or a process started elsewhere and silently
+  ;; served a catalogue with the factory half missing (the review3 #11 bug in
+  ;; a second place). It now resolves an enumerated list through io/resource,
+  ;; which cannot drift on its own — so pin the list against the directory.
+  (let [on-disk (->> (file-seq (io/file "resources/manifests"))
+                     (filter #(str/ends-with? (.getName %) ".edn"))
+                     (map #(str/replace (.getName %) #"\.edn$" ""))
+                     set)
+        catalogued (set (map :name (wf/catalog nil)))]
+    (is (seq on-disk) "the manifests dir is readable from the test's cwd")
+    (is (= on-disk catalogued)
+        (str "wf/catalog and resources/manifests disagree; missing from the"
+             " catalogue: " (sort (remove catalogued on-disk))
+             ", catalogued but absent from disk: "
+             (sort (remove on-disk catalogued))))))
+
+(deftest turn-manifest-is-one-turn-of-the-loop
+  ;; The beam drives the per-TURN slice of a manifest, derived rather than
+  ;; maintained as a second file: edges back to :start and edges into
+  ;; :loop/finish become :end, and the finish node goes away. This is what
+  ;; lets one driver serve both the scheduler and the single-branch path, and
+  ;; what finally makes :run :loop reach a production run.
+  (let [def' (wf/read-definition (slurp (io/resource "manifests/loop.edn")))
+        turn (wf/turn-manifest def')]
+    (testing "the back edge and the finish hand-off both terminate the turn"
+      (is (= {:continue :end :done :end :abandoned :end :exhausted :end}
+             (:route (:edges turn)))))
+    (testing "the finish node is dropped, not orphaned"
+      (is (contains? (:cells def') :finish))
+      (is (not (contains? (:cells turn) :finish)))
+      (is (not (contains? (:edges turn) :finish))))
+    (testing "the per-turn chain is untouched"
+      (is (= (:infer (:edges def')) (:infer (:edges turn))))
+      (is (= (:parse (:edges def')) (:parse (:edges turn))))
+      (is (= (:dispatches def') (:dispatches turn)))
+      (is (= (:constraints def') (:constraints turn))))))
+
+(deftest every-shipped-manifest-has-a-compilable-turn-slice
+  ;; The rewrite must leave a graph mycelium still accepts — reachable nodes,
+  ;; covered dispatches, satisfied constraints — for every manifest, not just
+  ;; the factory loop. A slice that fails to compile is a run that cannot
+  ;; start, and the beam compiles this before POST /v1/runs answers.
+  (doseq [nm ["loop" "critic" "review" "worker" "reviewer" "supervisor"
+              "orchestrator" "team" "feature" "decompose"]]
+    (testing nm
+      (let [d (wf/read-definition (slurp (io/resource (wf/manifest-resource nm))))]
+        (is (some? (wf/compile-loop (wf/turn-manifest d)))
+            (str nm "'s turn slice does not compile"))))))
+
+(deftest iterating-classification-decides-width-and-deadline
+  ;; A pass through the slice is one model call only when the slice contains
+  ;; :llm/infer AND loops back to start. Both halves matter: orchestrator
+  ;; loops back to a start node that is an entire nested worker run, and
+  ;; scheduling that as a "turn" would run five whole runs at once under a
+  ;; 900s deadline meant for one provider call.
+  (let [iterating? (fn [nm]
+                     (wf/iterating?
+                      (wf/read-definition
+                       (slurp (io/resource (wf/manifest-resource nm))))))]
+    (doseq [nm ["loop" "critic" "review" "worker" "reviewer" "supervisor"]]
+      (is (true? (iterating? nm)) (str nm " is a per-turn loop")))
+    (doseq [nm ["team" "feature" "decompose" "orchestrator"]]
+      (is (false? (iterating? nm)) (str nm " is a whole-run workflow")))))
+
 (deftest active-loop-name-comes-from-config
   (is (= "loop" (wf/active-loop-name {})))
   (is (= "loop" (wf/active-loop-name {:run {}})))

--- a/test/samizdat/workflow_test.clj
+++ b/test/samizdat/workflow_test.clj
@@ -22,6 +22,7 @@
   hand-written loop did. Editing the stored definition changes the next run —
   that is the whole point."
   (:require [clojure.data.json :as json]
+            [samizdat.agent.beam :as beam]
             [samizdat.cells :as cells]
             [clojure.edn :as edn]
             [clojure.string :as str]
@@ -118,6 +119,50 @@
         (let [turns (journal/branch-turns c (:run-id r) "B1")]
           (is (= ["thesis" "done"] (mapv :tool_name turns))))
         (is (= "completed" (:status (runs/get-run c (:run-id r)))))))))
+
+(deftest the-beam-drives-the-manifest-too
+  ;; The fix for the review's biggest finding: the beam used to call
+  ;; samizdat.agent.loop's steps directly and never touch a manifest, so
+  ;; `:run :loop` was documented, parsed from HARNESS_LOOP, and read by
+  ;; nothing on the production path — every POST /v1/runs got the factory
+  ;; composition no matter what was configured, and critic/team/feature/
+  ;; decompose ran only under this suite. The beam now compiles the per-turn
+  ;; SLICE of the selected manifest and runs each branch through it.
+  (with-db [c]
+    (with-redefs [llm/chat (scripted
+                            (fence {:name "thesis"
+                                    :args {:goal "solve the problem"
+                                           :technique "direct"}})
+                            (fence {:name "done"
+                                    :args {:answer "the problem is solved directly"}}))]
+      (let [r (beam/run! {:conn c :config {:run {:beam-width 1}}
+                          :llm-adapter :a :llm-config {:max-tokens 16384}
+                          :problem "solve the problem" :max-turns 10 :beam-width 1})]
+        (is (= :completed (:status r)))
+        (is (= "the problem is solved directly" (:answer r)))
+        (testing "the branch ran the manifest's per-turn chain"
+          (is (= ["thesis" "done"]
+                 (mapv :tool_name (journal/branch-turns c (:run-id r) "B1")))))
+        (testing "the run records which loop drove it, like the other driver"
+          (let [note (->> (journal/events-since c (:run-id r) 0)
+                          (filter #(= "loop-workflow" (:kind %)))
+                          first)]
+            (is (some? note)
+                "a beam run journals its :loop-workflow provenance")))))))
+
+(deftest a-non-iterating-manifest-forces-beam-width-1
+  ;; team/feature/decompose are whole-run workflows: one pass is the branch's
+  ;; entire job, not one model call. Running five concurrently would multiply
+  ;; the job rather than explore five lines of one, so the beam overrides the
+  ;; requested width and says so in the run row.
+  (with-db [c]
+    (with-redefs [llm/chat (scripted (fence {:name "give_up"
+                                             :args {:reason "stub"}}))]
+      (let [r (beam/run! {:conn c :config {:run {:loop "team" :subtasks ["a"]}}
+                          :llm-adapter :a :llm-config {:max-tokens 16384}
+                          :problem "anything" :max-turns 4 :beam-width 5})]
+        (is (= 1 (:beam_width (runs/get-run c (:run-id r))))
+            "a whole-run manifest runs one branch regardless of the width asked for")))))
 
 (deftest the-turn-cap-exhausts-through-the-manifest
   (with-db [c]


### PR DESCRIPTION
A read-through of the whole tree for bugs, dead wiring, and code that reads
like live policy but cannot run. Sixteen findings, fixed in four tranches by
severity; then a second commit for the build-time resource problem the first
one surfaced.

Suite **1037 tests / 3414 assertions, 0 failures** (baseline 1029/3338).
Release build green, and the binary now boots, serves and starts a run from
an empty directory.

## Correctness

- **`verify/run-verify` quoted a root holding `'` as `'\\''`** — one
  backslash too many. That closes the quote, emits a literal backslash, and
  leaves the rest of the command inside an unterminated quote, so every
  verify run in such a root was a shell syntax error and `done` could never
  see green. The escape is `util/sh-quote` now, shared with the shell tool.
- **An untargeted `cull` emptied the beam.** It matched every branch; the
  guard only ever caught `alive=1`, so the outcome it exists to prevent
  arrived by the other door.
- **`arbiter/settle` threw** on a gate the `:settle-called` vocabulary does
  not name — `(some nil …)` calls nil as a predicate. Defaults to `#{}`, and
  the coherence test now names a gate with neither a vocabulary nor a rule.
- **`state/rank-finished` was data-driven in name only**: it destructured
  five components and negated four, so dropping one from the phases.edn
  rubric threw on `(- nil)` and adding one silently left it out of the
  ranking. `compare-finished-keys` is generic over the tuple's shape.
- `run-shell` read a missing exit code as success where `run-verify` reads
  the same shape as failure; both fail closed. `resume!` reported
  `max_turns` by racing the row the resume was rewriting. `strip-think` left
  an unclosed `<think>` — a reply truncated mid-thought — inside the
  prefilled fence. `graph/fit` threw on an empty graph.

## Wiring

- **`beam/run!` and `resume/resume!` never set `:root`, `:repl-session` or
  `:git-baseline`** — the three ctx keys only the manifest driver set. Every
  consumer defends with `(or root ".")`, so the omission was silent:
  `:run :root` was documented and ignored, and `eval` fell through to
  `repl/default-session`, one process-wide namespace never closed and shared
  by every run on the box. That is the leak code-review-2026-08 #6 fixed on
  the other driver only.
- The shell tool runs in `:root`, like the file tools and the ship verify.
- `:verify-focused?` and `:require-test?` default on. `verify-on?` needed a
  `:verify-cmd` or the flag and neither had a default, so the ship gate's
  test rung — "done is a hard gate on a green test" — was inert on any run
  without a `.samizdat/config.edn`.

## Reload

`system/start!` reloaded three caches while everything **compiled** from them
stayed frozen at namespace load: the gate table, `by-name`, the forceable
schemas, the ship rungs, the stopwords, the tool-version pattern, the winner
rubric, the judge preamble. Exactly the parts documented as
retunable-without-a-rebuild were the parts a reload could not reach.
`util/generation-cache` memoizes each against a generation its loader bumps;
the three compile sites bind `*ns*` explicitly, since they compile on first
use now and the caller's namespace resolves none of
`threshold`/`prompt`/`state`.

`workflow/catalog` globbed a cwd-relative `resources/manifests` — the
review3 #11 bug in a second place, serving the supervisor a catalogue with
the factory half missing.

## Architecture

- **The beam drives the manifest.** `workflow/turn-manifest` derives a
  loop's per-turn slice (edges back to `:start` or into `:loop/finish`
  become `:end`) and `beam/advance-branch` runs one branch through it per
  round, so there is one driver and one definition of a turn. `:run :loop`
  was documented in config, parsed from `HARNESS_LOOP`, and read by nothing
  on the production path — critic, team, feature and decompose could not run
  outside the test suite. `iterating?` separates per-turn loops from
  whole-run workflows, which decides beam width and whether the turn
  deadline applies.
- **A green ship-verify is this loop's confirmed artifact.** Nothing had
  produced `:confirmed` artifacts since the proof engines left, so
  `confirmed-artifacts` was empty *by construction* — and the milestone,
  branch-out and emergency-review gates, the `:share` policy and the shared
  pool, the figure-coverage ship rung, `arbiter/progressed?`, and two
  components of the winner rubric were all dead code that read like live
  policy. `add-artifact` stamps `:tiers-seen` so the live path and resume's
  replay agree.

## Resource embedding (second commit)

`jolt build` links code and deps, not data. Without `:jolt/build :embed` the
binary resolved every resource **relative to the working directory**: it
booted from the project root and died anywhere else on the first
`reload-config!` with `Cannot open <nil> as a Reader`. jolt's own
`test/chez/build-app` fixture is the precedent.

The key fixes the flat files; it then exposes the two places that reach the
classpath as a *filesystem*:

- `cells/cell-files` globbed `(.getPath (io/resource "cells"))`. A classpath
  has no directory listing and an embedded resource names no file, so the
  kernel registered zero cells and every run died with
  `Cell :loop/assemble not found in registry`. The shipped cells are
  enumerated as resource names now, pinned against the directory by a test.
  The dir scan still runs and still wins, so a source checkout loads from
  disk and `.samizdat/cells` overrides still override.
- `samizdat.agent.decompose` was reached only through a cell's
  `load-string`, so it never reached the compile graph —
  `Could not locate samizdat/agent/decompose on the source roots`. That is
  what `samizdat.cell-prelude` exists to prevent and it had fallen off the
  list. A test now walks every shipped cell's requires against what is
  loaded.

## Review notes

- The `advance-branch` change is the riskiest thing here: it moves every
  production run onto the manifest driver. The factory loop's slice composes
  exactly the steps `run-turn` composed, and the suite covers both, but it
  is the change worth a second pair of eyes.
- Making the gate tables lazy broke `eval`'s symbol resolution (the forms
  resolved against the *caller's* namespace); the suite caught it and all
  three sites now bind `*ns*`. Worth knowing if similar `eval`-at-load code
  is added later.
