### PR TITLE
audit round 5: resume and adaptation fidelity

### DIFF
--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -790,7 +790,17 @@
         (try
           (let [{:keys [findings verdicts]}
                 (knowledge/distil-session! conn {:run-id run-id
-                                                 :findings (session/findings)
+                                                 :findings (session/findings
+                                                            ;; THIS RUN's window, not the
+                                                            ;; whole-process tally: counters
+                                                            ;; never reset between runs, so
+                                                            ;; run 1's parse-error rate kept
+                                                            ;; "corroborating" a finding at
+                                                            ;; the end of clean runs 2..n,
+                                                            ;; each with a distinct run-id
+                                                            ;; that defeated the guard
+                                                            ;; (karamazov-blt.24).
+                                                            (session/run-window run-id))
                                                  :experiments (session/experiments)})]
             (when (or (seq findings) (seq verdicts))
               (log/info "distilled" (count findings) "finding(s) and"

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -107,9 +107,11 @@
             [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.agent.loop :as branch-loop]
             [samizdat.agent.state :as state]
+            [samizdat.agent.tools.tasks :as task-tool]
             [samizdat.repl :as repl]
             [samizdat.store.journal :as journal]
             [samizdat.store.runs :as runs]
+            [samizdat.store.tasks :as tasks]
             [samizdat.workflow :as workflow]))
 
 (defn- parse-json [s]
@@ -182,18 +184,34 @@
                                                    :turn (:turn f)})
                                                 (remove #(:outcome %)
                                                         (get firings branch-id [])))))
-        ;; The counters, replayed through the same function the live loop
-        ;; uses. progress? is approximated from the category because the
-        ;; tool's own progress? flag is not journalled.
+        ;; The counters, replayed through the same functions the live loop
+        ;; uses — WITH the live loop's call discipline, not one of our own
+        ;; (karamazov-blt.22): a provider-error row is journalled but the live
+        ;; loop applies NEITHER add-turn nor record-outcome to it (the branch
+        ;; never got an answer to be wrong about — replaying it as :neutral
+        ;; DECREMENTED consecutive-failures and reset the mechanics
+        ;; counters), and a no-call/parse-error row records the outcome but
+        ;; appends no :turns entry. progress? is approximated from the
+        ;; category because the tool's own progress? flag is not journalled.
         branch (reduce (fn [b t]
-                         (let [cat (some-> (:category t) keyword)]
-                           (-> b
-                               (state/add-turn {:turn (:turn t)
-                                                :tool (:tool_name t)
-                                                :category cat})
-                               (state/record-outcome {:category cat
-                                                      :progress? (= :success cat)
-                                                      :policy-refusal? (pos? (or (:policy_refusal t) 0))}))))
+                         (let [cat (some-> (:category t) keyword)
+                               tool (:tool_name t)]
+                           (cond
+                             (= "__provider_error__" tool)
+                             b
+
+                             (contains? #{"__no_call__" "__parse_error__"} tool)
+                             (state/record-outcome b {:category cat
+                                                      :progress? false})
+
+                             :else
+                             (-> b
+                                 (state/add-turn {:turn (:turn t)
+                                                  :tool tool
+                                                  :category cat})
+                                 (state/record-outcome {:category cat
+                                                        :progress? (= :success cat)
+                                                        :policy-refusal? (pos? (or (:policy_refusal t) 0))})))))
                        base
                        branch-turns)
         branch (assoc branch
@@ -285,8 +303,21 @@
                :sessions sessions
                :abort abort}
           branches (mapv (fn [row]
-                           (rebuild-branch run row turns artifacts firings
-                                           max-turns))
+                           (let [b (rebuild-branch run row turns artifacts
+                                                   firings max-turns)
+                                 ;; The task claim survives the crash on its
+                                 ;; ROW; without restoring it here the branch
+                                 ;; came back reading "No task claimed", could
+                                 ;; claim a second task, and left the old one
+                                 ;; in_progress and attributed to it forever
+                                 ;; (karamazov-blt.21). The pinned statement
+                                 ;; is re-appended through the same renderer
+                                 ;; the claim used.
+                                 held (tasks/held-by conn run-id (:id b))]
+                             (cond-> b
+                               held (assoc :task {:id (:id held)
+                                                  :title (:title held)})
+                               held (task-tool/task-statement held))))
                          (runs/branches conn run-id))
           ;; The anchor: rounds completed are the max turn in the journal, so
           ;; the loop continues one past it. max-turns is the ORIGINAL budget.

--- a/src/samizdat/agent/skills.clj
+++ b/src/samizdat/agent/skills.clj
@@ -26,7 +26,26 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]))
 
-(def default-dirs ["resources/skills" ".samizdat/skills"])
+(def shipped-skills
+  "Basenames of the skills that ship, ENUMERATED not globbed — a classpath has
+  no directory listing and an embedded resource has no filesystem path, so a
+  dir scan found nothing inside a built binary or from any cwd but the
+  samizdat repo itself: every implementor silently lost the REPL/TDD guidance
+  and the catalogue rendered empty (karamazov-blt.33). Same reasoning as
+  cells/shipped-cells; pinned against resources/skills by skills-test."
+  ["mycelium" "repl-workflow"])
+
+(def default-dirs
+  "The project-overlay directories scanned in addition to the shipped
+  resources. Relative to the process cwd; a caller working on another project
+  passes `(project-dirs root)` instead."
+  [".samizdat/skills"])
+
+(defn project-dirs
+  "Where a project's own skills live, under the RUN's root — not the
+  harness's cwd (karamazov-blt.33)."
+  [root]
+  [(str (io/file (str (or root ".")) ".samizdat/skills"))])
 
 (defn- md-files [dir]
   (let [d (io/file dir)]
@@ -60,10 +79,27 @@
                (str/trim %))
             (str/split-lines (:body fm)))))
 
+(defn- shipped-entries
+  "The bundled skills, read off the classpath so they resolve from a built
+  binary and from any cwd."
+  []
+  (into {}
+        (keep (fn [nm]
+                (try
+                  (when-let [r (io/resource (str "skills/" nm ".md"))]
+                    (let [fm (parse-frontmatter (slurp r))
+                          nm' (or (not-empty (str (get-in fm [:meta :name]))) nm)]
+                      [nm' {:path (str "classpath:skills/" nm ".md")
+                            :description (describe fm nm')
+                            :body (:body fm)}]))
+                  (catch Throwable _ nil))))
+        shipped-skills))
+
 (defn discover
-  "skill-name -> {:path :description :body}. A skill in a later dir overrides an
-  earlier one, so .samizdat/skills wins over resources/skills. Malformed files
-  are skipped, never fatal."
+  "skill-name -> {:path :description :body}. The shipped skills come off the
+  classpath; `dirs` overlay them in order, so a project's .samizdat/skills
+  wins over a bundled skill of the same name. Malformed files are skipped,
+  never fatal."
   ([] (discover default-dirs))
   ([dirs]
    (reduce
@@ -78,7 +114,8 @@
                                  :body (:body fm)}))
                   (catch Throwable _ m)))
               acc (md-files dir)))
-    {} dirs)))
+    (shipped-entries)
+    dirs)))
 
 (defn catalog
   "The always-on catalogue the agent sees: [{:name :description} ...], sorted.

--- a/src/samizdat/agent/tools/skills.clj
+++ b/src/samizdat/agent/tools/skills.clj
@@ -13,15 +13,19 @@
 (def ^:private usage
   "Actions: list (the catalogue), load {name} (a skill's full guidance).")
 
-(defmethod base/run-tool "skill" [{:keys [branch] :as ctx}]
-  (let [action (some-> (base/arg ctx :action) str str/trim str/lower-case not-empty)]
+(defmethod base/run-tool "skill" [{:keys [branch root] :as ctx}]
+  ;; Project skills resolve under the RUN's root, not the harness's cwd — a
+  ;; run working on another checkout reads THAT project's .samizdat/skills
+  ;; (karamazov-blt.33). The shipped skills come off the classpath either way.
+  (let [action (some-> (base/arg ctx :action) str str/trim str/lower-case not-empty)
+        dirs (if root (skills/project-dirs root) skills/default-dirs)]
     (case action
       nil
       (base/malformed branch (str "`skill` needs an `action`. " usage))
 
       "list"
       (base/ok branch
-               (let [cat (skills/catalog)]
+               (let [cat (skills/catalog dirs)]
                  (if (seq cat)
                    (str "Skills — load one with `skill load {name}` when it is"
                         " relevant:\n"
@@ -38,7 +42,7 @@
           ;; into state/record-outcome (provenance CR1-1).
           (nil? name) (base/malformed branch (base/missing ctx :name))
           :else
-          (if-let [content (skills/load-skill name)]
+          (if-let [content (skills/load-skill dirs name)]
             (base/ok branch content)
             (base/malformed branch (str "No skill named '" name "'. " usage)))))
 

--- a/src/samizdat/agent/tools/tasks.clj
+++ b/src/samizdat/agent/tools/tasks.clj
@@ -54,7 +54,7 @@
 ;; Pinned means compaction never unloads it: the task matters MORE the longer
 ;; it runs, so ageing it out is exactly backwards.
 
-(defn- task-statement
+(defn task-statement
   "The pinned message a claimed task appends. Marked :pinned? so compaction
   leaves it alone, and stamped with the task id so a later turn can tell which
   statement belongs to which task."

--- a/src/samizdat/session.clj
+++ b/src/samizdat/session.clj
@@ -367,7 +367,14 @@
   full-session tally stays for the supervisor's cross-run view, where dilution
   is the point rather than the problem."
   [run-id]
-  (or (since (str "run:" run-id)) (snapshot)))
+  (let [k (str "run:" run-id)]
+    (if (get-in @tally [:marks k])
+      ;; The mark exists; a nil diff means NOTHING happened in the run — an
+      ;; empty window, not license to fall back to the whole-process tally.
+      ;; Conflating the two re-served run 1's patterns at the end of a
+      ;; perfectly quiet run (the karamazov-blt.24 edge).
+      (or (since k) {})
+      (snapshot))))
 
 (defn mark-run!
   "Stamp the start of a run, so findings can be evaluated over it."

--- a/src/samizdat/store/knowledge.clj
+++ b/src/samizdat/store/knowledge.clj
@@ -333,10 +333,21 @@
                pattern (str "finding:" (name kind))
                existing (by-pattern conn pattern)]]
      (if existing
-       (do (record-outcome! conn (:id existing) (= :good (keyword severity)))
+       ;; A recurring finding is a RE-OBSERVATION, and corroborate! is its
+       ;; record. It is NOT an outcome: `record-outcome! (= :good severity)`
+       ;; here conflated "this finding is bad news" with "acting on this
+       ;; memory failed", so every re-observation of a persistent problem
+       ;; added a failure_count and the most persistent problems progressively
+       ;; ranked below trivia (karamazov-blt.25). Only acting on a memory
+       ;; earns it an outcome — the verdict path below.
+       ;;
+       ;; The content refresh goes through restate! so the FTS mirror follows
+       ;; the wording — the raw UPDATE left the memory recallable only by its
+       ;; FIRST phrasing (same bead).
+       (do (restate! conn (:id existing) content)
            (db/with-writer
-             (db/execute! conn ["UPDATE knowledge SET content = ?, run_id = ? WHERE id = ?"
-                                content run-id (:id existing)]))
+             (db/execute! conn ["UPDATE knowledge SET run_id = ? WHERE id = ?"
+                                run-id (:id existing)]))
            {:id (:id existing) :kind kind :repeat? true
             :corroborations (corroborate! conn (:id existing) run-id)})
        {:id (remember! conn {:content content :kind "episodic" :run-id run-id
@@ -383,10 +394,14 @@
                existing (by-pattern conn pattern)
                worked? (= :better verdict)]]
      (if existing
+       ;; Here the outcome IS earned: the lever was pulled and measured.
+       ;; Content refresh through restate! so the FTS mirror follows the new
+       ;; wording (karamazov-blt.25).
        (do (record-outcome! conn (:id existing) worked?)
+           (restate! conn (:id existing) content)
            (db/with-writer
-             (db/execute! conn ["UPDATE knowledge SET content = ?, run_id = ? WHERE id = ?"
-                                content run-id (:id existing)]))
+             (db/execute! conn ["UPDATE knowledge SET run_id = ? WHERE id = ?"
+                                run-id (:id existing)]))
            {:id (:id existing) :lever change :verdict verdict :repeat? true})
        (let [id (remember! conn {:content content :kind "procedural" :run-id run-id
                                  :pattern-key pattern :confidence 0.7})]

--- a/src/samizdat/store/tasks.clj
+++ b/src/samizdat/store/tasks.clj
@@ -230,3 +230,19 @@
   (db/fetch conn [(str "SELECT * FROM tasks
                         WHERE run_id IS NULL
                           AND status NOT IN ('done','cancelled')" board-order)]))
+
+(defn held-by
+  "The non-terminal task a branch currently holds on this run, or nil.
+
+  The claim a resume must restore: the row survives the crash with its
+  branch_id set, but the rebuilt branch used to come back with no :task —
+  telling the model 'No task claimed', letting it claim a SECOND task (the
+  one-task rule reads the branch), and leaving the old row in_progress and
+  attributed to it forever, which is RFC-008's named worst state for a
+  shared board (karamazov-blt.21)."
+  [conn run-id branch-id]
+  (db/fetch-one conn ["SELECT * FROM tasks
+                        WHERE run_id = ? AND branch_id = ?
+                          AND status NOT IN ('done','cancelled')
+                        LIMIT 1"
+                      run-id branch-id]))

--- a/src/samizdat/workflow.clj
+++ b/src/samizdat/workflow.clj
@@ -335,7 +335,17 @@
         ;; the common path measured everything and remembered none of it.
         (try
           (knowledge/distil-session! conn {:run-id run-id
-                                           :findings (session/findings)
+                                           :findings (session/findings
+                                                            ;; THIS RUN's window, not the
+                                                            ;; whole-process tally: counters
+                                                            ;; never reset between runs, so
+                                                            ;; run 1's parse-error rate kept
+                                                            ;; "corroborating" a finding at
+                                                            ;; the end of clean runs 2..n,
+                                                            ;; each with a distinct run-id
+                                                            ;; that defeated the guard
+                                                            ;; (karamazov-blt.24).
+                                                            (session/run-window run-id))
                                            :experiments (session/experiments)})
           (catch Throwable e
             (log/warn "distilling the session failed:" (ex-message e))))

--- a/test/samizdat/control_test.clj
+++ b/test/samizdat/control_test.clj
@@ -32,10 +32,12 @@
             [samizdat.agent.loop :as aloop]
             [samizdat.workflow :as wf]
             [samizdat.agent.state :as state]
+            [samizdat.agent.resume :as resume]
             [samizdat.api.control :as api-control]
             [samizdat.api.openai :as openai]
             [samizdat.api.runs :as api-runs]
             [samizdat.cells :as cells]
+            [samizdat.store.tasks :as tasks]
             [mycelium.cell :as cell]
             [samizdat.llm.client :as llm]
             [samizdat.security.policy :as policy]
@@ -520,3 +522,48 @@
         (let [[r3] (beam/advance-all ctx [b] 3)]
           (is (true? (:fast r3)) "once the dangling turn completes, the branch advances")
           (is (not (contains? @in-flight "B1")) "and the memory is released"))))))
+
+(deftest a-resumed-branch-still-holds-its-task
+  ;; karamazov-blt.21: the claim survives the crash on its ROW, but the
+  ;; rebuilt branch came back with no :task — told "No task claimed", free to
+  ;; claim a SECOND task, with the old row in_progress and attributed to it
+  ;; forever: RFC-008's named worst state for a shared board.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (let [t-id (tasks/create! c {:title "the part" :body "do it" :run-id rid})]
+        (is (some? (tasks/claim! c t-id rid "B1")))
+        (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
+          (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
+                                   :llm-config {} :run-id rid})
+                b (first (:branches r))]
+            (is (= t-id (get-in b [:task :id]))
+                "the branch knows what it holds again")
+            (is (some :pinned? (:messages b))
+                "and the pinned task statement is back in its context")))))))
+
+(deftest replay-applies-the-live-loops-call-discipline
+  ;; karamazov-blt.22: replay pushed EVERY journalled row through add-turn +
+  ;; record-outcome, but the live loop applies neither to a provider-error row
+  ;; and only record-outcome to a no-call row — so each provider error
+  ;; DECREMENTED consecutive-failures on replay and the resumed branch's
+  ;; counters diverged from the ones the run actually had.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 1 :tool-name "eval"
+                                   :args {} :result "boom" :category "failure"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 2
+                                   :tool-name "__provider_error__"
+                                   :result "timeout" :category "neutral"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 3
+                                   :tool-name "__no_call__"
+                                   :result "no fence" :category "mechanics"})
+      (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
+        (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
+                                 :llm-config {} :run-id rid})
+              b (first (:branches r))]
+          (is (= 1 (:consecutive-failures b))
+              "the provider error neither decrements nor resets the counter")
+          (is (= 1 (count (:turns b)))
+              "and only the real tool turn entered the branch's own log"))))))

--- a/test/samizdat/knowledge_test.clj
+++ b/test/samizdat/knowledge_test.clj
@@ -315,3 +315,28 @@
         (let [again (knowledge/distil-project! c {:run-id rid2})]
           (is (every? :repeat? again))
           (is (= 2 (:corroborations (knowledge/by-pattern c "cmd-works:cat deps.edn")))))))))
+
+(deftest a-recurring-finding-is-corroborated-not-penalised
+  ;; karamazov-blt.25: the outcome axis means "did ACTING on this memory
+  ;; work" (RFC-010), and nothing on the distillation path measures that. The
+  ;; old record-outcome! call turned every re-observation of a persistent
+  ;; problem into a failure_count, sinking exactly the memories that matter
+  ;; most below trivia. And the raw content UPDATE skipped the FTS mirror, so
+  ;; the memory answered only to its FIRST wording.
+  (let [c @conn]
+    (let [rid1 (runs/start-run! c {:problem "p1"})
+          rid2 (runs/start-run! c {:problem "p2"})]
+      (knowledge/distill! c [{:kind :tool-failing :severity :bad
+                              :detail "eval keeps failing" :evidence {:rate 0.5}}]
+                          {:run-id rid1})
+      (knowledge/distill! c [{:kind :tool-failing :severity :bad
+                              :detail "shell keeps failing" :evidence {:rate 0.6}}]
+                          {:run-id rid2})
+      (let [row (knowledge/by-pattern c "finding:tool-failing")]
+        (is (= 2 (:corroborations row)) "recurrence is corroboration")
+        (is (zero? (or (:failure_count row) 0))
+            "a re-observation is not a failed outcome")
+        (is (str/includes? (str (:content row)) "shell keeps failing")
+            "the content follows the newest evidence")
+        (is (some #(= (:id row) (:id %)) (knowledge/recall c "shell"))
+            "and the memory answers to its NEW wording, not just its first")))))

--- a/test/samizdat/session_test.clj
+++ b/test/samizdat/session_test.clj
@@ -410,3 +410,20 @@
   (testing "below the firing floor nothing is claimed either way"
     (is (empty? (filter #(= :steering-ignored (:kind %))
                         (session/findings {:turns 8 :gates {:a {:fired 2}}}))))))
+
+(deftest run-end-distillation-reads-the-run-window-not-the-process-tally
+  ;; karamazov-blt.24: both drivers passed (session/findings) — the whole-
+  ;; process snapshot — to distil-session!, so run 1's parse-error rate kept
+  ;; a finding above threshold at the end of clean runs 2..n, and each end-of-
+  ;; run distillation corroborated it with a DISTINCT run-id, defeating the
+  ;; distinct-run guard. They pass (session/run-window run-id) now; this pins
+  ;; the window semantics that fix relies on.
+  (session/reset!)
+  (dotimes [_ 10]
+    (session/observe-turn! {:tool "eval" :category :mechanics
+                            :signals {:parse-error true}}))
+  (is (seq (session/findings))
+      "the whole-process tally reports the bad old run's pattern")
+  (session/mark-run! "clean-run")
+  (is (empty? (session/findings (session/run-window "clean-run")))
+      "a clean later run inherits none of it"))

--- a/test/samizdat/skills_test.clj
+++ b/test/samizdat/skills_test.clj
@@ -58,3 +58,22 @@
     (is (map? (:branch r)) "the branch rides along")
     (is (str/includes? (:result r) "Missing required argument(s): name"))
     (is (str/includes? (:result r) "\"skill\"") "the skeleton names the tool")))
+
+(deftest shipped-skills-resolve-off-the-classpath-from-any-cwd
+  ;; karamazov-blt.33: the loader scanned cwd-relative "resources/skills", so
+  ;; from any other project (and from a built binary, where the dir does not
+  ;; exist on disk) every implementor silently lost the REPL/TDD guidance and
+  ;; the catalogue rendered empty — the classpath-has-no-listing trap
+  ;; cells/shipped-cells enumerates around, in a fourth place.
+  (let [cat (skills/catalog ["/no/such/dir"])]
+    (is (some #(= "repl-workflow" (:name %)) cat)
+        "the bundled skills survive a foreign cwd"))
+  (is (str/includes? (str (skills/load-skill ["/no/such/dir"] "repl-workflow"))
+                     "eval")
+      "and load by name with no overlay directory present")
+  (let [on-disk (->> (file-seq (java.io.File. "resources/skills"))
+                     (filter #(str/ends-with? (.getName ^java.io.File %) ".md"))
+                     (map #(str/replace (.getName ^java.io.File %) #"\.md$" ""))
+                     set)]
+    (is (= on-disk (set skills/shipped-skills))
+        "the enumerated list is pinned against the directory")))


### PR DESCRIPTION
Fifth audit PR — resume-by-replay and the learning loop:

- task claims survive resume: `tasks/held-by` restores `:task` and re-appends the pinned statement (blt.21)
- replay mirrors the live loop's discipline for `__provider_error__` / `__no_call__` rows — counters no longer diverge after a resume (blt.22)
- both drivers distil `(session/run-window run-id)`; `run-window` distinguishes a quiet marked run from an unmarked one (blt.24)
- `distill!` stops recording re-observations as failed outcomes; content refreshes go through `restate!` so recall answers to the newest wording (blt.25)
- skills: `shipped-skills` enumerated off the classpath + `project-dirs` under the run's root; the skill tool passes `ctx :root` (blt.33)

Suite: 1336 tests, 4759 assertions, green.