### PR TITLE
audit round 3: wire the beam control surface end to end

### DIFF
--- a/resources/cells/beam.clj
+++ b/resources/cells/beam.clj
@@ -354,14 +354,33 @@
     (let [{:keys [conn run-id]} ctx
           pending (interventions/pending conn run-id)
           {:keys [branches max-turns paused?]}
-          (beam/drain-directives! ctx active pending turn)]
-      ;; :paused? is NOT carried in the data map — beam/await-resume! reads the
-      ;; interventions table, because the resume that ends the wait is written
-      ;; by another process while this round is inside it. It is recorded here
-      ;; only so the round's trace says what happened.
-      (cond-> (assoc data :active branches)
-        (some? paused?) (assoc :paused-by-directive? paused?)
-        max-turns (update :max-turns (fnil + (beam/round-max-turns ctx data)) max-turns)))))
+          (beam/drain-directives! ctx active pending turn)
+          ;; A branch the human just culled is inactive NOW, and this cell is
+          ;; the only one that knows: it never enters :advanced, so the
+          ;; settle/cull bookkeeping downstream never sees it. Close its row
+          ;; and release what it held here, and fold the mark into :branches
+          ;; so settle's inactive set (computed from :branches) carries it
+          ;; into the round's record instead of tick dropping it — the open
+          ;; zombie row of karamazov-blt.11.
+          now-inactive (filterv (complement state/active?) branches)
+          still-active (filterv state/active? branches)
+          marked (into {} (map (juxt :id identity)) branches)]
+      (beam/record-inactive! ctx now-inactive)
+      (let [data' (cond-> (assoc data
+                                 :active still-active
+                                 :branches (mapv #(get marked (:id %) %)
+                                                 (:branches data)))
+                    (some? paused?) (assoc :paused-by-directive? paused?)
+                    max-turns (update :max-turns
+                                      (fnil + (beam/round-max-turns ctx data))
+                                      max-turns))]
+        ;; An extension is a fact about the RUN, so it survives a crash: the
+        ;; row is what a resume reads its budget from, and the drain's old
+        ;; comment ("a resume re-reads its budget from the control API
+        ;; anyway") was simply false (karamazov-blt.12).
+        (when max-turns
+          (runs/extend-budget! conn run-id (:max-turns data')))
+        data'))))
 
 (cell/defcell :beam/advance
   {:doc "One turn for every active branch, concurrently, each under a hard
@@ -370,7 +389,14 @@
    :effects [:net :db :fs :proc]
    :requires [:live-branches]}
   (fn [ctx {:keys [active branches turn] :as data}]
-    (let [advanced (beam/advance-all (assoc ctx :branch-count (count branches))
+    ;; The turn slice and its gates read (:max-turns ctx); an `extend` lives
+    ;; in the round's data map. Without this, every turn past the ORIGINAL
+    ;; cap routed :exhausted -> :memory/distil — one LLM reflection per
+    ;; branch per extended round — while the beam kept scheduling
+    ;; (karamazov-blt.12).
+    (let [advanced (beam/advance-all (assoc ctx
+                                            :branch-count (count branches)
+                                            :max-turns (beam/round-max-turns ctx data))
                                      (filterv state/active? active)
                                      turn)]
       ;; The driver's teardown needs the branches as they stand, and a manifest

--- a/resources/cells/loop.clj
+++ b/resources/cells/loop.clj
@@ -113,7 +113,10 @@
    :pure true
    :requires [:max-turns]}
   (fn [ctx {:keys [branch turn] :as data}]
-    (let [max-turns (:max-turns ctx)
+    ;; Plus whatever `extend` directives granted this branch: ctx is fixed for
+    ;; the life of the run, so a raised cap has to travel on the branch
+    ;; (karamazov-blt.12).
+    (let [max-turns (+ (:max-turns ctx) (or (:extended-turns branch) 0))
           verdict (cond
                     (not (state/active? branch))
                     (if (:final-answer branch) :done :abandoned)

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -278,17 +278,30 @@
   The abort flag is checked on every pass, because a paused run that could not
   be aborted out of would be a wedge with a friendly name.
 
+  APPLIES pending pause/resume rows itself, every pass. The `:beam/directives`
+  cell that normally applies them sits DOWNSTREAM of the node this blocks in,
+  so a `resume` submitted while paused stayed `pending` forever and `paused?`
+  — which counts applied rows only — kept reading the pause: the pause was a
+  one-way door to abort (karamazov-blt.9). Draining the two run-level kinds
+  here is the same boundary the directives cell applies them at — the top of
+  a round, with nothing in flight.
+
   Returns the number of times it waited, so a test can tell waiting from not
   waiting without watching the clock."
   [{:keys [conn run-id abort] :as _ctx}]
   (if-not (and conn run-id)
     0
     (loop [waited 0]
-      (if (and (interventions/paused? conn run-id)
-               (not (and abort @abort)))
-        (do (Thread/sleep (gates/threshold :pause-poll-ms))
-            (recur (inc waited)))
-        waited))))
+      (if (and abort @abort)
+        waited
+        (do
+          (doseq [d (interventions/pending conn run-id)
+                  :when (#{"pause" "resume"} (:kind d))]
+            (interventions/resolve! conn run-id (:id d) :applied nil nil))
+          (if (interventions/paused? conn run-id)
+            (do (Thread/sleep (gates/threshold :pause-poll-ms))
+                (recur (inc waited)))
+            waited))))))
 
 (defn- rejected
   "Record a refused directive with its reason.

--- a/src/samizdat/agent/loop.clj
+++ b/src/samizdat/agent/loop.clj
@@ -34,7 +34,8 @@
   fire, so a gate cannot be credited with an outcome that preceded it. Those
   constraints are the manifest's to keep; what this namespace guarantees is
   that each step does one thing and says what it touched."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [samizdat.agent.arbiter :as arbiter]
@@ -560,30 +561,75 @@
     (runs/set-thesis! conn run-id (:id branch) t))
   nil)
 
+(defn- directive-turns
+  "How many turns an `extend` asks for, from its JSON payload, or nil."
+  [d]
+  (let [payload (or (try (json/read-str (str (:payload d)) :key-fn keyword)
+                         (catch Throwable _ nil))
+                    {})
+        by (or (:turns payload) (:by payload) (:max_turns payload))]
+    (when (and (number? by) (pos? by)) (long by))))
+
 (defn- drain-directives!
-  "Apply the human directives waiting at this boundary. The single-branch
-  driver only sees the branch-scoped kinds: `message` and `review` become a
-  :pending-directive the arbiter puts at priority zero; the scheduler-only
-  kinds (cull/fork/pause/resume) belong to the beam and are rejected here with
-  a reason rather than accepted silently. Returns the branch, possibly carrying
-  a :pending-directive. Shares the interventions queue with the HTTP control
-  surface, so a REPL steer and a UI steer are the same event."
-  [conn run-id branch turn]
+  "Apply the human directives waiting at this branch's boundary.
+
+  TWO DRIVERS, ONE QUEUE, and which drain owns a directive depends on the
+  run's shape (karamazov-blt.10):
+
+  On a BEAM run this drain takes only what is addressed to THIS branch —
+  a branch-scoped `message`/`review` lands sooner here than at the next
+  round top. Everything else (run-wide messages, cull/fork/retract/pause/
+  resume/extend) is LEFT PENDING for `:beam/directives`: this used to eat
+  and reject the scheduler kinds at whichever branch's boundary came first,
+  which — since a round's wall-clock lives inside `:beam/advance` — was
+  nearly always before the beam drain ever saw them. A human's pause was
+  resolved `:rejected` by a branch.
+
+  On a SINGLE-BRANCH run there is no beam drain, so everything lands here:
+  `message`/`review` become the :pending-directive the arbiter puts at
+  priority zero, `extend` raises the branch's cap and persists the run row
+  (karamazov-blt.12 — the old arm assumed control/extend! had run, which is
+  REPL-only, and left the row pending forever), and the scheduler-only kinds
+  are rejected with a reason rather than accepted silently.
+
+  Shares the interventions queue with the HTTP control surface, so a REPL
+  steer and a UI steer are the same event."
+  [{:keys [conn run-id beam?] :as ctx} branch turn]
   (if-not (and conn run-id)
     branch
     (reduce
      (fn [b d]
-       (case (:kind d)
-         ("message" "review")
-         (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
-             (assoc b :pending-directive d))
-         "extend"
-         b ;; handled by control/extend! against the runs row, not here
-         (do (interventions/resolve! conn run-id (:id d) :rejected
-                                     (str (:kind d) " applies to the beam scheduler,"
-                                          " not a single-branch run")
-                                     turn)
-             b)))
+       (let [scoped-here? (some? (:branch_id d))]
+         (case (:kind d)
+           ("message" "review")
+           (if (and beam? (not scoped-here?))
+             b ;; run-wide: the beam broadcasts it to every branch at the round top
+             (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
+                 (assoc b :pending-directive d)))
+
+           "extend"
+           (if beam?
+             b ;; run-level: the beam drain applies and persists it
+             (if-let [n (directive-turns d)]
+               (let [b' (update b :extended-turns (fnil + 0) n)]
+                 (interventions/resolve! conn run-id (:id d) :applied nil turn)
+                 ;; The row is what a crash-resume reads its budget from.
+                 (runs/extend-budget! conn run-id
+                                      (+ (:max-turns ctx) (:extended-turns b')))
+                 b')
+               (do (interventions/resolve! conn run-id (:id d) :rejected
+                                           (prompt/render "directive-rejected"
+                                                          {:extend-no-turns true})
+                                           turn)
+                   b)))
+
+           (if beam?
+             b ;; scheduler kinds: the beam drain owns them
+             (do (interventions/resolve! conn run-id (:id d) :rejected
+                                         (str (:kind d) " applies to the beam scheduler,"
+                                              " not a single-branch run")
+                                         turn)
+                 b)))))
      branch
      (interventions/pending conn run-id (:id branch)))))
 
@@ -612,7 +658,12 @@
   [{:keys [conn run-id max-turns] :as ctx} before branch turn {:keys [parsed result]}]
   (let [tool (:name parsed)
         branch (settle-predictions! conn branch turn [tool] before branch)
-        branch (drain-directives! conn run-id branch turn)]
+        branch (drain-directives! ctx branch turn)
+        ;; The cap the gates reason against includes whatever `extend`
+        ;; directives have granted this branch — otherwise last-call and the
+        ;; turn-budget notices keep firing against the spent original cap
+        ;; (karamazov-blt.12).
+        max-turns (+ max-turns (or (:extended-turns branch) 0))]
     (if (:done? result)
       (state/add-message branch "user" (truncate (:result result)) {:turn turn})
       ;; Coverage answers whether the safe-state rung's fallback is honest:

--- a/src/samizdat/api/openai.clj
+++ b/src/samizdat/api/openai.clj
@@ -28,6 +28,7 @@
   worth keeping precisely because it is the comparison anyone will ask for."
   (:require [clojure.string :as str]
             [samizdat.agent.beam :as beam]
+            [samizdat.api.control :as api-control]
             [samizdat.llm.client :as llm]
             [samizdat.llm.registry :as registry]
             [samizdat.store.journal :as journal]))
@@ -91,13 +92,28 @@
                                     {:usage (:usage r) :harness {:mode "raw"}})})
 
       :else
-      (let [r (beam/run! {:conn conn :config config
-                          :llm-adapter adapter :llm-config llm-config
-                          :problem problem
-                          :max-turns (or (:max_turns body) (:max-turns body)
-                                         (get-in config [:run :max-turns]))
-                          :beam-width (or (:beam_width body) (:beam-width body)
-                                          (get-in config [:run :beam-width]))})
+      ;; Registered in api.control/active like a run started by POST /v1/runs,
+      ;; so POST /v1/runs/:id/abort works on it — without the abort atom and
+      ;; the registration this run was unabortable for its whole (potentially
+      ;; hours-long) life (karamazov-blt.13). The request thread still blocks:
+      ;; that IS the OpenAI-compat contract this endpoint exists for.
+      (let [abort (atom false)
+            run-id* (atom nil)
+            r (try
+                (beam/run! {:conn conn :config config
+                            :llm-adapter adapter :llm-config llm-config
+                            :problem problem
+                            :abort abort
+                            :on-start (fn [rid]
+                                        (reset! run-id* rid)
+                                        (swap! api-control/active assoc rid {:abort abort}))
+                            :max-turns (or (:max_turns body) (:max-turns body)
+                                           (get-in config [:run :max-turns]))
+                            :beam-width (or (:beam_width body) (:beam-width body)
+                                            (get-in config [:run :beam-width]))})
+                (finally
+                  (when-let [rid @run-id*]
+                    (swap! api-control/active dissoc rid))))
             artifacts (journal/artifacts conn (:run-id r))
             answered (= :completed (:status r))]
         {:status 200

--- a/test/samizdat/control_test.clj
+++ b/test/samizdat/control_test.clj
@@ -33,7 +33,10 @@
             [samizdat.workflow :as wf]
             [samizdat.agent.state :as state]
             [samizdat.api.control :as api-control]
+            [samizdat.api.openai :as openai]
             [samizdat.api.runs :as api-runs]
+            [samizdat.cells :as cells]
+            [mycelium.cell :as cell]
             [samizdat.llm.client :as llm]
             [samizdat.security.policy :as policy]
             [samizdat.store.db :as db]
@@ -330,3 +333,121 @@
               (str k " reached a boundary and was left pending"))
           (is (not (str/includes? (str (:disposition d)) "not wired"))
               (str k " is advertised to a human and rejected as unwired")))))))
+
+(deftest a-pending-resume-ends-the-pause-wait
+  ;; blt.9: paused? counts APPLIED rows, and the only code applying a resume
+  ;; was the :beam/directives cell — downstream of the round-open node that
+  ;; blocks while paused. The resume stayed pending forever; pause was a
+  ;; one-way door to abort. await-resume! now applies the two run-level kinds
+  ;; itself, every pass, at the same boundary the cell applies them.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (interventions/submit! c rid {:kind "pause"})
+      (drain c rid [(branch "B1")])
+      (is (true? (interventions/paused? c rid)))
+      ;; the resume a human submits from ANOTHER process while the beam parks
+      (interventions/submit! c rid {:kind "resume"})
+      (is (number? (beam/await-resume! {:conn c :run-id rid}))
+          "the wait returns rather than polling forever")
+      (is (false? (interventions/paused? c rid))
+          "the pending resume was applied by the wait loop itself"))))
+
+(deftest the-per-turn-drain-leaves-the-beams-directives-alone
+  ;; blt.10: the per-branch drain runs at every steer boundary and used to
+  ;; resolve cull/fork/pause/resume/retract as :rejected — on a beam run,
+  ;; where a round's wall-clock lives inside :beam/advance, so a human's
+  ;; pause almost always landed mid-round and was eaten by the first branch
+  ;; to finish its turn, before :beam/directives ever saw it.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (doseq [[k p] [["pause" {}] ["cull" {}] ["fork" {:thesis "t"}]
+                     ["retract" {:artifact_id 1}] ["extend" {:turns 3}]]]
+        (interventions/submit! c rid {:kind k :payload p}))
+      (interventions/submit! c rid {:kind "message" :payload {:text "all hands"}})
+      (interventions/submit! c rid {:kind "message" :branch-id "B1"
+                                    :payload {:text "just you"}})
+      (let [b (#'aloop/drain-directives! {:conn c :run-id rid :beam? true
+                                          :max-turns 40}
+                                         (branch "B1") 2)
+            by-kind (group-by :kind (interventions/history c rid))]
+        (is (some? (:pending-directive b))
+            "the branch-scoped message lands here, sooner than the round top")
+        (doseq [k ["pause" "cull" "fork" "retract" "extend"]]
+          (is (= "pending" (:status (first (by-kind k))))
+              (str k " is left for the beam drain, not eaten")))
+        (let [msgs (by-kind "message")
+              run-wide (first (filter #(nil? (:branch_id %)) msgs))
+              scoped (first (filter #(= "B1" (:branch_id %)) msgs))]
+          (is (= "pending" (:status run-wide))
+              "the run-wide message is the beam's to broadcast to every branch")
+          (is (= "applied" (:status scoped))))))))
+
+(deftest extend-lands-on-a-single-branch-run
+  ;; blt.12: the old arm returned the branch untouched, assuming
+  ;; control/extend! (REPL-only) had raised the runs row — the HTTP path only
+  ;; enqueues, so the directive sat pending forever and the cap never moved.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p" :max-turns 10})]
+      (interventions/submit! c rid {:kind "extend" :payload {:turns 5}})
+      (let [b (#'aloop/drain-directives! {:conn c :run-id rid :beam? false
+                                          :max-turns 10}
+                                         (branch "B1") 2)
+            [d] (interventions/history c rid)]
+        (is (= 5 (:extended-turns b)) "the cap travels on the branch")
+        (is (= "applied" (:status d)))
+        (is (= 15 (:max_turns (runs/get-run c rid)))
+            "and persists on the row a crash-resume reads its budget from")))))
+
+(deftest an-extended-branch-routes-past-the-original-cap
+  ;; blt.12: ctx is fixed for the life of the run, so past the original cap
+  ;; every turn routed :exhausted -> :memory/distil — one LLM reflection per
+  ;; branch per extended round. The route reads the branch's extension now.
+  (cells/load-cells!)
+  (let [route (:handler (cell/get-cell :loop/route))
+        b (branch "B1")]
+    (is (= :exhausted (:verdict (route {:max-turns 5} {:branch b :turn 5}))))
+    (is (= :continue (:verdict (route {:max-turns 5}
+                                      {:branch (assoc b :extended-turns 3)
+                                       :turn 5})))
+        "an extension grants real turns, not a reflection loop")))
+
+(deftest a-human-cull-closes-the-row-and-keeps-the-branch-in-the-record
+  ;; blt.11: the drain marked :status :culled in the data map but nothing
+  ;; closed the row or carried the branch through settle/tick — it vanished
+  ;; from the run and its branches row stayed open forever, the exact zombie
+  ;; record-inactive!'s docstring warns about.
+  (cells/load-cells!)
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (runs/open-branch! c rid {:branch-id "B2"})
+      (interventions/submit! c rid {:kind "cull" :branch-id "B2"})
+      (let [cellfn (:handler (cell/get-cell :beam/directives))
+            data (cellfn {:conn c :run-id rid}
+                         {:active [(branch "B1") (branch "B2")]
+                          :branches [(branch "B1") (branch "B2")]
+                          :turn 3})]
+        (is (= ["B1"] (mapv :id (:active data))))
+        (is (some #(and (= "B2" (:id %)) (= :culled (:status %)))
+                  (:branches data))
+            "the verdict is visible to settle's bookkeeping, so tick keeps it")
+        (let [row (first (filter #(= "B2" (:id %)) (runs/branches c rid)))]
+          (is (= "culled" (:status row)) "the row is closed, not a zombie"))))))
+
+(deftest a-chat-completion-run-is-registered-and-abortable
+  ;; blt.13: beam/run! was called with no :abort atom and no control/active
+  ;; registration, so POST /v1/runs/:id/abort answered 409 "no active run"
+  ;; for a genuinely running run, for its whole (potentially hours-long) life.
+  (with-db [c]
+    (let [seen (atom nil)]
+      (with-redefs [beam/run!
+                    (fn [{:keys [abort on-start]}]
+                      (is (some? abort) "an abort atom reaches the run")
+                      (on-start "r-oai")
+                      (reset! seen (contains? @api-control/active "r-oai"))
+                      {:status :completed :run-id "r-oai" :answer "a"})]
+        (openai/chat-completion {:conn c :config {:llm {:provider :local :model "m"}}}
+                                {:messages [{:role "user" :content "q"}]})
+        (is (true? @seen) "the run was visible to the abort endpoint while live")
+        (is (not (contains? @api-control/active "r-oai"))
+            "and deregistered when it finished")))))


### PR DESCRIPTION
Third audit PR — the human control surface, end to end:

- `await-resume!` applies pending pause/resume itself; a resume written while the beam is parked actually ends the wait (blt.9)
- the per-turn drain is beam-aware: branch-scoped message/review land early, everything else stays pending for `:beam/directives` instead of being resolved `:rejected` by whichever branch finished first (blt.10)
- a human `cull` runs `record-inactive!` and folds its mark into `:branches`, so the row closes and the branch stays in the run record (blt.11)
- one `extend`: `:extended-turns` on the branch, read by the route cell and the gate cap; persisted to `runs.max_turns` on both drivers; the beam hands the extended cap to the turn slice (blt.12)
- `chat-completion` runs carry an abort atom and register in `api.control/active`, deregistering in a `finally` (blt.13)

Suite: 1324 tests, 4720 assertions, green.