### PR TITLE
audit round 1: crashes and security one-liners

### DIFF
--- a/docs/RFCS/RFC-003-security-model.md
+++ b/docs/RFCS/RFC-003-security-model.md
@@ -91,12 +91,25 @@ flowchart LR
     env --> eval
     secrets --> eval
     eval --> redact
+
+    lsp[lsp tool: clojure-lsp subprocess]
+    toolcall --> lsp
+    scrub --> lsp
+    lsp --> redact
 ```
 
 The `eval` node and its three edges were absent from this graph until this RFC
 was written, which is how the property they violated stayed believed for four
 review passes. `eval --> redact` is the fix (F1); before it, eval reached
 `result` directly.
+
+The `lsp` node repeated the omission: clojure-lsp was the one subprocess
+spawned with the full parent environment (and it re-spawns children of its
+own), and its file argument resolved with a bare `io/file`, outside the root
+confinement every file tool enforces. Both fixed in the 2026-08 audit
+(karamazov-blt.27, blt.28): it spawns through `scrub` and its paths go
+through `resolve-under-root`; its replies were already inside the envelope
+redaction.
 
 Reading the load-bearing solid edges:
 

--- a/resources/prompts/cell-tool.md
+++ b/resources/prompts/cell-tool.md
@@ -1,0 +1,1 @@
+{% if live-unsaved %}Cell '{{name}}' compiled and dry-ran, and is live in this process — but no project store is bound, so nothing was saved and the edit will not survive a restart.{% endif %}

--- a/src/samizdat/agent/files.clj
+++ b/src/samizdat/agent/files.clj
@@ -75,10 +75,14 @@
   []
   (:grep-ranges (gates/threshold :context-budget)))
 
-(defn- resolve-under-root
+(defn resolve-under-root
   "Canonicalize `path` under `root`; return the resolved absolute path string,
   or nil when it escapes the root. The canonical root is the boundary — a
-  `..` or an absolute path that lands outside it fails closed."
+  `..` or an absolute path that lands outside it fails closed.
+
+  Public because it is THE confinement primitive: every tool that turns a
+  model-supplied path into a filesystem read must come through here, and the
+  lsp tool rolling its own bare io/file was the escape (karamazov-blt.28)."
   [root path]
   (let [root* (str (fs/canonicalize root))
         target (str (fs/canonicalize (fs/path root path)))]

--- a/src/samizdat/agent/tools/lsp.clj
+++ b/src/samizdat/agent/tools/lsp.clj
@@ -3,10 +3,11 @@
 
 (ns samizdat.agent.tools.lsp
   "LSP tool: code navigation via clojure-lsp. Read-only inspection."
-  (:require [clojure.java.io :as io]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
+            [samizdat.agent.files :as files]
             [samizdat.agent.tools.base :as base]
-            [samizdat.lsp.client :as client]))
+            [samizdat.lsp.client :as client]
+            [samizdat.prompt :as prompt]))
 
 (def ^:private usage
   (str "lsp ops: definition|references|hover need file (project-relative), line, col (0-based); "
@@ -26,8 +27,13 @@
   (str (get-in d [:range :start :line]) ":" (get-in d [:range :start :character])
        " " (:severity d) ": " (:message d)))
 
-(defn- resolve-file [ctx]
-  (str (io/file (:root ctx) (base/arg ctx :file))))
+(defn- resolve-file
+  "The confined path, or nil when it escapes the project root. The bare
+  io/file version let `../` and absolute paths escape the boundary read_file
+  enforces, and ensure-open! then slurped whatever they named
+  (karamazov-blt.28)."
+  [ctx]
+  (files/resolve-under-root (:root ctx) (str (base/arg ctx :file))))
 
 (defn- parse-int-or-nil [s]
   (try (Integer/parseInt (str/trim (str s))) (catch Exception _ nil)))
@@ -55,22 +61,36 @@
     (let [op (some-> (base/arg ctx :op) str str/trim str/lower-case not-empty)]
       (if-not (#{"definition" "references" "hover" "diagnostics"} op)
         (base/malformed branch (str "lsp needs a valid :op. " usage))
-        (let [miss-file (base/missing ctx :file)]
-          (if miss-file
+        (let [miss-file (base/missing ctx :file)
+              file (when-not miss-file (resolve-file ctx))]
+          (cond
+            miss-file
             (base/malformed branch miss-file)
-            (let [file (resolve-file ctx)]
-              (if (= op "diagnostics")
+
+            (nil? file)
+            ;; The same sentence read_file's refusal renders, from the same
+            ;; template — one surface for one message class, and editable
+            ;; without a rebuild (the no-new-model-facing-prose ratchet).
+            (base/malformed branch
+                            (prompt/render "file-tool"
+                                           {:outside-root true
+                                            :path (str (base/arg ctx :file))
+                                            :verb "inspected"}))
+
+            (= op "diagnostics")
+            (let [c (client/client-for root)]
+              (if (nil? c)
+                (base/fail branch "could not start clojure-lsp for root")
+                (let [ds (client/diagnostics c file)]
+                  (base/ok branch (if (seq ds) (str/join "\n" (map render-diag ds)) "no problems")))))
+
+            :else
+            (let [err-pos (want-pos ctx)]
+              (if err-pos
+                (base/malformed branch err-pos)
                 (let [c (client/client-for root)]
                   (if (nil? c)
                     (base/fail branch "could not start clojure-lsp for root")
-                    (let [ds (client/diagnostics c file)]
-                      (base/ok branch (if (seq ds) (str/join "\n" (map render-diag ds)) "no problems")))))
-                (let [err-pos (want-pos ctx)]
-                  (if err-pos
-                    (base/malformed branch err-pos)
-                    (let [c (client/client-for root)]
-                      (if (nil? c)
-                        (base/fail branch "could not start clojure-lsp for root")
-                        (base/ok branch (lookup-op op c file
-                                                   (parse-int-or-nil (base/arg ctx :line))
-                                                   (parse-int-or-nil (base/arg ctx :col))))))))))))))))
+                    (base/ok branch (lookup-op op c file
+                                               (parse-int-or-nil (base/arg ctx :line))
+                                               (parse-int-or-nil (base/arg ctx :col))))))))))))))

--- a/src/samizdat/agent/tools/mutate.clj
+++ b/src/samizdat/agent/tools/mutate.clj
@@ -33,6 +33,7 @@
             [samizdat.agent.tools.base :as base]
             [samizdat.cells :as cells]
             [samizdat.mutation :as mutation]
+            [samizdat.prompt :as prompt]
             [samizdat.store.userspace]
             [samizdat.userspace :as userspace]))
 
@@ -149,13 +150,24 @@
                       :loop-def (current-loop-def)
                       :soak-input (soak-input)
                       :conn conn :run-id run-id})]
-              (if (= :committed (:status r))
+              (case (:status r)
+                :committed
                 (base/ok branch
                          (str "Saved cell '" name "' as v" (:version r)
                               " in this project — it compiled, it dry-ran, and it"
                               " is live on your next turn. The shipped template is"
                               " unchanged; other projects still start from it.")
                          :progress? true)
+
+                ;; Validate and soak passed and the edit is live in this
+                ;; image, but nothing was persisted — telling the model it
+                ;; was "saved as v" here was a lie about durability
+                ;; (karamazov-blt.8).
+                :live-unsaved
+                (base/ok branch
+                         (prompt/render "cell-tool" {:live-unsaved true
+                                                     :name name}))
+
                 (base/fail branch
                            (str "Cell '" name "' was NOT saved; the loop is"
                                 " unchanged and nothing entered this project's"

--- a/src/samizdat/config.clj
+++ b/src/samizdat/config.clj
@@ -24,7 +24,8 @@
   In-process GGUF inference is not carried over — point HARNESS_BASE_URL at any
   OpenAI-compatible endpoint (including llama-server) instead."
   (:require [clojure.edn :as edn]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.walk :as walk]))
 
 (defn deep-merge
   "Merge maps left to right, recursing when BOTH values are maps; any other
@@ -244,8 +245,19 @@
      overrides)))
 
 (defn redacted
-  "The config with the API key masked, for logging and for /health."
+  "The config with every :api-key masked, WHEREVER it sits, for logging and
+  for /health.
+
+  A walk rather than a path: [:llm :api-key] is not the only place a key
+  lives — a role spec under :run :role-models may carry its own :api-key
+  override (role-ctx merges it into the provider config), and the path
+  version served exactly that one cleartext (karamazov-blt.29). Masking by
+  key name means the next nested key is masked without anyone remembering
+  this function exists."
   [config]
-  (cond-> config
-    (get-in config [:llm :api-key])
-    (assoc-in [:llm :api-key] "***")))
+  (walk/postwalk
+   (fn [x]
+     (if (and (map? x) (some? (:api-key x)))
+       (assoc x :api-key "***")
+       x))
+   config))

--- a/src/samizdat/lsp/client.clj
+++ b/src/samizdat/lsp/client.clj
@@ -36,7 +36,8 @@
             [clojure.java.io :as io]
             [clojure.string :as str]
             [jolt.process :as jp]
-            [samizdat.engine.proc :as proc])
+            [samizdat.engine.proc :as proc]
+            [samizdat.security.secrets :as secrets])
   (:import [java.io BufferedInputStream OutputStream]))
 
 ;; root -> {:proc :out :in :next-id :opened :diagnostics :pending}
@@ -152,11 +153,23 @@
 
 (defn- uri [path] (str "file://" (.getAbsolutePath (io/file path))))
 
+(defn spawn-spec
+  "What start! spawns, as data, so a test can hold the seam without a server.
+
+  The environment is the SCRUBBED one — the same seam the shell tool, verify
+  and gitdiff spawn through. clojure-lsp was the one subprocess inheriting the
+  full parent environment, and it re-spawns children of its own (classpath
+  resolution) that inherit whatever it got (karamazov-blt.27)."
+  []
+  {:cmd ["clojure-lsp" "listen"]
+   :opts {:env (secrets/scrubbed-process-env)}})
+
 (defn start!
   "Spawn clojure-lsp for `root` and run the initialize/initialized
   handshake. Returns the client map."
   [root]
-  (let [p (jp/process ["clojure-lsp" "listen"])
+  (let [{:keys [cmd opts]} (spawn-spec)
+        p (jp/process cmd opts)
         ^java.lang.Process osproc (:proc p)
         client {:proc p
                 :root root

--- a/src/samizdat/mutation.clj
+++ b/src/samizdat/mutation.clj
@@ -217,11 +217,24 @@
           (fail reason)
           ;; COMMIT. The candidate is already live; this is what makes it
           ;; survive a restart and what another run will load.
+          ;;
+          ;; save! returns nil when no project store is bound (RFC-001), and
+          ;; that is NOT a commit: reporting :committed with a nil version had
+          ;; the tool telling the model "saved as v … live on your next turn"
+          ;; about an edit that vanishes on restart (karamazov-blt.8). It is
+          ;; not a rollback either — validate and soak passed, the candidate
+          ;; stays live in this image — so the caller hears exactly that.
           (let [v (userspace/save! :cell name body)]
-            (when (and conn run-id)
-              (journal/note! conn run-id :mutation-committed
-                             {:data {:cell name :version v}}))
-            (log/info "cell" name "committed as version" v)
-            {:status :committed :version v})))
+            (if (nil? v)
+              ;; :reason is a KEYWORD, not prose: the sentence the model reads
+              ;; is the tool's to render (prompts/cell-tool.md), same as every
+              ;; other model-facing word.
+              (do (log/warn "cell" name "is live but UNSAVED — no project store is bound")
+                  {:status :live-unsaved :reason :unbound})
+              (do (when (and conn run-id)
+                    (journal/note! conn run-id :mutation-committed
+                                   {:data {:cell name :version v}}))
+                  (log/info "cell" name "committed as version" v)
+                  {:status :committed :version v})))))
       (catch Throwable e
         (fail (str "the candidate did not load — " (or (ex-message e) (str e))))))))

--- a/src/samizdat/prompt.clj
+++ b/src/samizdat/prompt.clj
@@ -38,6 +38,7 @@
    "architect"
    "branch-cap"
    "branch-out"
+   "cell-tool"
    "critic"
    "critic-system"
    "crossover"

--- a/src/samizdat/security/secrets.clj
+++ b/src/samizdat/security/secrets.clj
@@ -79,10 +79,16 @@
   #"(?i)([a-z][a-z0-9+.-]*://[^:@/]+:)([^@\s]{1,512})(@)")
 
 (def ^:private vendor-gates
-  ["sk-" "AKIA" "ghp_" "github_pat_" "hf_" "xox" "xai-" "AIza"])
+  ;; gh[opusr]_ is the whole GitHub token family: ghp_ (classic PAT) plus the
+  ;; gho_/ghu_/ghs_/ghr_ OAuth-flow tokens `gh auth login` issues. The family
+  ;; matters doubly because GITHUB_TOKEN/GH_TOKEN are SAFE_EXACT — their
+  ;; values never enter known-values, so this regex rail is the only thing
+  ;; between `echo $GITHUB_TOKEN` and the journal (karamazov-blt.30).
+  ["sk-" "AKIA" "ghp_" "gho_" "ghu_" "ghs_" "ghr_" "github_pat_" "hf_"
+   "xox" "xai-" "AIza"])
 
 (def ^:private vendor-prefix-re
-  #"(?x)\b(?:sk-(?:live_|test_|proj-)?[a-zA-Z0-9+/=]{20,512}(?:-[a-zA-Z0-9+/=]{1,64}){0,16}|sk-ant-api[0-9]{2}-[A-Za-z0-9+/=]{90,512}[_-][A-Za-z0-9]{5}|AKIA[A-Z0-9]{16}|ghp_[A-Za-z0-9]{36,255}|github_pat_[A-Za-z0-9]{22,64}_[A-Za-z0-9]{59,255}|hf_[A-Za-z0-9]{34,255}|xox[bpras]-[0-9]{2,20}-[0-9]{2,20}-[0-9]{2,20}-[a-zA-Z0-9]{32,255}|xai-[A-Za-z0-9+/=]{20,512}(?:\.[A-Za-z0-9+/=]{1,128}){0,16}|AIza[0-9A-Za-z_-]{35})")
+  #"(?x)\b(?:sk-(?:live_|test_|proj-)?[a-zA-Z0-9+/=]{20,512}(?:-[a-zA-Z0-9+/=]{1,64}){0,16}|sk-ant-api[0-9]{2}-[A-Za-z0-9+/=]{90,512}[_-][A-Za-z0-9]{5}|AKIA[A-Z0-9]{16}|gh[opusr]_[A-Za-z0-9]{36,255}|github_pat_[A-Za-z0-9]{22,64}_[A-Za-z0-9]{59,255}|hf_[A-Za-z0-9]{34,255}|xox[bpras]-[0-9]{2,20}-[0-9]{2,20}-[0-9]{2,20}-[a-zA-Z0-9]{32,255}|xai-[A-Za-z0-9+/=]{20,512}(?:\.[A-Za-z0-9+/=]{1,128}){0,16}|AIza[0-9A-Za-z_-]{35})")
 
 (defn- has-vendor-gate? [s]
   (boolean (some #(str/includes? s %) vendor-gates)))

--- a/src/samizdat/store/runs.clj
+++ b/src/samizdat/store/runs.clj
@@ -25,6 +25,12 @@
   entity with a durable id rather than a value threaded through the loop,
   because an intervention has to be able to name one."
   (:require [clojure.data.json :as json]
+            ;; log is called from start-run!'s retention sweep. jolt resolves
+            ;; ns aliases lazily, so leaving this out loads fine and throws on
+            ;; the first run start that actually prunes — which made enabling
+            ;; :retention :run-record-days break every subsequent run start
+            ;; (karamazov-blt.31).
+            [clojure.tools.logging :as log]
             [jdbc.core :as jdbc]
             [samizdat.store.db :as db]
             [samizdat.store.journal :as journal]

--- a/src/samizdat/tape.clj
+++ b/src/samizdat/tape.clj
@@ -171,14 +171,22 @@
   Extended one message earlier when the k-th-from-last assistant reply is
   immediately preceded by the user turn that prompted it, so an exchange is
   never split down the middle. `nil` when there are k or fewer assistant turns
-  — nothing has aged out yet."
+  — nothing has aged out yet.
+
+  `k` of zero (or less) is an EMPTY window: keep nothing verbatim, so the
+  window begins one past the end of the tape and everything before it is due.
+  It is a coherent setting for a runtime-editable budget, and the previous
+  `nth` one past the assistant indices threw out of infer/render on every
+  model call until the edit was reverted (karamazov-blt.32)."
   [messages k]
   (let [a-idxs (assistant-indices messages)]
     (when (> (count a-idxs) k)
-      (let [a (nth a-idxs (- (count a-idxs) k))]
-        (if (and (pos? a) (= "user" (:role (nth messages (dec a)))))
-          (dec a)
-          a)))))
+      (if-not (pos? k)
+        (count messages)
+        (let [a (nth a-idxs (- (count a-idxs) k))]
+          (if (and (pos? a) (= "user" (:role (nth messages (dec a)))))
+            (dec a)
+            a))))))
 
 (def default-roles
   "Which roles compaction may rewrite, by default.

--- a/test/samizdat/config_test.clj
+++ b/test/samizdat/config_test.clj
@@ -110,3 +110,21 @@
       (try
         (is (= {} (config/project-config root)))
         (finally (delete-recursively (java.io.File. root)))))))
+
+(deftest redacted-masks-an-api-key-wherever-it-sits
+  ;; /health serves (config/redacted …), which masked [:llm :api-key] only. A
+  ;; role spec under :run :role-models may carry its own :api-key override —
+  ;; role-ctx merges it into the provider config — and it was served cleartext
+  ;; (karamazov-blt.29).
+  (let [cfg {:llm {:api-key "sk-top" :model "m"}
+             :run {:role-models {:critic {:provider :glm :model "g"
+                                          :api-key "sk-role"}}}
+             :db {:path "x"}}
+        r (config/redacted cfg)]
+    (is (= "***" (get-in r [:llm :api-key])))
+    (is (= "***" (get-in r [:run :role-models :critic :api-key]))
+        "a nested per-role key is masked too")
+    (is (= "g" (get-in r [:run :role-models :critic :model]))
+        "only the key is touched")
+    (is (= {:db {:path "x"}} (config/redacted {:db {:path "x"}}))
+        "a config with no key gains none")))

--- a/test/samizdat/lsp_test.clj
+++ b/test/samizdat/lsp_test.clj
@@ -1,10 +1,12 @@
 (ns samizdat.lsp-test
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [samizdat.agent.tools.base :as base]
              [samizdat.agent.tools.lsp]
              [clojure.data.json :as json]
-             [samizdat.lsp.client :as client]))
+             [samizdat.lsp.client :as client]
+             [samizdat.security.secrets :as secrets]))
 
 ;; clojure-lsp is not installed on CI; every lsp-touching assert is gated so the
 ;; suite is trivially green there and meaningful on a machine that has it.
@@ -173,3 +175,31 @@
     (client/shutdown-all!)
     (is (empty? @(deref (var client/clients)))
         "every entry is gone, and the junk fake clients did not throw")))
+
+(deftest the-lsp-server-spawns-with-a-scrubbed-environment
+  ;; Every other subprocess seam (shell, verify, gitdiff) passes
+  ;; scrubbed-process-env; clojure-lsp inherited the whole parent environment,
+  ;; and it re-spawns children for classpath resolution that inherit whatever
+  ;; it got (karamazov-blt.27). RFC-003's flow graph gains the lsp node with
+  ;; this — a check cannot fail against a graph that omits its subject.
+  (let [{:keys [cmd opts]} (client/spawn-spec)]
+    (is (= ["clojure-lsp" "listen"] cmd))
+    (is (contains? opts :env) "the child environment is explicit, not inherited")
+    (is (= (secrets/scrubbed-process-env) (:env opts))
+        "and it is the scrubbed one — same seam as the shell tool")))
+
+(deftest the-lsp-tool-refuses-a-path-that-escapes-the-root
+  ;; read_file refuses ../..; the lsp tool resolved with a bare io/file, then
+  ;; slurped the result and handed the text to clojure-lsp (karamazov-blt.28).
+  (let [root (io/file "/tmp" "samizdat-lsp-escape-root")]
+    (.mkdirs root)
+    (with-redefs [client/available? (constantly true)]
+      (doseq [path ["../outside.clj" "/etc/hosts"]]
+        (let [r (base/run-tool {:tool-name "lsp"
+                                :branch {:id "B1"}
+                                :root (str root)
+                                :args {:op "diagnostics" :file path}})]
+          (is (= :mechanics (:category r))
+              (str path " is refused before anything is read"))
+          (is (str/includes? (str (:result r)) "root")
+              "the refusal names the boundary"))))))

--- a/test/samizdat/mutation_test.clj
+++ b/test/samizdat/mutation_test.clj
@@ -185,6 +185,33 @@
                          (journal/events-since c rid 0)))))
       (finally (us/unbind!) (db/close c)))))
 
+(deftest an-unbound-proposal-is-not-reported-committed
+  ;; userspace/save! returns nil when no project store is bound, and the
+  ;; commit branch used to report {:status :committed :version nil} — the tool
+  ;; then told the model "Saved as v … live on your next turn" about an edit
+  ;; that vanishes on restart (karamazov-blt.8). The candidate IS live in the
+  ;; image (it compiled and soaked), so this is not a rollback either; the
+  ;; caller hears exactly what happened.
+  (write-cells! (str @root "/cells") "(fn [_ d] (update d :n inc))")
+  (cells/load-cells! (:dirs (opts)))
+  (us/unbind!)
+  (let [r (mut/propose-cell!
+           {:name "mini"
+            :body (str "(ns cells.mini (:require [mycelium.cell :as cell]))\n"
+                       "(cell/defcell :mini/start {:doc \"start\" :pure true}\n"
+                       "  (fn [_ d] (update d :n + 7)))\n"
+                       "(cell/defcell :mini/end {:doc \"end\" :pure true}\n"
+                       "  (fn [_ d] (assoc d :verdict :done)))\n")
+            :loop-def mini-def
+            :soak-input {:n 0}})]
+    (is (= :live-unsaved (:status r))
+        "not :committed — nothing entered any project's history")
+    (is (nil? (:version r)))
+    (is (= :unbound (:reason r))
+        "the reason is data; the sentence is the tool's to render")
+    (is (= 7 (:n ((:handler (cell/get-cell :mini/start)) {} {:n 0})))
+        "the candidate stays live in this process, as validate and soak left it")))
+
 (deftest the-shipped-template-is-never-written
   (let [c (db/open! ":memory:")
         before (us/template :cell "loop")]

--- a/test/samizdat/repl_test.clj
+++ b/test/samizdat/repl_test.clj
@@ -119,9 +119,13 @@
   ;; directory, and slurp samizdat's deps.edn believing all three were the
   ;; project's. Nothing in the process notices, so the harness has to say so.
   (testing "a root elsewhere is a mismatch, reported with both directories"
+    ;; Compare CANONICALIZED paths on both sides: warn-if-not-cwd! resolves
+    ;; symlinks so the two directories it names are the real ones, and on
+    ;; macOS /tmp IS a symlink (to /private/tmp) — the raw-string expectation
+    ;; kept this suite permanently red there (karamazov-blt.37).
     (let [m (repl/warn-if-not-cwd! "/tmp")]
       (is (some? m))
-      (is (= "/tmp" (:root m)))
+      (is (= (str (.getCanonicalFile (java.io.File. "/tmp"))) (:root m)))
       (is (not= (:root m) (:cwd m)))))
   (testing "the ordinary self-hosting case is silent"
     (is (nil? (repl/warn-if-not-cwd! ".")))))

--- a/test/samizdat/security/secrets_test.clj
+++ b/test/samizdat/security/secrets_test.clj
@@ -203,3 +203,16 @@
         payload (str "=> {:api-key \"" canary "\"}")]
     (is (not (str/includes? (secrets/redact payload known) canary))
         "a credential read in-process does not reach the transcript verbatim")))
+
+(deftest the-whole-github-token-family-is-redactable
+  ;; GITHUB_TOKEN/GH_TOKEN are deliberately SAFE_EXACT — gh must see them — so
+  ;; their values are never in known-values and the regex rail is the only
+  ;; thing between `echo $GITHUB_TOKEN` (which rides the echo allow) and the
+  ;; journal. The rail covered ghp_/github_pat_ only, while `gh auth login`
+  ;; issues gho_/ghu_/ghs_/ghr_ tokens (karamazov-blt.30).
+  (doseq [prefix ["ghp_" "gho_" "ghu_" "ghs_" "ghr_"]]
+    (let [tok (str prefix "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789")]
+      (is (secrets/sensitive-value? tok)
+          (str prefix " is a high-confidence credential shape"))
+      (is (not (str/includes? (secrets/redact (str "token: " tok)) tok))
+          (str prefix " is caught by the regex rail with no known-values")))))

--- a/test/samizdat/store_test.clj
+++ b/test/samizdat/store_test.clj
@@ -993,3 +993,27 @@
       (journal/prune-run-record! c "2999-01-01T00:00:00Z")
       (is (empty? (failures/similar c rid "greedy bound"))
           "the index went with the rows"))))
+
+(deftest enabling-record-retention-does-not-break-run-start
+  ;; start-run! logged the sweep through an alias the ns never required; jolt
+  ;; resolves aliases lazily, so the ns loaded fine and the throw waited for
+  ;; the first run start that actually pruned something — at which point every
+  ;; subsequent start failed until the knob was reverted (karamazov-blt.31).
+  ;; The one code path that exercises the advertised retention feature is the
+  ;; one this drives.
+  (with-db [c]
+    (let [old (runs/start-run! c {:problem "old"})]
+      (runs/open-branch! c old {:branch-id "B1"})
+      (journal/record-turn! c old {:branch-id "B1" :turn 1 :tool-name "eval"
+                                   :args {} :result "r" :category "success"})
+      (runs/finish-run! c old "completed" "done")
+      (db/execute! c ["UPDATE runs SET ended_at = ? WHERE id = ?"
+                      (str (.minusSeconds (java.time.Instant/now) (* 40 86400)))
+                      old])
+      (with-redefs [lexicon/policy (fn [k] (get {:retention {:events-hours 24
+                                                             :run-record-days 30}}
+                                               k))]
+        (let [id (runs/start-run! c {:problem "next"})]
+          (is (some? id) "the sweep-and-log path starts the run")
+          (is (empty? (journal/turns c old))
+              "and the aged-out record was actually pruned"))))))

--- a/test/samizdat/tape_test.clj
+++ b/test/samizdat/tape_test.clj
@@ -161,3 +161,19 @@
     (is (= 3 (count (filter :compacted? out))))
     (is (empty? (tape/due-indices out 2))
         "and nothing is left due, so a second pass is a no-op")))
+
+(deftest a-zero-window-ages-out-the-whole-tape
+  ;; :context-budget :keep-pairs is runtime-editable and 0 is a coherent
+  ;; setting — keep nothing verbatim, compact everything. window-index used to
+  ;; nth one past the end of the assistant indices for it, throwing out of
+  ;; infer/render on every model call of every run until the edit was
+  ;; reverted (karamazov-blt.32).
+  (let [t [(tape/message "system" "s") (tape/message "user" "p")
+           (tape/message "user" "q1") (tape/message "assistant" "a1")
+           (tape/message "user" "q2") (tape/message "assistant" "a2")]]
+    (is (= (count t) (tape/window-index t 0))
+        "an empty verbatim window begins past the end of the tape")
+    (is (= [3 5] (tape/due-indices t 0))
+        "every assistant message has aged out")
+    (is (nil? (tape/window-index [] 0))
+        "no assistant turns still means nothing has aged out")))


### PR DESCRIPTION
First of six PRs from the 2026-08-26 harness audit (epic karamazov-blt), in planned fix order. This one is the quick crashes and security holes:

- store.runs: missing tools.logging require crashed every run start once `:retention :run-record-days` was set (blt.31)
- tape/window-index: `keep-pairs 0` threw out of infer/render on every model call (blt.32)
- secrets: `gho_/ghu_/ghs_/ghr_` gh-auth tokens are now redactable; they are SAFE_EXACT so the regex rail is all that covers an `echo $GITHUB_TOKEN` (blt.30)
- config/redacted walks the map, so per-role `:api-key` overrides under `:run :role-models` stop being served cleartext by /health (blt.29)
- clojure-lsp spawns through `scrubbed-process-env` and its file args go through `resolve-under-root`; RFC-003's flow graph gains the lsp node (blt.27, blt.28)
- propose-cell! returns `:live-unsaved` instead of lying `:committed` with a nil version when unbound (blt.8, first part)
- repl_test compares canonicalized paths, ending the permanent red on macOS (blt.37)

Suite: 1307 tests, 4661 assertions, green.