### PR TITLE
audit round 6: the remaining mediums, and RFCs brought to match intent

### DIFF
--- a/docs/RFCS/RFC-001-core-layer.md
+++ b/docs/RFCS/RFC-001-core-layer.md
@@ -163,9 +163,19 @@ re-querying for a row that is not there costs the same as one that is.
 
 - The base/userspace rule has no mechanical check. A behaviour added to `src/`
   will not fail a test.
-- `store/workflows.clj` remains as a shim over `:manifest` so `workflow` and the
-  manifest tool keep their `name`-only signatures. New code should use
-  `samizdat.userspace`.
 - Migration v11 copied the pre-existing `workflows` rows into `userspace` and
   left the old table in place. Nothing reads it; it is not dropped, so a
-  rollback to a pre-v11 binary still resolves.
+  rollback to a pre-v11 binary still resolves. The `store/workflows.clj` shim
+  that once fronted it is gone.
+
+## Refinement: the factory row is a mirror, not history
+
+"History is append-only" holds for every version the PROJECT wrote. The one
+deliberate exception (migration v17): a version-1 row whose `source` column
+says `factory` is the shipped template's mirror, and `seed!` UPDATEs it in
+place when a harness upgrade changes the template — that is how an upgrade
+reaches a project that never edited the piece. The moment a project saves its
+own version, the append-only discipline owns every row from there on. The
+`source` column is what tells the two apart; inferring it from the version
+number would risk overwriting a project's own v1, which is the one thing
+userspace exists to prevent.

--- a/docs/RFCS/RFC-002-manifests-and-cells.md
+++ b/docs/RFCS/RFC-002-manifests-and-cells.md
@@ -84,6 +84,23 @@ multi-minute job under the per-turn deadline and run five at once.
 
 ## API
 
+### `samizdat.manifests` and `samizdat.workflow`
+
+Reading, validating and compiling a manifest lives in **`samizdat.manifests`**
+(mechanism only: mycelium + the cell loader + the userspace seam, no driver),
+so the self-modification tools validate an edit EXACTLY the way the loader
+will — they cannot require `samizdat.workflow`, which reaches the tool
+dispatcher through the branch loop, and each once re-implemented a slice of
+the pipeline that drifted (2026-08 audit, blt.2/.3/.4/.6). `samizdat.workflow`
+delegates the moved names, so every caller below keeps working; it retains
+the drivers (`load-loop!`, `compile-turn-loop`, `run-turn`, `run!`) and the
+role plumbing. Two functions worth knowing apart:
+
+| fn | contract |
+|---|---|
+| `(manifests/compile-loop definition)` | The loader's full pipeline: registry reload, sub-workflow registration through userspace, ctx-key requires, derived constraints, mycelium pre-compile. |
+| `(manifests/compile-definition definition)` | The same WITHOUT the registry reload — what the mutation protocol validates through, because reloading would replace the candidate it just installed. |
+
 ### `samizdat.workflow`
 
 | fn | contract |
@@ -118,8 +135,8 @@ rethrown, so a broken edit never half-loads.
 
 | fn | contract |
 |---|---|
-| `(propose-cell! {:keys [name body loop-def soak-input compile-fn conn run-id]})` | Validate a candidate and commit it as a new version **only if it survives**. `{:status :committed :version n}` or `{:status :rolled-back :reason s}`. |
-| `(apply-cell-edit! {:keys [dirs loop-def soak-input compile-fn conn run-id]})` | The legacy file-based protocol: reload, validate, soak, commit or restore the file. |
+| `(propose-cell! {:keys [name body loop-def extra-defs soak-input compile-fn conn run-id]})` | Validate a candidate and commit it as a new version **only if it survives**. `:loop-def` is the ACTIVE stored loop (soaked); `:extra-defs` is every other shipped+stored manifest (compiled, not soaked) — a cell wired only into the beam or a team loop is invisible to the active loop, and validating one definition let an edit that broke every other workflow commit (blt.2). `{:status :committed :version n}`, `{:status :live-unsaved :reason :unbound}` when no store is bound, or `{:status :rolled-back :reason s}`. |
+| `(apply-cell-edit! {:keys [dirs loop-def soak-input compile-fn conn run-id]})` | The legacy file-based protocol: reload, validate, soak, commit or restore the file. Refuses a store-mode image (`:reason :store-mode-image`) — its checkpoint is file paths, and the production loader's is store names (blt.7). |
 
 ## Protocol
 

--- a/docs/RFCS/RFC-003-security-model.md
+++ b/docs/RFCS/RFC-003-security-model.md
@@ -203,10 +203,13 @@ mechanical catches that omission.
 
 ## Known gaps
 
-- Redaction has **one structural chokepoint** (`run-shell`) and one wrapper
-  (`tools/repl`). Any future tool returning host-derived content is outside the
-  boundary by default and nothing will say so. `base/ok` would be the place to
-  make it structural, at the cost of redacting content that was never sensitive.
+- ~~Redaction has one structural chokepoint (`run-shell`) and one wrapper
+  (`tools/repl`); a future tool is outside the boundary by default.~~ Closed:
+  `samizdat.agent.tools/run-tool` — the dispatch wrapper every tool result
+  passes through — redacts the envelope (`:result`, `:artifact`, `:failure`)
+  structurally, so a new tool is inside the boundary by default.
+  `run-shell`'s scrub-before-spawn and the repl wrapper remain as the
+  earlier, tighter layers on their paths.
 - `sensitive-value?` covers named vendor prefixes. A credential with no
   recognisable shape is caught only by the substring pass, which requires the
   value to be in `known-values` — so a secret the harness never saw in the

--- a/docs/RFCS/RFC-004-tape-and-inference.md
+++ b/docs/RFCS/RFC-004-tape-and-inference.md
@@ -147,6 +147,12 @@ A block held at a fixed early position and rewritten when its subject changes
 invalidates every cached token behind it; one carrying anything per-turn means
 the cache never warms at all.
 
+One deliberate, bounded exception: `strip-stale-ledgers` (RFC-005) blanks the
+previous turn's settled-state block on the way to the wire, so the byte-stable
+prefix ends one ledger position earlier than the newest message. The cost is
+re-prefilling roughly one turn's tail per call; the alternative — every stale
+ledger riding along — grows the context by a full ledger per turn.
+
 ## Known gaps
 
 **F1 — the boundary fold has no production caller.** `apply-fold`, `fold-split`,

--- a/docs/RFCS/RFC-006-beam-and-scheduling.md
+++ b/docs/RFCS/RFC-006-beam-and-scheduling.md
@@ -178,9 +178,18 @@ is permissiveness, which is why every reprieve is a loan with a clock.
 - **Beam width is not justified.** Nobody has measured five branches against
   one branch at five times the turn budget. `samizdat.bench.beam` is named as
   the comparison and **does not exist** — the directory is absent.
-- `dispose-branch-engines!` is a no-op seam. The proof engines it existed for
-  are gone; the coding tools open sessions (nREPL, subprocesses) that will want
-  per-branch disposal here.
-- `drain-directives!` recognises `pause`, `resume`, `extend` and `fork` and
-  rejects them explicitly as unwired. Rejecting beats accepting silently, but
-  they are advertised by the control API.
+- ~~`dispose-branch-engines!` is a no-op seam.~~ Closed: it disposes the
+  per-branch eval session.
+- ~~`drain-directives!` rejects pause/resume/extend/fork as unwired.~~ Closed
+  (2026-08 audit): all eight advertised kinds land. `pause`/`resume` are also
+  applied by `await-resume!` itself, since the beam parks there upstream of
+  the directives cell (blt.9); the per-turn drain leaves scheduler kinds
+  pending for the beam instead of eating them mid-round (blt.10); a human
+  `cull` closes the row and stays in the record (blt.11); `extend` rides the
+  branch (`:extended-turns`), persists to the runs row, and reaches the turn
+  slice's cap (blt.12).
+
+Two invariants the audit added to the table's spirit: a forfeited turn's
+still-running thread is never run beside (`advance-all`'s `:in-flight`
+quarantine, blt.18), and the cull cell counts only ACTIVE branches as
+survivors and never re-judges an inactive one (blt.17).

--- a/docs/RFCS/RFC-007-steer-system.md
+++ b/docs/RFCS/RFC-007-steer-system.md
@@ -158,10 +158,16 @@ that is measurable rather than arguable.
 
 ## Known gaps
 
-- `:withholds` is empty for both phases, so the phase machinery is wired and
-  inert. `phase-refusal` is consulted on every dispatch and always returns
-  `nil`.
+- ~~`:withholds` is empty, so the phase machinery is wired and inert.~~
+  Partly closed: `:withholds` stays empty, but phases.edn now carries a
+  populated `:refusals` table (per-branch conditions — the task-required rule
+  among them), and `phase-refusal` consults both. A refusal is `:mechanics`
+  with `:policy-refusal? true`, so it feeds the refusal counter, never the
+  cull counter (blt.15).
 - A prediction's `:window` is in turns, so a gate whose advice takes longer than
   its window to follow settles `:unmet` regardless of whether it worked.
-- `:transitions` carries one entry. An artifact-status trigger is available
-  (`ship.clj` emits `:claim-status :confirmed`) and unused.
+- ~~`:transitions` carries one entry; the artifact-status trigger is
+  unused.~~ Closed: both entries are live, and a typo'd effect name warns
+  loudly instead of no-oping (blt.38).
+- `settle` can return `:met-late` (acted on, one turn later than the window
+  asked); it counts as met wherever the tally is read.

--- a/docs/RFCS/RFC-008-tools-and-tasks.md
+++ b/docs/RFCS/RFC-008-tools-and-tasks.md
@@ -119,14 +119,15 @@ indistinguishable from work that is progressing.
 | group | tools |
 |---|---|
 | REPL | `eval` `doc` `complete` |
-| files | `read` `write_file` `edit_file` `grep` |
+| files | `read_file` `write_file` `edit_file` `grep` |
 | shell | `shell` |
-| shipping | `done` `give_up` `branch_theses` |
+| shipping | `done` `give_up` `thesis` `branch_theses` |
 | board | `task` |
 | coordination | `message` |
-| memory | `remember` `recall` |
+| memory | `remember` `recall` `forget` `outcome` |
 | record | `fetch_turn` `fetch_artifact` |
-| self-modification | `cells` `cell` `reload_cells` `manifest` `introspect` `manual` |
+| self-modification | `cells` `cell` `reload_cells` `manifest` `policy` `prompt` `introspect` `manual` |
+| adaptation | `experiment` `verdict` |
 | skills | `skill` |
 | lsp | `lsp` |
 
@@ -176,13 +177,15 @@ per turn: context-block prepends "Current task: …" or "No task claimed."
 
 ## Known gaps
 
-- **The board is encouraged, not enforced.** The context block says "No task
-  claimed" and the prompt says work starts with a task, but nothing refuses a
-  tool call from an unclaimed branch. `phases.edn :withholds` is the mechanism
-  and is empty (RFC-007).
-- The result envelope has no schema. A tool returning a bare string instead of a
-  map NPE'd the loop once (`provenance CR1-1`); the helpers exist to prevent it
-  and nothing enforces their use.
+- ~~The board is encouraged, not enforced.~~ Closed: phases.edn's `:refusals`
+  table carries the work-needs-a-task rule, and a refusal is a policy
+  refusal (`:mechanics` + `:policy-refusal?`), not a failure (blt.15). The
+  claim also survives a resume (blt.21), a switch to the held task is a
+  no-op rather than a silent release, only the holder closes held work, and
+  setting a task's status to `open` clears its holder (blt.34).
+- The result envelope has no schema, but the dispatch wrapper backstops the
+  two observed failure shapes (a bare string, a map with no `:branch`) and
+  redacts the envelope structurally.
 - Pre-v12 claimed rows migrated with `branch_id NULL`, which reads as "on this
   board, nobody holding it" — claimable. The safe reading: the alternative is a
   task no branch can take because it is attributed to one that no longer exists.

--- a/docs/RFCS/RFC-009-storage.md
+++ b/docs/RFCS/RFC-009-storage.md
@@ -150,9 +150,12 @@ system/start!
 
 ## Known gaps
 
-- **Retention is partial.** `events/prune-finished!` exists; `turns`,
-  `artifacts`, `failures` and `gate_firings` grow forever in one shared file
-  (`provenance R2-11` was the finding; only the events half is addressed).
+- ~~Retention is partial: only events prune.~~ Closed:
+  `journal/prune-run-record!` sweeps the detail tables of runs older than
+  `gates.edn :retention :run-record-days`, at run start, FTS mirrors
+  included; the run row itself stays as an index. The knob defaults to nil —
+  the record is kept forever unless an operator decides otherwise, because
+  pruning ends replay and inspectability for the pruned run.
 - `workflows` remains after migration v11 copied its rows into `userspace`.
   Nothing reads it and it is not dropped, so a rollback to a pre-v11 binary
   still resolves.

--- a/resources/cells/beam.clj
+++ b/resources/cells/beam.clj
@@ -534,8 +534,14 @@
 
         The trace is capped hard here. Every mycelium trace entry snapshots the
         whole data map, and this map holds every branch's entire message
-        history — an uncapped trace would be quadratic in the run."
-   :pure true
+        history — an uncapped trace would be quadratic in the run.
+
+        Declared EFFECTFUL although it touches no table: it reset!s the
+        driver's :live-branches teardown atom, and the :pure mark is
+        load-bearing — the mutation soak runs pure cells for real, so a soak
+        of this manifest would have clobbered the record the driver's finally
+        reads (karamazov-blt.35)."
+   :effects [:db]
    :requires [:live-branches]}
   (fn [ctx {:keys [inactive updated children] :as data}]
     (let [next-branches (into (into (vec inactive) updated) children)]

--- a/resources/cells/decompose.clj
+++ b/resources/cells/decompose.clj
@@ -57,7 +57,9 @@
         base (gitdiff/baseline root)
         prob (:problem node)]
     (try
-      (runs/open-branch! conn run-id {:branch-id bid})
+      ;; The unit's contract is the branch's OWN problem, durably — what a
+      ;; resume rebuilds this branch's opening messages from (blt.23).
+      (runs/open-branch! conn run-id {:branch-id bid :problem prob})
       (let [b (state/new-branch {:id bid :problem prob
                                  :messages (turn/initial-messages prob (attempt-suffix node))})
             ;; The attempt's own baseline reaches the worker's ship gate, so the

--- a/resources/cells/feature.clj
+++ b/resources/cells/feature.clj
@@ -203,7 +203,7 @@
         or a revise verdict means the loop is going back anyway. No :verify-cmd
         configured -> not applicable, passes."
    :effects [:proc :db]
-   :requires [:config :conn :root :run-id]}
+   :requires [:config :conn :git-baseline :root :run-id]}
   (fn [{:keys [conn run-id root config] :as ctx} data]
     (let [cmd (get-in config [:run :verify-cmd])]
       (cond

--- a/resources/cells/probe.clj
+++ b/resources/cells/probe.clj
@@ -27,6 +27,7 @@
             [samizdat.agent.infer :as infer]
             [samizdat.agent.phases :as phases]
             [samizdat.agent.state :as state]
+            [samizdat.agent.tools.base :as base]
             [samizdat.config :as config]
             [samizdat.llm.registry :as registry]
             [samizdat.prompt :as prompt]))
@@ -56,7 +57,14 @@
                 (:name parsed)
                 (not= "__parse_error__" (:name parsed))
                 (not (contains? (phases/withholds (:phase branch))
-                                (:name parsed))))))
+                                (:name parsed)))
+                ;; The REFUSALS table too, not just the (empty) withholds —
+                ;; the probe used to pay inference to steer the branch into
+                ;; exactly the refusal it exists to avoid (a task-less branch
+                ;; steered into write_file, then declined by the
+                ;; work-needs-a-task rule) (karamazov-blt.36).
+                (nil? (base/phase-refusal {:branch branch
+                                           :tool-name (:name parsed)})))))
 
 (defn- pick
   "The winning bounce, or nil.

--- a/resources/cells/team.clj
+++ b/resources/cells/team.clj
@@ -88,7 +88,9 @@
   worker's crash is not the team's."
   [{:keys [conn run-id] :as ctx} worker bid idx st prob suffix task-id]
   (try
-    (runs/open-branch! conn run-id {:branch-id bid})
+    ;; The sub-task is the branch's OWN problem, durably — what a resume
+    ;; rebuilds this branch's opening messages from (blt.23).
+    (runs/open-branch! conn run-id {:branch-id bid :problem prob})
     (let [b (state/new-branch {:id bid :problem prob
                                :messages (turn/initial-messages prob suffix)})
           ;; The worker opens HOLDING its part of the board. Claimed here rather
@@ -142,7 +144,7 @@
         :run :subtasks), pass through — an explicit split wins. Otherwise one
         LLM call proposes at most :max-subtasks parts; fail-soft to a single
         worker on the whole problem when the call fails or yields no list."
-   :effects [:net]
+   :effects [:net :db]
    :requires [:config :conn :run-id]}
   (fn [{:keys [conn run-id config] :as ctx}
        {:keys [branch subtasks] :as data}]
@@ -169,7 +171,7 @@
         answers into the manager branch and finish. A dataflow join, not a live
         actor: workers run to completion."
    :effects [:net :db]
-   :requires [:conn :run-id]}
+   :requires [:config :conn :run-id]}
   (fn [{:keys [conn run-id] :as ctx} {:keys [branch subtasks] :as data}]
     (let [tasks (vec (if (seq subtasks) subtasks [(:problem branch)]))
           worker (wf/worker-compiled)
@@ -202,17 +204,26 @@
           ;; :contract, which is what a worker reads.
           title-of (fn [s] (let [t (str/trim (str/replace (str s) #"\s+" " "))]
                              (if (> (count t) 100) (str (subs t 0 100) "…") t)))
-          parent (when (seq subtasks)
-                   (tasks/create! conn {:title (str "Feature: " (title-of (:problem branch)))
-                                        :body (str (:problem branch))
-                                        :type "epic" :run-id run-id}))
-          task-ids (mapv (fn [s]
-                           (tasks/create! conn {:title (title-of s)
-                                                :body (str s)
-                                                :parent-id parent
-                                                :run-id run-id
-                                                :contract (str s)}))
-                         tasks)
+          ;; Created ONCE. A revise round re-enters this cell with the same
+          ;; parts; re-running create! each round left one epic and one full
+          ;; set of duplicate rows per revision, with the prior rounds'
+          ;; released rows still open — making "which parts are still open",
+          ;; the board's whole purpose, unanswerable (karamazov-blt.36). The
+          ;; ids ride the data map; a retry re-claims the SAME row the first
+          ;; attempt released.
+          parent (or (:team/epic data)
+                     (when (seq subtasks)
+                       (tasks/create! conn {:title (str "Feature: " (title-of (:problem branch)))
+                                            :body (str (:problem branch))
+                                            :type "epic" :run-id run-id})))
+          task-ids (or (not-empty (:team/task-ids data))
+                       (mapv (fn [s]
+                               (tasks/create! conn {:title (title-of s)
+                                                    :body (str s)
+                                                    :parent-id parent
+                                                    :run-id run-id
+                                                    :contract (str s)}))
+                             tasks))
           results (->> (map-indexed vector tasks)
                        (mapv (fn [[i s]]
                                (future (run-worker ictx worker (bid-of i) i s
@@ -235,6 +246,8 @@
       (assoc data
              :subtasks tasks
              :results (vec results)
+             :team/epic parent
+             :team/task-ids task-ids
              :branch (assoc branch :final-answer (summarize results))))))
 
 (cell/defcell :team/supervise

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -936,7 +936,13 @@
           :shell-output-chars  8000
           :shared-code-chars   700
           :ledger-claim-chars  180
-          :critic-claim-chars  400}
+          :critic-claim-chars  400
+          ;; The base output budget a truncation RETRY doubles from when the
+          ;; provider config sets no :max-tokens of its own — without it the
+          ;; "retry at a doubled budget" contract silently degraded to a
+          ;; same-budget repeat, reproducing the truncation it exists to
+          ;; escape (blt.38).
+          :retry-base-tokens   8192}
   :kind :cost-ceiling :capability-tunable? false
   :doc "HOW MUCH THE MODEL GETS TO SEE. Every one of these was a constant in
         code, and together they are the most project-specific numbers in the
@@ -1430,8 +1436,11 @@
          which is dirge PR 717's finding arriving as a design property rather
          than a bug fix."
    :when (some? directive)
+   ;; :payload-text is attached by the drains — the payload column is a JSON
+   ;; blob ({"text": "..."}), and rendering it raw framed `{"text":"[watch]
+   ;; ..."}` as the human's words (blt.38).
    :message-form (str "**A human has intervened in this run.**\n\n"
-                      (:payload directive)
+                      (or (:payload-text directive) (:payload directive))
                       "\n\nThis takes precedence over anything the harness has told"
                       " you. Act on it on this turn.")
    :prediction "the branch acts on the directive on the next turn"

--- a/resources/manifests/critic.edn
+++ b/resources/manifests/critic.edn
@@ -19,6 +19,10 @@
          :arbiter        :gate/arbiter
          :route          :loop/route
          :critic         :gate/critic
+         ;; Task reflection on every ending, as the factory loop has (blt.26)
+         ;; — this manifest's header says "everything is the default loop
+         ;; except the critic", and dropping distil was the silent exception.
+         :distil         :memory/distil
          :finish         :loop/finish}
 
  :edges {:start          :infer
@@ -34,11 +38,12 @@
          ;; A genuine done faces the critic first; everything else is unchanged.
          :route          {:continue  :start
                           :done      :critic
-                          :abandoned :finish
-                          :exhausted :finish}
+                          :abandoned :distil
+                          :exhausted :distil}
          ;; The critic either ships the done or sends the branch back to work.
-         :critic         {:ship   :finish
+         :critic         {:ship   :distil
                           :revise :start}
+         :distil         :finish
          :finish         :end}
 
  :dispatches {:parse [[:provider-error (fn [d] (not (:ok (:call d))))]

--- a/resources/manifests/review.edn
+++ b/resources/manifests/review.edn
@@ -16,6 +16,8 @@
          :journal        :journal/record
          :arbiter        :gate/arbiter
          :route          :loop/route
+         ;; Task reflection on every ending, as the factory loop has (blt.26).
+         :distil         :memory/distil
          :finish         :loop/finish}
 
  :edges {:start          :infer
@@ -29,9 +31,10 @@
          :journal        :arbiter
          :arbiter        :route
          :route          {:continue  :start
-                          :done      :finish
-                          :abandoned :finish
-                          :exhausted :finish}
+                          :done      :distil
+                          :abandoned :distil
+                          :exhausted :distil}
+         :distil         :finish
          :finish         :end}
 
  :dispatches {:parse [[:provider-error (fn [d] (not (:ok (:call d))))]

--- a/resources/manifests/reviewer.edn
+++ b/resources/manifests/reviewer.edn
@@ -18,7 +18,9 @@
          :dispatch       :tool/dispatch
          :journal        :journal/record
          :arbiter        :gate/arbiter
-         :route          :loop/route}
+         :route          :loop/route
+         ;; Task reflection on every ending (blt.26).
+         :distil         :memory/distil}
 
  :edges {:start          :infer
          :infer          :parse
@@ -31,9 +33,10 @@
          :journal        :arbiter
          :arbiter        :route
          :route          {:continue  :start
-                          :done      :end
-                          :abandoned :end
-                          :exhausted :end}}
+                          :done      :distil
+                          :abandoned :distil
+                          :exhausted :distil}
+         :distil         :end}
 
  :dispatches {:parse [[:provider-error (fn [d] (not (:ok (:call d))))]
                       [:no-call (fn [d] (let [p (:parsed d)]

--- a/resources/manifests/worker.edn
+++ b/resources/manifests/worker.edn
@@ -15,7 +15,11 @@
          :dispatch       :tool/dispatch
          :journal        :journal/record
          :arbiter        :gate/arbiter
-         :route          :loop/route}
+         :route          :loop/route
+         ;; Task reflection on every ending (blt.26): what this attempt owes
+         ;; the next one is distilled whether the worker runs standalone or
+         ;; composed — the parent decides finishing, not remembering.
+         :distil         :memory/distil}
 
  :edges {:start          :infer
          :infer          :parse
@@ -30,9 +34,10 @@
          ;; :continue iterates; every terminal verdict returns to the parent,
          ;; which reads :verdict to decide finishing vs critique.
          :route          {:continue  :start
-                          :done      :end
-                          :abandoned :end
-                          :exhausted :end}}
+                          :done      :distil
+                          :abandoned :distil
+                          :exhausted :distil}
+         :distil         :end}
 
  :dispatches {:parse [[:provider-error (fn [d] (not (:ok (:call d))))]
                       [:no-call (fn [d] (let [p (:parsed d)]

--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -398,9 +398,15 @@
          ("message" "review")
          (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
              ;; Delivered as a directive on the branch, which the arbiter puts
-             ;; at priority zero — above every machine gate.
-             (assoc acc :branches
-                    (mapv #(if (matches? %) (assoc % :pending-directive d) %) bs)))
+             ;; at priority zero — above every machine gate. :payload-text is
+             ;; the parsed human words; the raw column is a JSON blob and the
+             ;; gate rendered it verbatim (blt.38).
+             (let [d' (assoc d :payload-text
+                             (let [payload (directive-payload d)]
+                               (or (:text payload)
+                                   (when (string? payload) payload))))]
+               (assoc acc :branches
+                      (mapv #(if (matches? %) (assoc % :pending-directive d') %) bs))))
 
          "fork"
          ;; A fork needs no scheduler machinery of its own: `:beam/spawn`
@@ -952,7 +958,16 @@
       (log/info "loop" loop-nm "is a whole-run workflow; beam width forced to 1"
                 "(asked for" (str requested-width ")")))
     (let [initial (mapv #(open-branch! ctx (str "B" (inc %)) nil nil 0) (range width))
-          result (run-rounds ctx initial 1)]
+          result (try (run-rounds ctx initial 1)
+                      (catch Throwable e
+                        ;; A crash is an outcome too: a workflow that crashes
+                        ;; five times showing "no runs" in the selection
+                        ;; history taught the chooser nothing (blt.38).
+                        (try (knowledge/record-workflow-outcome!
+                              conn {:workflow loop-nm :run-id run-id
+                                    :shipped? false})
+                             (catch Throwable _ nil))
+                        (throw e)))]
       ;; HOW THIS WORKFLOW WENT, for the next run's choice. A run only ever
       ;; sees its own attempt, so `direct attempts on this project keep getting
       ;; stuck` is not something any single run can notice — it has to be

--- a/src/samizdat/agent/critic.clj
+++ b/src/samizdat/agent/critic.clj
@@ -75,14 +75,20 @@
         ;; Built from the rubric rather than written beside it. The names and
         ;; the range are gates.edn, and a pattern that named them again would
         ;; be a second copy that a retune silently leaves behind.
+        ;; \\d+ with a NUMERIC bounds check, not a character class built
+        ;; from the range: [1-10] parses as "1, hyphen, 0", so any retune of
+        ;; :critic-scale past 9 silently failed every parse and the critic
+        ;; went dark (karamazov-blt.38).
         pattern (re-pattern (str "(?i)SCORE\\s+("
                                  (str/join "|" (map name objs))
-                                 ")\\s*:\\s*([" min "-" max "])\\s*"))
+                                 ")\\s*:\\s*(\\d+)\\s*"))
         t (message/strip-think-blocks text)
         m (into {}
                 (keep (fn [line]
                         (when-let [[_ obj v] (re-matches pattern (str/trim line))]
-                          [(keyword (str/lower-case obj)) (parse-long v)])))
+                          (let [n (parse-long v)]
+                            (when (and n (<= min n max))
+                              [(keyword (str/lower-case obj)) n])))))
                 (str/split-lines t))]
     (when (= (count objs) (count m)) m)))
 

--- a/src/samizdat/agent/decompose.clj
+++ b/src/samizdat/agent/decompose.clj
@@ -30,13 +30,18 @@
 ;; :decompose-max-parts) — cost ceilings, since each level of recursion
 ;; multiplies sub-agents.
 
-(def max-depth
+(defn max-depth
   "How deep the split recursion may go before a stuck unit is a hard failure
   rather than split again. Kept shallow: each level multiplies sub-agents, and a
-  unit that still won't pass its tests three levels down is not a size problem."
+  unit that still won't pass its tests three levels down is not a size problem.
+
+  A FUNCTION: a top-level def froze the gates.edn value at namespace load —
+  the exact bug generation-cache fixed everywhere else — so a retune (or the
+  project's own policy after bind) never took effect (blt.38)."
+  []
   (gates/threshold :decompose-max-depth))
 
-(def default-max-parts (gates/threshold :decompose-max-parts))
+(defn default-max-parts [] (gates/threshold :decompose-max-parts))
 
 (defn architect-prompt
   "Ask the architect to diagnose a stuck unit and choose to split it or hint a
@@ -59,8 +64,8 @@
      :last-answer (not-empty (str/trim (str last-answer)))
      :last-failure (not-empty (str/trim (str last-failure)))
      :force-split (boolean (or fresh-failed force-split))
-     :max-parts default-max-parts
-     :last-round (>= (or depth 0) (dec max-depth))}))
+     :max-parts (default-max-parts)
+     :last-round (>= (or depth 0) (dec (max-depth)))}))
 
 (defn- normalize-subtask [m]
   (let [name (some-> (or (get m "name") (get m :name)) str str/trim not-empty)
@@ -139,7 +144,7 @@
   node is a stable subassembly: it passed its own tests, so a parent that
   composes it never re-litigates it."
   [node depth {:keys [attempt recover fan max-depth] :as ops}]
-  (let [max-d (or max-depth samizdat.agent.decompose/max-depth)
+  (let [max-d (or max-depth (samizdat.agent.decompose/max-depth))
         r (attempt node)]
     (if (:passed? r)
       {:status :landed :answer (:answer r) :node node}
@@ -202,7 +207,7 @@
              ;; a decompose degrades to a fresh approach.
              want-split? (and (= decision "decompose")
                               (seq subtasks)
-                              (< depth (dec max-depth)))]
+                              (< depth (dec (max-depth))))]
          (cond
            want-split? {:kind :decompose :reason reason :subtasks subtasks}
            (or hint (= decision "fresh_approach"))

--- a/src/samizdat/agent/files.clj
+++ b/src/samizdat/agent/files.clj
@@ -202,13 +202,24 @@
         fn* (count flines)
         starts (reductions + 0 (map #(inc (count %)) clines))]
     (when (and (pos? fn*) (<= fn* (count clines)))
-      (for [i (range (inc (- (count clines) fn*)))
-            :let [block (subvec (vec clines) i (+ i fn*))]
-            :when (every? true? (map #(= (str/trim %1) (str/trim %2)) block flines))]
-        (let [start (nth starts i)
-              end (reduce + start (concat (map count block)
-                                          (repeat (dec fn*) 1)))]
-          [start end])))))
+      ;; NON-OVERLAPPING, greedily from the top: a multi-line needle like
+      ;; "a\na" matches at consecutive lines of "a\na\na", and the reverse
+      ;; splice then wrote new-text into a region the previous replacement had
+      ;; already rewritten, corrupting the file under replace_all (blt.38).
+      (let [all (for [i (range (inc (- (count clines) fn*)))
+                      :let [block (subvec (vec clines) i (+ i fn*))]
+                      :when (every? true? (map #(= (str/trim %1) (str/trim %2))
+                                               block flines))]
+                  (let [start (nth starts i)
+                        end (reduce + start (concat (map count block)
+                                                    (repeat (dec fn*) 1)))]
+                    [start end]))]
+        (reduce (fn [acc [start end :as r]]
+                  (if (and (seq acc) (< start (second (peek acc))))
+                    acc
+                    (conj acc r)))
+                []
+                all)))))
 
 (defn- line-of [starts pos]
   (inc (count (take-while #(<= % pos) (rest starts)))))

--- a/src/samizdat/agent/infer.clj
+++ b/src/samizdat/agent/infer.clj
@@ -152,8 +152,13 @@
   ([ctx {:keys [journal?] :or {journal? true}}]
    (fn [{:keys [id prefill force-tool] :as tape}]
      (loop [attempt 1]
-       (let [budget (when-let [base (:max-tokens (:llm-config ctx))]
-                      (* base (bit-shift-left 1 (dec attempt))))
+       (let [base (or (:max-tokens (:llm-config ctx))
+                      ;; No configured cap: the FIRST attempt keeps the
+                      ;; provider's default, but a retry exists to buy room —
+                      ;; doubling nothing was a same-budget repeat (blt.38).
+                      (when (> attempt 1)
+                        (:retry-base-tokens (gates/threshold :context-budget))))
+             budget (when base (* base (bit-shift-left 1 (dec attempt))))
              r (try
                  {:ok true
                   :response (llm/chat (:llm-adapter ctx) (:llm-config ctx)

--- a/src/samizdat/agent/loop.clj
+++ b/src/samizdat/agent/loop.clj
@@ -450,7 +450,13 @@
             (case effect
               :mark-green    (state/mark-green b)
               :clear-reframe (state/clear-reframe b)
-              b))
+              ;; phases.edn is runtime-editable, so a typo'd effect name has
+              ;; to SAY something — a silent no-op reads as the transition
+              ;; working (blt.38).
+              (do (log/warn "phases.edn :transitions names an effect this loop"
+                            "does not implement:" effect
+                            "— known: :mark-green :clear-reframe")
+                  b)))
           branch
           (transition-effects {:result result :artifact artifact})))
 
@@ -614,7 +620,16 @@
            (if (and beam? (not scoped-here?))
              b ;; run-wide: the beam broadcasts it to every branch at the round top
              (do (interventions/resolve! conn run-id (:id d) :applied nil turn)
-                 (assoc b :pending-directive d)))
+                 ;; :payload-text = the parsed human words; the raw column is
+                 ;; a JSON blob the gate would render verbatim (blt.38).
+                 (assoc b :pending-directive
+                        (assoc d :payload-text
+                               (let [payload (or (try (json/read-str (str (:payload d))
+                                                                     :key-fn keyword)
+                                                      (catch Throwable _ nil))
+                                                 {})]
+                                 (or (:text payload)
+                                     (when (string? payload) payload)))))))
 
            "extend"
            (if beam?
@@ -667,7 +682,11 @@
   [{:keys [conn run-id max-turns] :as ctx} before branch turn {:keys [parsed result]}]
   (let [tool (:name parsed)
         branch (settle-predictions! conn branch turn [tool] before branch)
-        branch (drain-directives! ctx branch turn)
+        ;; Not on a done turn: the done path renders no steer, so a directive
+        ;; drained here was resolved "applied" and never shown (blt.38). Left
+        ;; pending, it reaches whoever can still act — another branch, or the
+        ;; queue's history as honestly undelivered.
+        branch (if (:done? result) branch (drain-directives! ctx branch turn))
         ;; The cap the gates reason against includes whatever `extend`
         ;; directives have granted this branch — otherwise last-call and the
         ;; turn-budget notices keep firing against the spent original cap

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -150,6 +150,11 @@
   the safe-state rule from its 'otherwise' arm."
   [run branch-row turns artifacts firings max-turns]
   (let [branch-id (:id branch-row)
+        ;; The branch's OWN problem where it has one — a decompose unit's
+        ;; contract, a team worker's sub-task — else the run's. Rebuilding
+        ;; every branch on the run-level problem re-aimed every worker at the
+        ;; top-level feature text (karamazov-blt.23).
+        problem (or (not-empty (str (:problem branch-row))) (:problem run))
         branch-turns (get turns branch-id [])
         ;; The phase is rebuilt from the banked sketch artifacts: a sketch on
         ;; record means the branch left explore, and its turn is the phase
@@ -161,9 +166,9 @@
                            artifact-maps)
         base (-> (state/new-branch {:id branch-id
                                     :parent-id (:parent_id branch-row)
-                                    :problem (:problem run)
+                                    :problem problem
                                     :created-at-turn (:created_at_turn branch-row)
-                                    :messages (messages-from-turns (:problem run)
+                                    :messages (messages-from-turns problem
                                                                    branch-turns)})
                  (assoc :status (keyword (:status branch-row))
                         :inactive-reason (:inactive_reason branch-row)

--- a/src/samizdat/agent/state.clj
+++ b/src/samizdat/agent/state.clj
@@ -785,8 +785,12 @@
                                         "\n  → " (:reason f)))))
       :gate-tally (when (seq (:gate-tally r))
                     (str/join "\n" (for [g (:gate-tally r)]
+                                     ;; met-late IS met — acting a turn later
+                                     ;; is acting. Omitting it rendered a gate
+                                     ;; that settled met-late 3x as "3 fired,
+                                     ;; 0 met" (blt.38).
                                      (str "- " (:gate g) ": " (:fired g) " fired, "
-                                          (or (:met g) 0) " met, "
+                                          (+ (or (:met g) 0) (or (:met-late g) 0)) " met, "
                                           (or (:unmet g) 0) " unmet, "
                                           (or (:open g) 0) " open"))))})))
 

--- a/src/samizdat/agent/tools/tasks.clj
+++ b/src/samizdat/agent/tools/tasks.clj
@@ -168,6 +168,13 @@
         (or (want :id) (want :reason)
             (let [held (holding conn branch)
                   reason (str (base/arg ctx :reason))]
+              (if (and held (= (:id held) (base/arg ctx :id)))
+                ;; Switching to what you already hold: a no-op, NOT a
+                ;; claim-then-release — the idempotent re-claim succeeded and
+                ;; the release then set the row back to open while the branch
+                ;; kept working it, so a sibling could claim the same task
+                ;; (karamazov-blt.34).
+                (base/ok branch (str "Already working on " (task-line held)))
               (if-let [t (tasks/claim! conn (base/arg ctx :id) run-id (:id branch))]
                 (do
                   ;; The task being set down goes back to the board rather than
@@ -190,12 +197,28 @@
                                 "\nRecorded why: " reason)
                            :progress? true))
                 (base/malformed branch (str "Cannot switch to " (base/arg ctx :id)
-                                       ": no such task, or another run holds it.")))))
+                                       ": no such task, or another run holds it."))))))
 
         "close"
         (or (want :id)
-            (if-not (tasks/get-task conn (base/arg ctx :id))
-              (base/malformed branch (str "No task " (base/arg ctx :id) "."))
+            (let [row (tasks/get-task conn (base/arg ctx :id))]
+              (cond
+                (not row)
+                (base/malformed branch (str "No task " (base/arg ctx :id) "."))
+
+                ;; Only the holder closes held work. Any branch could close a
+                ;; sibling's in-progress task — "tidying the board" away from
+                ;; under the branch working it (karamazov-blt.34). Unheld
+                ;; rows stay closable by anyone: cancelling backlog is
+                ;; bookkeeping, not theft.
+                (and (some? (:branch_id row))
+                     (not= (:branch_id row) (:id branch)))
+                (base/malformed branch
+                                (str "Task " (:id row) " is held by "
+                                     (:branch_id row) "; only the holder"
+                                     " closes it."))
+
+                :else
               (let [t (tasks/close! conn (base/arg ctx :id) (or (base/arg ctx :status) "done"))
                     ;; Closing the CURRENT task clears the slot, so the next
                     ;; context block asks for the next one instead of pointing
@@ -203,7 +226,7 @@
                     branch (cond-> branch
                              (= (:id t) (:id (:task branch))) (assoc :task nil))]
                 (base/ok branch (str "Closed " (task-line t))
-                         :progress? true))))
+                         :progress? true)))))
 
         (base/malformed branch (str "Unknown task action `" action "`. " task-usage)))
       (catch Throwable e

--- a/src/samizdat/api/control.clj
+++ b/src/samizdat/api/control.clj
@@ -84,6 +84,13 @@
         beam-width (or (:beam_width body) (:beam-width body))
         seed-run (or (:seed_run body) (:seed-run body))
         quarantine (or (:quarantine body) (get body "quarantine"))]
+  ;; A {} body used to start a REAL run on a nil problem — a selection model
+  ;; call plus a full beam of provider spend answering nothing, while
+  ;; /v1/chat/completions 400s the same input (blt.38).
+  (if (str/blank? (str problem))
+    {:status 400
+     :body {:error {:message "a run needs a non-blank `problem`"
+                    :type "invalid_request_error"}}}
   (let [llm-config (run-llm-config (:llm config) body)
         adapter (registry/adapter-for (:provider llm-config))
         abort (atom false)
@@ -133,7 +140,7 @@
       ;; the status code read this as a started run, which is why gui.api's
       ;; start-run! had to unwrap the body to find out otherwise.
       {:status 503
-       :body {:error {:message "the run did not start within 30s"}}}))))
+       :body {:error {:message "the run did not start within 30s"}}})))))
 
 (defn abort!
   "Stop a run without asking it to cooperate. The flag is checked at the top of
@@ -235,6 +242,18 @@
       {:status 400
        :body {:error {:message "a grant intervention needs payload.pattern — the shell glob to allow"
                      :run_id run-id}}})
+    (if-let [run (let [r (runs/get-run conn run-id)]
+                   (when (or (nil? r)
+                             (contains? #{"completed" "aborted" "failed"} (:status r)))
+                     (or r ::absent)))]
+      ;; A directive against a run that does not exist or has ended would sit
+      ;; `pending` forever — the UI showing an intervention that will never
+      ;; resolve (blt.38).
+      (if (= ::absent run)
+        {:status 404 :body {:error {:message (str "no run " run-id)}}}
+        {:status 409 :body {:error {:message (str "run " run-id " is already "
+                                                  (:status run))
+                                    :run_id run-id}}})
     (if-not (contains? interventions/kinds (:kind body))
       ;; provenance R3-12: this reached submit!'s throw and surfaced as the
       ;; server's catch-all 500. An unknown kind is the client's mistake.
@@ -253,6 +272,6 @@
           :status "pending"
           ;; Said plainly rather than implied, because the difference between
           ;; accepted and applied is the thing a UI most easily lies about.
-          :note "Queued. It applies at the branch's next turn boundary, not now."}}))))
+          :note "Queued. It applies at the branch's next turn boundary, not now."}})))))
 
 (defn kinds [] {:kinds interventions/kinds})

--- a/src/samizdat/llm/message.clj
+++ b/src/samizdat/llm/message.clj
@@ -203,7 +203,7 @@
              ;; problem. tape/due-indices deliberately knows nothing about
              ;; which leading messages are load-bearing, so the frame is
              ;; protected here, by the caller that owns it.
-             due (remove #(< % 2)
+             due (remove #(< % frame-size)
                          (tape/due-indices messages keep-pairs compactable-roles))]
          (reduce (fn [ms i]
                    (tape/compact-at ms i

--- a/src/samizdat/memory.clj
+++ b/src/samizdat/memory.clj
@@ -137,12 +137,15 @@
         (- (double (or salience (base-salience :note p))) (:disuse-decay p)))))
 
 (defn rank
-  "Memories, most worth reading first. Ties break on recency, because between
-  two memories of equal standing the newer one is the more likely to still be
-  true."
+  "Memories, most worth reading first. TIES KEEP THE CALLER'S ORDER: sort-by
+  is stable, so memories of equal standing stay in the order the text search
+  ranked them — bm25 relevance from the FTS path, newest-first from the LIKE
+  scan. The old created_at tie key threw that second opinion away (and
+  delivered oldest-first while its docstring promised recency —
+  karamazov-blt.38): a two-term bm25 winner lost its place to a one-term
+  match that happened to be newer."
   ([rows] (rank rows (policy) (java.time.Instant/now)))
   ([rows p now]
    (->> rows
-        (sort-by (juxt #(- (effective-salience % p now))
-                       #(str (:created_at %))))
+        (sort-by #(- (effective-salience % p now)))
         vec)))

--- a/src/samizdat/mutation.clj
+++ b/src/samizdat/mutation.clj
@@ -72,6 +72,11 @@
                                                   (or soak-input {}))}
                        (catch Throwable e {:error (or (ex-message e) (str e))})))
             outcome (deref fut soak-timeout-ms ::timeout)]
+        (when (= ::timeout outcome)
+          ;; Best effort: a looping candidate otherwise burns a thread forever
+          ;; per rejected edit (blt.38). Cancellation may not interrupt a
+          ;; tight loop, but a cancellable wait dies here instead of never.
+          (try (future-cancel fut) (catch Throwable _ nil)))
         (cond
           (= ::timeout outcome)
           "soak did not terminate within the time budget — the edited cell may loop"

--- a/src/samizdat/security/policy.clj
+++ b/src/samizdat/security/policy.clj
@@ -381,7 +381,13 @@
                                           (str/join " or "
                                                     (map #(str "`" % "`")
                                                          (complex-markers-in command))))})
-       :policy {:effect :ask :suggest (str head " *")}}
+       :policy {:effect :ask
+                ;; No grant unlocks a COMPLEX command (invariant 5 downgrades
+                ;; it to :ask even over a grant), so suggesting `head *` for
+                ;; one taught a fix that could not work — the observed
+                ;; same-wall-twice loop through the grant path (blt.38). The
+                ;; refusal text already teaches "issue these separately".
+                :suggest (when-not complex? (str head " *"))}}
 
       :allow
       (let [resolved (secrets/resolve-refs command env)

--- a/src/samizdat/store/migrations.clj
+++ b/src/samizdat/store/migrations.clj
@@ -524,6 +524,15 @@
                           AND u2.name = userspace.name
                           AND u2.version > 1)"])
 
+(def ^:private v18
+  ;; A branch's OWN problem. Sub-workflow branches do not work the run-level
+  ;; problem: a decompose unit's branch opens on its unit CONTRACT, a team
+  ;; worker on its sub-task. Nothing durable recorded that, so a resume
+  ;; rebuilt every branch on the top-level feature text with no role framing —
+  ;; re-aiming every worker at the wrong job (karamazov-blt.23). NULL means
+  ;; "the run's problem", which is what every branch before this column meant.
+  ["ALTER TABLE branches ADD COLUMN problem TEXT"])
+
 (def migrations
   "Ordered. Index 0 is migration 1; PRAGMA user_version holds the count applied."
-  [v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17])
+  [v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15 v16 v17 v18])

--- a/src/samizdat/store/runs.clj
+++ b/src/samizdat/store/runs.clj
@@ -189,12 +189,16 @@
    (db/fetch conn ["SELECT * FROM runs ORDER BY started_at DESC LIMIT ?" limit])))
 
 (defn open-branch!
-  [conn run-id {:keys [branch-id parent-id created-at-turn]}]
+  "`:problem` is the branch's OWN problem when it differs from the run's — a
+  decompose unit's contract, a team worker's sub-task — and nil for a branch
+  working the run-level problem. It is what a resume rebuilds the branch's
+  opening messages from (karamazov-blt.23)."
+  [conn run-id {:keys [branch-id parent-id created-at-turn problem]}]
   (db/with-writer
     (db/execute! conn
-                   ["INSERT INTO branches (id, run_id, parent_id, status, created_at_turn)
-                     VALUES (?, ?, ?, 'active', ?)"
-                    branch-id run-id parent-id (or created-at-turn 0)]))
+                   ["INSERT INTO branches (id, run_id, parent_id, status, created_at_turn, problem)
+                     VALUES (?, ?, ?, 'active', ?, ?)"
+                    branch-id run-id parent-id (or created-at-turn 0) problem]))
   (journal/note! conn run-id :branch-opened
                  {:branch-id branch-id :data {:parent parent-id}})
   branch-id)

--- a/src/samizdat/store/tasks.clj
+++ b/src/samizdat/store/tasks.clj
@@ -131,6 +131,11 @@
                  body (assoc :body body)
                  type (assoc :type type)
                  status (assoc :status status :closed_at closed-at)
+                 ;; `open` MEANS claimable (RFC-008: branch_id NULL is the
+                 ;; claimable state). Setting status open while the holder
+                 ;; stayed attributed produced a row that read open but that
+                 ;; claim!'s guard refused to everyone (karamazov-blt.34).
+                 (= "open" status) (assoc :branch_id nil)
                  priority (assoc :priority priority)
                  parent-id (assoc :parent_id parent-id)
                  run-id (assoc :run_id run-id)

--- a/src/samizdat/system.clj
+++ b/src/samizdat/system.clj
@@ -35,6 +35,7 @@
             [jolt.time]
             [jolt.http.platform :as platform]
             [ring-chez.adapter :as adapter]
+            [samizdat.api.control :as api-control]
             [samizdat.agent.gates :as gates]
             [samizdat.agent.phases :as phases]
             [samizdat.lexicon :as lexicon]
@@ -158,7 +159,25 @@
   stop the Lisp task regardless of what the agent believed."
   []
   (when-let [s @system]
-    (doseq [[label f] [["http server" #(adapter/stop-server (:server s))]
+    (doseq [[label f] [;; Active runs FIRST, before anything they depend on
+                       ;; closes under them: set every abort flag and give the
+                       ;; run threads a bounded window to reach a boundary and
+                       ;; journal their ending. Tearing the db down while run
+                       ;; futures kept executing meant their writes — including
+                       ;; the crash record — landed on a closed handle, and a
+                       ;; restart!'s reconcile-orphans! marked still-executing
+                       ;; runs interrupted while their threads kept going
+                       ;; (karamazov-blt.14).
+                       ["active runs"
+                        #(let [runs @api-control/active]
+                           (doseq [[_ {:keys [abort]}] runs]
+                             (when abort (reset! abort true)))
+                           (doseq [[rid {:keys [future]}] runs]
+                             (when future
+                               (when (= ::hung (deref future 15000 ::hung))
+                                 (log/warn "run" rid "did not stop within 15s;"
+                                           "closing the system under it")))))]
+                       ["http server" #(adapter/stop-server (:server s))]
                        ["lsp clients" #(lsp-client/shutdown-all!)]
                        ;; Unbind BEFORE the connection closes: a userspace read
                        ;; against a closed handle would throw where the same

--- a/test/samizdat/control_test.clj
+++ b/test/samizdat/control_test.clj
@@ -129,7 +129,8 @@
                               (let [rid (str (random-uuid))]
                                 (on-start rid)
                                 {:run-id rid :status :completed}))]
-      (let [r (api-control/start-run! {:conn c :config {:llm {:provider :local}}} {})
+      (let [r (api-control/start-run! {:conn c :config {:llm {:provider :local}}}
+                                      {:problem "p"})
             rid (:run_id (:body r))]
         (is (= "running" (:status (:body r))))
         (let [gone? (loop [n 0]
@@ -436,23 +437,70 @@
         (let [row (first (filter #(= "B2" (:id %)) (runs/branches c rid)))]
           (is (= "culled" (:status row)) "the row is closed, not a zombie"))))))
 
-(deftest a-chat-completion-run-is-registered-and-abortable
-  ;; blt.13: beam/run! was called with no :abort atom and no control/active
-  ;; registration, so POST /v1/runs/:id/abort answered 409 "no active run"
-  ;; for a genuinely running run, for its whole (potentially hours-long) life.
+(deftest a-resumed-branch-still-holds-its-task
+  ;; karamazov-blt.21: the claim survives the crash on its ROW, but the
+  ;; rebuilt branch came back with no :task — told "No task claimed", free to
+  ;; claim a SECOND task, with the old row in_progress and attributed to it
+  ;; forever: RFC-008's named worst state for a shared board.
   (with-db [c]
-    (let [seen (atom nil)]
-      (with-redefs [beam/run!
-                    (fn [{:keys [abort on-start]}]
-                      (is (some? abort) "an abort atom reaches the run")
-                      (on-start "r-oai")
-                      (reset! seen (contains? @api-control/active "r-oai"))
-                      {:status :completed :run-id "r-oai" :answer "a"})]
-        (openai/chat-completion {:conn c :config {:llm {:provider :local :model "m"}}}
-                                {:messages [{:role "user" :content "q"}]})
-        (is (true? @seen) "the run was visible to the abort endpoint while live")
-        (is (not (contains? @api-control/active "r-oai"))
-            "and deregistered when it finished")))))
+    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (let [t-id (tasks/create! c {:title "the part" :body "do it" :run-id rid})]
+        (is (some? (tasks/claim! c t-id rid "B1")))
+        (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
+          (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
+                                   :llm-config {} :run-id rid})
+                b (first (:branches r))]
+            (is (= t-id (get-in b [:task :id]))
+                "the branch knows what it holds again")
+            (is (some :pinned? (:messages b))
+                "and the pinned task statement is back in its context")))))))
+
+(deftest a-resumed-worker-keeps-its-own-problem
+  ;; karamazov-blt.23: sub-workflow branches (a decompose unit, a team worker)
+  ;; open on their own contract, stored on the branches row since v18 — and
+  ;; the rebuild must actually READ it. The first cut bound it and then kept
+  ;; using the run's problem anyway; this is the test that catches the
+  ;; half-wire.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "the whole feature"
+                                  :max-turns 10 :beam-width 1})]
+      (runs/open-branch! c rid {:branch-id "W0" :problem "part A only"})
+      (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
+        (let [b (first (:branches (resume/resume! {:conn c :config {}
+                                                   :llm-adapter :a :llm-config {}
+                                                   :run-id rid})))]
+          (is (= "part A only" (:problem b))
+              "the branch's own contract, not the run-level feature text")
+          (is (some #(str/includes? (str (:content %)) "part A only")
+                    (:messages b))
+              "and its opening messages are rebuilt from it"))))))
+
+(deftest replay-applies-the-live-loops-call-discipline
+  ;; karamazov-blt.22: replay pushed EVERY journalled row through add-turn +
+  ;; record-outcome, but the live loop applies neither to a provider-error row
+  ;; and only record-outcome to a no-call row — so each provider error
+  ;; DECREMENTED consecutive-failures on replay and the resumed branch's
+  ;; counters diverged from the ones the run actually had.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 1 :tool-name "eval"
+                                   :args {} :result "boom" :category "failure"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 2
+                                   :tool-name "__provider_error__"
+                                   :result "timeout" :category "neutral"})
+      (journal/record-turn! c rid {:branch-id "B1" :turn 3
+                                   :tool-name "__no_call__"
+                                   :result "no fence" :category "mechanics"})
+      (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
+        (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
+                                 :llm-config {} :run-id rid})
+              b (first (:branches r))]
+          (is (= 1 (:consecutive-failures b))
+              "the provider error neither decrements nor resets the counter")
+          (is (= 1 (count (:turns b)))
+              "and only the real tool turn entered the branch's own log"))))))
 
 (deftest the-last-active-branch-survives-beside-inactive-siblings
   ;; karamazov-blt.17: the cull cell seeded its survivor count with (count
@@ -523,47 +571,20 @@
           (is (true? (:fast r3)) "once the dangling turn completes, the branch advances")
           (is (not (contains? @in-flight "B1")) "and the memory is released"))))))
 
-(deftest a-resumed-branch-still-holds-its-task
-  ;; karamazov-blt.21: the claim survives the crash on its ROW, but the
-  ;; rebuilt branch came back with no :task — told "No task claimed", free to
-  ;; claim a SECOND task, with the old row in_progress and attributed to it
-  ;; forever: RFC-008's named worst state for a shared board.
+(deftest a-chat-completion-run-is-registered-and-abortable
+  ;; blt.13: beam/run! was called with no :abort atom and no control/active
+  ;; registration, so POST /v1/runs/:id/abort answered 409 "no active run"
+  ;; for a genuinely running run, for its whole (potentially hours-long) life.
   (with-db [c]
-    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
-      (runs/open-branch! c rid {:branch-id "B1"})
-      (let [t-id (tasks/create! c {:title "the part" :body "do it" :run-id rid})]
-        (is (some? (tasks/claim! c t-id rid "B1")))
-        (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
-          (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
-                                   :llm-config {} :run-id rid})
-                b (first (:branches r))]
-            (is (= t-id (get-in b [:task :id]))
-                "the branch knows what it holds again")
-            (is (some :pinned? (:messages b))
-                "and the pinned task statement is back in its context")))))))
-
-(deftest replay-applies-the-live-loops-call-discipline
-  ;; karamazov-blt.22: replay pushed EVERY journalled row through add-turn +
-  ;; record-outcome, but the live loop applies neither to a provider-error row
-  ;; and only record-outcome to a no-call row — so each provider error
-  ;; DECREMENTED consecutive-failures on replay and the resumed branch's
-  ;; counters diverged from the ones the run actually had.
-  (with-db [c]
-    (let [rid (runs/start-run! c {:problem "p" :max-turns 10 :beam-width 1})]
-      (runs/open-branch! c rid {:branch-id "B1"})
-      (journal/record-turn! c rid {:branch-id "B1" :turn 1 :tool-name "eval"
-                                   :args {} :result "boom" :category "failure"})
-      (journal/record-turn! c rid {:branch-id "B1" :turn 2
-                                   :tool-name "__provider_error__"
-                                   :result "timeout" :category "neutral"})
-      (journal/record-turn! c rid {:branch-id "B1" :turn 3
-                                   :tool-name "__no_call__"
-                                   :result "no fence" :category "mechanics"})
-      (with-redefs [beam/run-rounds (fn [_ branches _] {:branches branches})]
-        (let [r (resume/resume! {:conn c :config {} :llm-adapter :a
-                                 :llm-config {} :run-id rid})
-              b (first (:branches r))]
-          (is (= 1 (:consecutive-failures b))
-              "the provider error neither decrements nor resets the counter")
-          (is (= 1 (count (:turns b)))
-              "and only the real tool turn entered the branch's own log"))))))
+    (let [seen (atom nil)]
+      (with-redefs [beam/run!
+                    (fn [{:keys [abort on-start]}]
+                      (is (some? abort) "an abort atom reaches the run")
+                      (on-start "r-oai")
+                      (reset! seen (contains? @api-control/active "r-oai"))
+                      {:status :completed :run-id "r-oai" :answer "a"})]
+        (openai/chat-completion {:conn c :config {:llm {:provider :local :model "m"}}}
+                                {:messages [{:role "user" :content "q"}]})
+        (is (true? @seen) "the run was visible to the abort endpoint while live")
+        (is (not (contains? @api-control/active "r-oai"))
+            "and deregistered when it finished")))))

--- a/test/samizdat/decompose_test.clj
+++ b/test/samizdat/decompose_test.clj
@@ -32,7 +32,7 @@
     (is (str/includes? p "FRESH_APPROACH"))))
 
 (deftest architect-prompt-forces-fresh-approach-at-the-depth-edge
-  (let [p (dec/architect-prompt {:problem "x"} {:depth (dec dec/max-depth)})]
+  (let [p (dec/architect-prompt {:problem "x"} {:depth (dec (dec/max-depth))})]
     (is (str/includes? p "MUST choose FRESH_APPROACH"))))
 
 (deftest parse-decision-reads-a-decompose
@@ -55,7 +55,7 @@
   (testing "a decompose too deep degrades to a fresh approach, not a split"
     (let [d (dec/parse-decision
              "{\"decision\":\"decompose\",\"subtasks\":[{\"name\":\"a\",\"description\":\"x\"}]}"
-             (dec dec/max-depth))]
+             (dec (dec/max-depth)))]
       (is (= :fresh-approach (:kind d)) "no split at the depth edge"))))
 
 (deftest parse-decision-degrades-a-subtaskless-decompose
@@ -114,7 +114,7 @@
     (is (contains? (set @attempts) "root/b"))))
 
 (deftest solve-fails-hard-at-the-depth-budget
-  (let [r (dec/solve {:id "x" :problem "p"} dec/max-depth
+  (let [r (dec/solve {:id "x" :problem "p"} (dec/max-depth)
                      {:attempt (constantly {:passed? false :failure "nope"})
                       :recover (fn [& _] {:kind :decompose :subtasks [{:name "a" :description "x"}]})
                       :fan seq-fan})]


### PR DESCRIPTION
Sixth and final audit PR:

- `system/stop!` aborts registered runs first, bounded wait, before closing the db under them (blt.14)
- migration v18: per-branch `problem` column; team/decompose store it, resume reads it — with the regression test that caught the first cut's half-wire (blt.23)
- `:memory/distil` wired into worker/reviewer/critic/review manifests (blt.26)
- task holder guards: switch-to-held no-op, holder-only close, `open` clears the holder (blt.34)
- honest cell declarations (`:beam/tick` effectful; missing `:requires`) (blt.35)
- probe consults `phases/refusals`; team revise rounds reuse their board rows (blt.36)
- the fifteen-item low bundle (blt.38) — details in the bead's close reason
- RFC sweep under the intent-first rule (blt.39): code was fixed where the RFC held the intent; only deliberate realities got doc updates

Suite: 1337 tests, 4765 assertions, green.