### PR TITLE
audit round 4: make culling fair and completion honest

### DIFF
--- a/resources/cells/beam.clj
+++ b/resources/cells/beam.clj
@@ -201,7 +201,9 @@
       ;; Juvenile grace. Progress and momentum are age-correlated, so a
       ;; newborn is dominated by its own parent one turn after being forked.
       ;; Let it express itself first.
-      (< (state/turn-count branch) (gates/threshold :juvenile-grace))
+      ;; The branch's OWN experience, not its position in the run: a fork
+      ;; born at round 18 is 0 turns old (blt.16).
+      (< (state/own-turn-count branch) (gates/threshold :juvenile-grace))
       (do (when (and conn run-id)
             (journal/note! conn run-id :cull-spared
                            {:branch-id (:id branch)
@@ -426,16 +428,27 @@
    :effects [:db]
    :requires []}
   (fn [ctx {:keys [advanced turn] :as data}]
+    ;; Only ACTIVE branches face the rule, and only they count as survivors.
+    ;; `advanced` also holds branches that went done/abandoned during this
+    ;; round's advance: counting them seeded `alive` high, so the LAST active
+    ;; branch saw phantom survivors and was cullable — the beam emptied and
+    ;; the run exhausted, violating the last-branch invariant. And running the
+    ;; cascade over an already-inactive branch rewrote its ending (:abandoned
+    ;; relabelled :culled with a fabricated mechanics reason) — the false-
+    ;; reason class this cell's own comments exist to prevent
+    ;; (karamazov-blt.17).
     (let [culled (first
                   (reduce (fn [[acc alive] b]
-                            (let [sibs (keep #(when (and (state/active? %)
-                                                         (not= (:id %) (:id b)))
-                                                (get-in % [:critic :scores]))
-                                             advanced)
-                                  b' (cull-or-keep (assoc ctx :turn turn)
-                                                   b (dec alive) sibs)]
-                              [(conj acc b') (if (state/active? b') alive (dec alive))]))
-                          [[] (count advanced)]
+                            (if-not (state/active? b)
+                              [(conj acc b) alive]
+                              (let [sibs (keep #(when (and (state/active? %)
+                                                           (not= (:id %) (:id b)))
+                                                  (get-in % [:critic :scores]))
+                                               advanced)
+                                    b' (cull-or-keep (assoc ctx :turn turn)
+                                                     b (dec alive) sibs)]
+                                [(conj acc b') (if (state/active? b') alive (dec alive))])))
+                          [[] (count (filter state/active? advanced))]
                           advanced))]
       ;; SHARPENING vs EXPANSION (papers/2608.17981v1 §4.5.4, after Yue et al.
       ;; on pass@k). A beam can fail two ways and they want opposite fixes:
@@ -572,21 +585,31 @@
         does not re-derive scope from the transcript."
    :effects [:db]
    :requires [:conn :max-turns :run-id]}
-  (fn [{:keys [conn run-id max-turns]} {:keys [branches active] :as data}]
-    (let [residuals (keep state/residual branches)
-          report (state/build-residual-report
-                  {:branches branches
-                   :failures (failures/recent conn run-id 10)
-                   :gate-tally (journal/gate-tally conn run-id)
-                   :max-turns max-turns})]
+  (fn [{:keys [conn run-id max-turns] :as ctx} {:keys [branches active] :as data}]
+    ;; A branch may have SHIPPED rounds ago while :stop-on-first-done? kept
+    ;; the beam exploring. The cap expiring is not a failure then: the banked
+    ;; answer ends the run, ranked by the same rubric :beam/complete uses.
+    ;; finish-run! :failed nil here discarded it (karamazov-blt.20).
+    (let [winner (beam/select-done-branch ctx (filterv :final-answer branches))]
       (doseq [b active]
         (runs/close-branch! conn run-id (:id b) :exhausted
                             (str "turn cap of " max-turns " reached")))
-      (doseq [r residuals]
-        (journal/note! conn run-id :residual {:branch-id (:branch r) :data r}))
-      (journal/note! conn run-id :residual-report {:data report})
-      (runs/finish-run! conn run-id :failed nil)
-      (assoc data :status :exhausted
-             :result {:status :exhausted :run-id run-id :branches branches
-                      :residuals (vec residuals) :report report
-                      :report-text (state/render-residual-report report)}))))
+      (if winner
+        (do (runs/finish-run! conn run-id :completed (:final-answer winner))
+            (assoc data :status :completed :done-branch winner
+                   :result {:status :completed :answer (:final-answer winner)
+                            :run-id run-id :branches branches}))
+        (let [residuals (keep state/residual branches)
+              report (state/build-residual-report
+                      {:branches branches
+                       :failures (failures/recent conn run-id 10)
+                       :gate-tally (journal/gate-tally conn run-id)
+                       :max-turns max-turns})]
+          (doseq [r residuals]
+            (journal/note! conn run-id :residual {:branch-id (:branch r) :data r}))
+          (journal/note! conn run-id :residual-report {:data report})
+          (runs/finish-run! conn run-id :failed nil)
+          (assoc data :status :exhausted
+                 :result {:status :exhausted :run-id run-id :branches branches
+                          :residuals (vec residuals) :report report
+                          :report-text (state/render-residual-report report)}))))))

--- a/resources/cells/feature.clj
+++ b/resources/cells/feature.clj
@@ -394,7 +394,12 @@
                              :gave-up (boolean give-up?) :runaway runaway?}})
       (case decision
         :ship
-        (assoc data :feature/decision :ship)   ; -> finish, :completed
+        ;; The DECLARATION of done lives here, behind both gates — review
+        ;; pass + critic ship + a real diff + green tests — not in the
+        ;; fan-out join, which used to mark it unconditionally
+        ;; (karamazov-blt.19).
+        (assoc data :feature/decision :ship :verdict :done
+               :branch (assoc (:branch data) :status :done))   ; -> finish, :completed
 
         :abandon
         ;; Honest end, not a hollow completed. Any partial work stays on disk for

--- a/resources/cells/team.clj
+++ b/resources/cells/team.clj
@@ -224,12 +224,18 @@
                              :epic parent
                              :tasks (vec (remove nil? task-ids))
                              :done (count (filter ok? results))}})
+      ;; The JOIN lands on the branch — the feature loop's review/critique/
+      ;; verify gates read it — but no verdict and no :done here: marking the
+      ;; run done unconditionally at this point meant a team where every
+      ;; worker failed still finished :completed with a summary of failures
+      ;; as its answer (karamazov-blt.19), upstream of the false-completion
+      ;; memories in karamazov-mjb. In team.edn the verdict is
+      ;; :team/supervise's (after its retries); in feature.edn it is
+      ;; :feature/route's, behind both gates.
       (assoc data
              :subtasks tasks
              :results (vec results)
-             :verdict :done
-             :branch (assoc branch :status :done
-                            :final-answer (summarize results))))))
+             :branch (assoc branch :final-answer (summarize results))))))
 
 (cell/defcell :team/supervise
   {:doc "Watch the fan-out's results and re-task the parts that did not land: a
@@ -262,6 +268,23 @@
                                (map vector results retried)))]
       (journal/note! conn run-id :supervise
                      {:data {:retried (count (remove ok? results)) :fixed fixed}})
-      (assoc data
-             :results retried
-             :branch (assoc branch :final-answer (summarize retried))))))
+      ;; The verdict, decided AFTER the retries, from what actually landed. A
+      ;; team where nothing landed — retries included — ends :abandoned with
+      ;; no answer, so :loop/finish records an abandoned run rather than a
+      ;; completed one (karamazov-blt.19).
+      (if (some ok? retried)
+        (assoc data
+               :results retried
+               :verdict :done
+               :branch (assoc branch :status :done
+                              :final-answer (summarize retried)))
+        (assoc data
+               :results retried
+               :verdict :abandoned
+               ;; :final-answer cleared explicitly — the fan-out's join put
+               ;; the failure summary there for the reviewer's benefit, and
+               ;; :loop/finish reads a non-blank answer as a completion.
+               :branch (assoc branch :status :abandoned
+                              :final-answer nil
+                              :inactive-reason
+                              "every worker failed, retries included"))))))

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -1218,8 +1218,10 @@
          with. Fires on a cadence, not a condition, which is why it sits below
          every gate that fires because something is wrong."
    :when (and (state/active? branch)
-              (pos? (state/turn-count branch))
-              (zero? (mod (state/turn-count branch)
+              ;; The branch's OWN turns: a fork reflects on a fresh cadence
+              ;; rather than inheriting its parent's position (blt.16).
+              (pos? (state/own-turn-count branch))
+              (zero? (mod (state/own-turn-count branch)
                           (threshold :reflection-cadence))))
    :message-file "reflection"
    :prediction "the branch inspects or reshapes its loop"
@@ -1241,7 +1243,8 @@
          harness just asked of it."
    :when (and (= :build (:phase branch))
               (not (:any-progress? branch))
-              (>= (state/turn-count branch) (threshold :prologue-cap)))
+              ;; OWN turns: what THIS branch has produced nothing in (blt.16).
+              (>= (state/own-turn-count branch) (threshold :prologue-cap)))
    :message-file "prologue-cap"
    :message-suffix "\n\nYou are {{turn-count}} turns in with nothing verified."
    :prediction "the branch produces its first artifact"

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -529,31 +529,56 @@
   [ctx branches turn]
   (let [deadline (when (get ctx :iterating-loop? true)
                    (or (:turn-deadline-ms ctx) (turn-deadline-ms)))
+        ;; {branch-id future} of turns that blew their deadline and are STILL
+        ;; executing. A forfeited turn's thread cannot be interrupted (and
+        ;; killing it mid-journal-write would be worse), but it shares the
+        ;; branch's eval session and journals under its id — so advancing the
+        ;; same branch again while it runs interleaved two turns of one branch
+        ;; and made the journal diverge from the live state
+        ;; (karamazov-blt.18). The branch forfeits again instead, until the
+        ;; dangling call completes; the wait is bounded by the provider socket
+        ;; timeout and the tool timeouts inside the turn.
+        in-flight (:in-flight ctx)
+        forfeit (fn [b]
+                  (-> b
+                      (state/add-message
+                       "user"
+                       (str "[harness] " (prompt/render "turn-deadline"
+                                           {:seconds (quot (or deadline 0) 1000)})))
+                      (update :timeouts (fnil inc 0))))
         pending (mapv (fn [b]
-                        [b (future
-                             (try
-                               (advance-branch ctx b turn)
-                               (catch Throwable e
-                                 (log/warn "branch" (:id b) "died on turn" turn
-                                           ":" (ex-message e))
-                                 (assoc b :status :abandoned
-                                        :inactive-reason
-                                        (str "branch error: " (ex-message e))))))])
+                        (let [dangling (when in-flight (get @in-flight (:id b)))]
+                          (cond
+                            (and dangling (not (realized? dangling)))
+                            [b ::still-dangling]
+
+                            :else
+                            (do (when dangling (swap! in-flight dissoc (:id b)))
+                                [b (future
+                                     (try
+                                       (advance-branch ctx b turn)
+                                       (catch Throwable e
+                                         (log/warn "branch" (:id b) "died on turn" turn
+                                                   ":" (ex-message e))
+                                         (assoc b :status :abandoned
+                                                :inactive-reason
+                                                (str "branch error: " (ex-message e))))))]))))
                       branches)]
     (mapv (fn [[b fut]]
-            (let [r (if deadline (deref fut deadline ::timeout) @fut)]
-              (if (= ::timeout r)
-                (do (log/warn "branch" (:id b) "exceeded the turn deadline on turn" turn)
-                    ;; Not a verification failure: the branch did not get an
-                    ;; answer to be wrong about. It loses the turn and is told
-                    ;; so, and the dangling call is left to finish or not.
-                    (-> b
-                        (state/add-message
-                         "user"
-                         (str "[harness] " (prompt/render "turn-deadline"
-                                             {:seconds (quot deadline 1000)})))
-                        (update :timeouts (fnil inc 0))))
-                r)))
+            (if (= ::still-dangling fut)
+              (do (log/warn "branch" (:id b) "still executing a forfeited turn;"
+                            "skipping turn" turn "to keep its turns serial")
+                  (forfeit b))
+              (let [r (if deadline (deref fut deadline ::timeout) @fut)]
+                (if (= ::timeout r)
+                  (do (log/warn "branch" (:id b) "exceeded the turn deadline on turn" turn)
+                      ;; Not a verification failure: the branch did not get an
+                      ;; answer to be wrong about. It loses the turn and is told
+                      ;; so; the dangling call is REMEMBERED so the next round
+                      ;; does not run beside it.
+                      (when in-flight (swap! in-flight assoc (:id b) fut))
+                      (forfeit b))
+                  r))))
           pending)))
 
 (defn dispose-branch-engines!
@@ -881,6 +906,10 @@
              :repl-session (repl/new-session)
              :sessions sessions
              :engine-sessions engine-sessions
+             ;; {branch-id future} of forfeited turns still executing, so
+             ;; advance-all never runs a branch beside its own dangling turn
+             ;; (karamazov-blt.18).
+             :in-flight (atom {})
              :abort abort}]
     ;; Before the branches, not after. api.control/start-run! blocks until this
     ;; fires, so this line is how long POST /v1/runs takes — and open-branch!

--- a/src/samizdat/agent/loop.clj
+++ b/src/samizdat/agent/loop.clj
@@ -296,7 +296,16 @@
   why. The message lands before the model call so the next response actually
   sees it."
   [branch turn]
-  (cond-> branch
+  (cond-> (assoc branch :current-turn turn)
+    ;; :current-turn is the branch's knowledge of the GLOBAL turn, stamped at
+    ;; the top of every turn (both drivers come through here). It is what
+    ;; state/turn-count serves, so budget arithmetic — last-call, wind-down,
+    ;; crossed-fractions, banked-in-last — runs in the same unit as max-turns
+    ;; and the artifact/gate stamps. (count :turns) undercounted it: no-call
+    ;; and provider-error turns append no :turns entry, and a FORK's log
+    ;; starts nearly empty, so a fork born at round 18 of 25 read as turn ~0,
+    ;; was never told to ship, and its parent's old artifacts read as
+    ;; \"recent\" forever (karamazov-blt.16).
     (state/explore-cap-expired? branch (gates/threshold :explore-cap) turn)
     (-> (state/enter-phase turn)
         (state/add-message

--- a/src/samizdat/agent/state.clj
+++ b/src/samizdat/agent/state.clj
@@ -160,6 +160,25 @@
 
 (defn active? [branch] (= :active (:status branch)))
 
+(defn turn-count
+  "How far into the RUN this branch is, in GLOBAL turns — the unit
+  `max-turns`, artifact `:turn` stamps and gate-history stamps are all
+  expressed in. Served from `:current-turn`, which the loop stamps at the top
+  of every turn; the length of the branch's own log is the fallback for a
+  branch no driver has touched (a fresh test branch), and the WRONG answer
+  for budget arithmetic on a live one — a fork's log starts nearly empty and
+  no-call turns append nothing (karamazov-blt.16)."
+  [branch]
+  (or (:current-turn branch) (count (:turns branch))))
+
+(defn own-turn-count
+  "How many turns THIS branch has itself taken — its experience, not its
+  position in the run's budget. What juvenile-grace and the prologue cap
+  mean by a turn: a fork born at round 18 is 0 turns OLD while being 18
+  turns IN."
+  [branch]
+  (count (:turns branch)))
+
 (defn confirmed-artifacts [branch]
   (filter #(= :confirmed (:claim-status %)) (:artifacts branch)))
 
@@ -178,7 +197,10 @@
   strategies naturally look like verify size N, fail at N+1, verify N+1, and
   culling them throws away the most valuable branch."
   [branch n]
-  (let [cutoff (- (count (:turns branch)) n)]
+  ;; Cutoff in GLOBAL turns — the unit the artifact stamps are in. Local
+  ;; (count :turns) made a fork read its parent's ten-round-old artifact as
+  ;; recent forever (karamazov-blt.16).
+  (let [cutoff (- (turn-count branch) n)]
     (boolean (some #(and (= :confirmed (:claim-status %))
                          (>= (:turn %) cutoff))
                    (:artifacts branch)))))
@@ -194,7 +216,9 @@
   branch to SHIP still read `confirmed-in-last`, because a measurement is not
   something to ship."
   [branch n]
-  (let [cutoff (- (count (:turns branch)) n)]
+  ;; Same unit note as confirmed-in-last: the cutoff and the stamps must both
+  ;; be global turns.
+  (let [cutoff (- (turn-count branch) n)]
     (boolean (some #(and (#{:confirmed :empirical} (:claim-status %))
                          (>= (:turn %) cutoff))
                    (:artifacts branch)))))
@@ -618,7 +642,8 @@
    (update branch :messages conj
            (merge {:role role :content content} (not-empty meta)))))
 
-(defn turn-count [branch] (count (:turns branch)))
+;; turn-count and own-turn-count are defined beside `active?`, above their
+;; budget-arithmetic callers (confirmed-in-last / banked-in-last).
 
 (defn describe
   "One line for logs and for the run summary."

--- a/src/samizdat/agent/tools/base.clj
+++ b/src/samizdat/agent/tools/base.clj
@@ -35,6 +35,22 @@
 (defn fail [branch result & {:as extra}]
   (merge {:result result :category :failure :progress? false :branch branch} extra))
 
+(defn refusal
+  "A policy refusal: a WELL-FORMED call the harness declined.
+
+  :mechanics, not :failure — no claim was produced and nothing was tested, so
+  there is no evidence here about the branch's line of inquiry — plus
+  :policy-refusal? true, which is the pair `state/record-outcome` feeds the
+  refusal counter from. Refusals used to go out as `fail`, so no production
+  path ever produced that pair: the refusal counter could never move, the
+  cull record's 'every call declined by policy' arm was unreachable, and a
+  branch refused N times by the task-required rule died as 'N consecutive
+  failures' — the vf-jki mistake in a sixth place (karamazov-blt.15)."
+  [branch result & {:as extra}]
+  (merge {:result result :category :mechanics :progress? false
+          :policy-refusal? true :branch branch}
+         extra))
+
 (defn malformed
   "A call the harness could not act on because its arguments were wrong.
 
@@ -116,11 +132,10 @@
   [{:keys [branch tool-name] :as ctx}]
   (or
    (when (contains? (phases/withholds (:phase branch)) tool-name)
-     (fail branch
+     (refusal branch
            (str "`" tool-name "` is not available in the "
                 (name (:phase branch))
-                " phase. The phase-valve message says when that changes.")
-           :policy-refusal? true))
+                " phase. The phase-valve message says when that changes.")))
 
    ;; `condition` rather than destructuring `:when` — a local named `when`
    ;; shadows clojure.core/when for the whole body, and the shadowing is
@@ -130,12 +145,11 @@
              (clojure.core/when
               (and (contains? (set tools) tool-name)
                    (when-fn-holds? condition ctx))
-              (fail branch
-                    (prompt/render message-file
-                                   {:tool-name tool-name
-                                    :phase (some-> (:phase branch) name)})
-                    :policy-refusal? true
-                    :refusal-rule (:rule rule)))))
+              (refusal branch
+                       (prompt/render message-file
+                                      {:tool-name tool-name
+                                       :phase (some-> (:phase branch) name)})
+                       :refusal-rule (:rule rule)))))
          (phases/refusals))))
 
 

--- a/src/samizdat/agent/tools/experiments.clj
+++ b/src/samizdat/agent/tools/experiments.clj
@@ -44,10 +44,9 @@
             ;; and the harness declined it, which is a policy refusal like any
             ;; other and must not read as its mistake.
             (let [{:keys [open cap unsettled]} (ex-data e)]
-              (base/fail branch (msg {:too-many true :open open :cap cap
-                                      :unsettled (when (seq unsettled)
-                                                   (str/join ", " unsettled))})
-                         :policy-refusal? true))
+              (base/refusal branch (msg {:too-many true :open open :cap cap
+                                         :unsettled (when (seq unsettled)
+                                                      (str/join ", " unsettled))})))
             (throw e)))))))
 
 (defmethod base/run-tool "verdict" [{:keys [branch] :as ctx}]

--- a/src/samizdat/agent/tools/shell.clj
+++ b/src/samizdat/agent/tools/shell.clj
@@ -30,9 +30,11 @@
   ;; Every command faces the permission engine, runs under a scrubbed
   ;; environment, and its output is redacted before it returns — one call into
   ;; samizdat.security.policy, which owns all three. A denied or unapproved
-  ;; command never spawns. The result's :category is what the cull guard reads:
-  ;; a policy refusal is :neutral (the branch did nothing wrong, the harness
-  ;; declined), a real command failure is :failure.
+  ;; command never spawns. The result's :category is what the cull guard
+  ;; reads: a deny is :mechanics with :policy-refusal? (the branch did
+  ;; nothing wrong, the harness declined — the refusal counter's business,
+  ;; not the cull counter's), an :ask is :neutral (waiting on a human), and
+  ;; a real command failure is :failure.
   (if-let [m (base/missing ctx :command)]
     (base/malformed branch m)
     (let [r (policy/run-shell ctx)]

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -118,7 +118,7 @@
     :conn :run-id :config :llm-adapter :llm-config :root :max-turns :abort
     ;; What the beam driver adds
     :problem :beam? :beam-width :turn-workflow :iterating-loop? :git-baseline
-    :repl-session :sessions :engine-sessions :live-branches})
+    :repl-session :sessions :engine-sessions :live-branches :in-flight})
 
 (defn cell-requires
   "The ctx keys `cell-id` declares it reads. `:requires` is mycelium's own

--- a/src/samizdat/security/policy.clj
+++ b/src/samizdat/security/policy.clj
@@ -356,7 +356,12 @@
         known (secrets/known-values env command)]
     (case effect
       :deny
-      {:category :failure :progress? false
+      ;; :mechanics, not :failure: a deny is the harness declining a
+      ;; well-formed call, not evidence about the branch's line of inquiry —
+      ;; charging it to the cull counter was karamazov-blt.15. The shell tool
+      ;; stamps :policy-refusal? on top, which is what routes it to the
+      ;; refusal counter.
+      {:category :mechanics :progress? false
        :result (str "Command denied by policy: `" head "` is on the deny list."
                     " This cannot be overridden.")
        :policy {:effect :deny}}

--- a/test/samizdat/agent_test.clj
+++ b/test/samizdat/agent_test.clj
@@ -2228,3 +2228,49 @@
           :when (str/includes? (str (:when g)) "cadence")]
     (is (some? (:budget g))
         (str (:gate g) " fires on a cadence and has no :budget — nothing bounds it"))))
+
+(deftest a-production-refusal-feeds-the-refusal-counter-not-the-cull-counter
+  ;; karamazov-blt.15. The synthetic-input test above proves the COUNTER works;
+  ;; this proves a production path actually produces the pair it needs.
+  ;; Refusals used to go out as :failure, so a task-less branch refused N
+  ;; times by the work-needs-a-task rule died as "N consecutive failures" —
+  ;; the vf-jki lie in a sixth place.
+  (let [b (state/new-branch {:id "B" :problem "p"})
+        r (tools-base/phase-refusal {:branch b :tool-name "write_file"})]
+    (is (some? r) "the task-required rule refuses work from a task-less branch")
+    (is (= :mechanics (:category r)))
+    (is (true? (:policy-refusal? r)))
+    (let [b' (state/record-outcome b {:category (:category r)
+                                      :policy-refusal? (:policy-refusal? r)})]
+      (is (= 1 (:consecutive-policy-refusals b')))
+      (is (zero? (:consecutive-failures b'))
+          "a declined call is not evidence about the branch's line of inquiry"))))
+
+(deftest a-shell-deny-is-a-refusal-not-a-failure
+  ;; The hard-deny arm returned :failure while the tool's own comment claimed
+  ;; :neutral; every deny charged the counter that kills branches
+  ;; (karamazov-blt.15).
+  (let [b (state/new-branch {:id "B" :problem "p"})
+        r (tools-base/run-tool {:tool-name "shell" :branch b :root "/tmp"
+                          :args {:command "rm -rf /"}})]
+    (is (= :mechanics (:category r)))
+    (is (true? (:policy-refusal? r)))))
+
+(deftest budget-arithmetic-runs-in-global-turns
+  ;; karamazov-blt.16. max-turns, artifact stamps and gate-history stamps are
+  ;; all GLOBAL turns; (count :turns) is the branch's own experience. Mixing
+  ;; them meant a fork born at round 18 of 25 read as turn ~0 — never told to
+  ;; ship — while its parent's ten-round-old artifact read as "recent"
+  ;; forever, making it cull-exempt.
+  (let [fork (assoc (state/new-branch {:id "F" :problem "p"}) :current-turn 18)]
+    (is (= 18 (state/turn-count fork))
+        "the loop's per-turn stamp wins over the log length")
+    (is (zero? (state/own-turn-count fork))
+        "while the branch's own experience stays separate (juvenile-grace's unit)")
+    (let [b (update fork :artifacts conj {:claim-status :confirmed :turn 5})]
+      (is (false? (state/banked-in-last b 6))
+          "an artifact banked at global turn 5 is not recent at turn 18")
+      (is (true? (state/banked-in-last (assoc b :current-turn 9) 6))
+          "and IS recent when the run is actually at turn 9")))
+  (is (= 7 (:current-turn (aloop/phase-valve (state/new-branch {:id "B" :problem "p"}) 7)))
+      "phase-valve is where the stamp lands, at the top of every turn"))

--- a/test/samizdat/control_test.clj
+++ b/test/samizdat/control_test.clj
@@ -451,3 +451,72 @@
         (is (true? @seen) "the run was visible to the abort endpoint while live")
         (is (not (contains? @api-control/active "r-oai"))
             "and deregistered when it finished")))))
+
+(deftest the-last-active-branch-survives-beside-inactive-siblings
+  ;; karamazov-blt.17: the cull cell seeded its survivor count with (count
+  ;; advanced), which includes branches that went done/abandoned during the
+  ;; round's advance — so the LAST active branch saw phantom survivors and was
+  ;; cullable, emptying the beam. It also ran the cascade over already-inactive
+  ;; branches, rewriting their endings.
+  (cells/load-cells!)
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})
+          cullfn (:handler (cell/get-cell :beam/cull))
+          done-b {:id "B1" :status :done :final-answer "a" :messages [] :turns []}
+          failing (assoc (state/new-branch {:id "B2" :problem "p"})
+                         :consecutive-failures 99
+                         :turns (vec (repeat 9 {})))
+          data (cullfn {:conn c :run-id rid :turn 9}
+                       {:advanced [done-b failing] :turn 9})
+          [b1' b2'] (:culled data)]
+      (is (= :done (:status b1'))
+          "an already-inactive sibling's ending is not re-judged or rewritten")
+      (is (state/active? b2')
+          "the last ACTIVE branch is never culled — a done sibling is not a survivor"))))
+
+(deftest exhaust-ships-a-banked-answer-instead-of-discarding-it
+  ;; karamazov-blt.20: with :stop-on-first-done? false, a branch that shipped
+  ;; at round 10 while a sibling explored to the cap ended in finish-run!
+  ;; :failed nil — the banked answer never reached the run row.
+  (cells/load-cells!)
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (runs/open-branch! c rid {:branch-id "B2"})
+      (let [done-b {:id "B1" :status :done :final-answer "the answer"
+                    :messages [] :turns []}
+            active-b (state/new-branch {:id "B2" :problem "p"})
+            exhaust (:handler (cell/get-cell :beam/exhaust))
+            data (exhaust {:conn c :run-id rid :max-turns 5}
+                          {:branches [done-b active-b] :active [active-b]})]
+        (is (= :completed (:status data)))
+        (is (= "the answer" (get-in data [:result :answer])))
+        (is (= "completed" (:status (runs/get-run c rid)))
+            "the run row records the completion, not a failure")))))
+
+(deftest a-forfeited-turns-thread-is-never-run-beside
+  ;; karamazov-blt.18: a turn that blew its deadline kept executing — it
+  ;; journals under the branch's id and shares its eval session — while the
+  ;; beam advanced the SAME branch again next round, interleaving two turns of
+  ;; one branch and making the journal diverge from the live state. The
+  ;; dangling future is remembered now, and the branch forfeits until it
+  ;; completes.
+  (let [calls (atom 0)]
+    (with-redefs [beam/advance-branch (fn [_ b _]
+                                        (if (= 1 (swap! calls inc))
+                                          (do (Thread/sleep 400) (assoc b :slow true))
+                                          (assoc b :fast true)))]
+      (let [in-flight (atom {})
+            ctx {:iterating-loop? true :turn-deadline-ms 50 :in-flight in-flight}
+            b (state/new-branch {:id "B1" :problem "p"})
+            [r1] (beam/advance-all ctx [b] 1)]
+        (is (= 1 (:timeouts r1)) "the slow turn forfeits")
+        (is (contains? @in-flight "B1") "and its dangling future is remembered")
+        (let [[r2] (beam/advance-all ctx [b] 2)]
+          (is (= 1 (:timeouts r2))
+              "the next round forfeits again rather than running beside it")
+          (is (= 1 @calls) "crucially, NO second turn ran while one dangled"))
+        (Thread/sleep 500)
+        (let [[r3] (beam/advance-all ctx [b] 3)]
+          (is (true? (:fast r3)) "once the dangling turn completes, the branch advances")
+          (is (not (contains? @in-flight "B1")) "and the memory is released"))))))

--- a/test/samizdat/security/policy_test.clj
+++ b/test/samizdat/security/policy_test.clj
@@ -175,7 +175,10 @@
           (is (str/includes? (:result r) "hello-from-shell"))))
       (testing "a denied command never runs"
         (let [r (call "rm -rf /")]
-          (is (= :failure (:category r)))
+          ;; :mechanics, not :failure — a deny is the harness declining a
+          ;; well-formed call, and charging it to the cull counter was
+          ;; karamazov-blt.15.
+          (is (= :mechanics (:category r)))
           (is (str/includes? (str/lower-case (:result r)) "denied"))))
       (testing "an ask blocks until a human grants, then runs"
         (let [r (call "python3 --version")]

--- a/test/samizdat/team_test.clj
+++ b/test/samizdat/team_test.clj
@@ -37,6 +37,29 @@
         (is (str/includes? (:answer r) "beta"))
         (is (str/includes? (:answer r) "2 workers"))))))
 
+(defn- worker-gives-up
+  "A worker that always gives up — nothing lands, retries included."
+  [_ _ _ & _]
+  {:content "```tool-call\n{\"name\":\"give_up\",\"args\":{\"reason\":\"cannot do it\"}}\n```"
+   :finish-reason "stop"})
+
+(deftest an-all-failed-team-run-does-not-report-completed
+  ;; karamazov-blt.19: the fan-out marked the run :done unconditionally, so a
+  ;; team where every worker failed still finished :completed with a summary
+  ;; of the failures as its answer — upstream of the false-completion
+  ;; memories in karamazov-mjb. The verdict now comes from :team/supervise,
+  ;; after its retries, from what actually landed.
+  (with-redefs [llm/chat worker-gives-up]
+    (let [conn (db/open! ":memory:")
+          r (workflow/run! {:conn conn
+                            :config {:run {:loop "team" :subtasks ["alpha"]}}
+                            :llm-adapter :a :llm-config {:max-tokens 16384}
+                            :problem "the feature" :max-turns 4})]
+      (is (not= :completed (:status r))
+          "a team where every worker failed must not read as a success")
+      (is (= "abandoned" (:status (db/fetch-one conn ["SELECT status FROM runs"])))
+          "the run row records the honest ending"))))
+
 (deftest team-with-no-subtasks-is-one-worker-on-the-whole-problem
   (with-redefs [llm/chat worker-dones-its-task]
     (let [conn (db/open! ":memory:")


### PR DESCRIPTION
Fourth audit PR — the accounting that decides which branches live and what counts as done:

- `base/refusal` (`:mechanics` + `:policy-refusal?`) for phase refusals, shell denies, the experiment cap: refusals stop charging the cull counter (blt.15)
- one turn unit per question: `turn-count` = global (`:current-turn`, stamped by phase-valve), `own-turn-count` = branch experience; last-call/wind-down/turn-budget/banked-in-last run in max-turns' unit, juvenile/prologue/reflection in the branch's own (blt.16)
- cull cell: survivors = active only; inactive branches pass through untouched (blt.17)
- `advance-all` quarantines a forfeited turn's dangling future via ctx `:in-flight` — no two concurrent turns of one branch (blt.18)
- team fan-out joins only; verdict decided by supervise (after retries) / feature route (behind both gates); all-failed runs end `:abandoned` (blt.19)
- `:beam/exhaust` ranks banked answers and finishes `:completed` instead of discarding them (blt.20)

Suite: 1331 tests, 4745 assertions, green.