### PR TITLE
drop the dead session registries; unpin superseded task statements

### DIFF
--- a/src/samizdat/agent/beam.clj
+++ b/src/samizdat/agent/beam.clj
@@ -813,12 +813,10 @@
                         (count verdicts) "verdict(s) into memory")))
           (catch Throwable e
             (log/warn "distilling the session failed:" (ex-message e))))
-        ;; The proof engines' teardown lived here: scheduler-opened sessions
-        ;; from the `sessions` atom, plus everything a tool opened via
-        ;; :engine-sessions, disposed no matter how the run ended. Per-branch
-        ;; disposal still runs through dispose-branch-engines!, so the coding
-        ;; tools' sessions (nREPL, subprocesses) plug their disposal back in
-        ;; here.
+        ;; The proof engines' scheduler- and tool-opened session registries
+        ;; are gone with the engines (karamazov-w7w); what a branch holds now
+        ;; — its eval session — is disposed per branch, no matter how the
+        ;; run ended.
         (doseq [b @live-branches] (dispose-branch-engines! b))
         ;; The run's eval namespace does not outlive the run
         ;; (provenance CR1-6). Best effort, and only for a session this
@@ -882,15 +880,6 @@
                                                    {:quarantine quarantine}))
         ;; Every session ever opened, including forked children, so the
         ;; supervisor can tear them all down regardless of how the run ended.
-        ;; The stop path must not depend on the agent's state — the RAX
-        ;; manager could always halt the Lisp task no matter what it believed.
-        sessions (atom [])
-        ;; Same reason as `sessions` above, for the engines whose sessions a
-        ;; TOOL opens rather than the scheduler. Collecting those off the
-        ;; branches at the end assumed every branch value survives, and three
-        ;; paths discard one: the tool-level catch, the turn deadline, and a
-        ;; turn that throws. See tools/register-session! (vf-cfp).
-        engine-sessions (atom [])
         ;; The three ctx keys the manifest driver set and this one did not.
         ;; Every consumer defends with `(or root ".")` or a nil check, so the
         ;; omission was silent: `:run :root` was documented and ignored, every
@@ -920,8 +909,6 @@
              ;; persist across its turns and die with the run. run-rounds
              ;; closes it in the same finally that disposes the sessions.
              :repl-session (repl/new-session)
-             :sessions sessions
-             :engine-sessions engine-sessions
              ;; {branch-id future} of forfeited turns still executing, so
              ;; advance-all never runs a branch beside its own dangling turn
              ;; (karamazov-blt.18).

--- a/src/samizdat/agent/resume.clj
+++ b/src/samizdat/agent/resume.clj
@@ -281,7 +281,6 @@
           turns (group-by :branch_id turn-rows)
           artifacts (group-by :branch_id (journal/artifacts conn run-id))
           firings (group-by :branch_id (journal/gate-firings conn run-id))
-          sessions (atom [])
           ;; Same three keys run! sets. A resumed run works on the same tree
           ;; and needs the same file root; the eval session is genuinely new,
           ;; because the old process's namespace died with it and nothing in
@@ -305,7 +304,6 @@
                ;; changed is already committed to the tree it starts from.
                :git-baseline (gitdiff/baseline root)
                :repl-session (repl/new-session)
-               :sessions sessions
                :abort abort}
           branches (mapv (fn [row]
                            (let [b (rebuild-branch run row turns artifacts

--- a/src/samizdat/agent/state.clj
+++ b/src/samizdat/agent/state.clj
@@ -592,6 +592,25 @@
   [branch entry]
   (update branch :turns conj entry))
 
+(defn unpin-task-statement
+  "Release `task-id`'s pinned statement back to the compaction pool.
+
+  A claim pins its statement so the branch's CURRENT task is never unloaded
+  (RFC-004); a task that is closed or set down is not current, and its
+  statement used to stay pinned forever — a branch that switched twice
+  carried three permanent 'your task is…' blocks, the earlier two wrong
+  (karamazov-swd). Un-pinning is a METADATA flip: llm.message/prepare
+  projects role and content only, so no wire byte changes and the prefix
+  cache is untouched; the statement then ages out of the verbatim window and
+  compacts to a digest line through the normal one-attempt in-place rewrite."
+  [branch task-id]
+  (update branch :messages
+          (fn [ms]
+            (mapv #(if (and (:pinned? %) (= task-id (:task-id %)))
+                     (dissoc % :pinned?)
+                     %)
+                  ms))))
+
 (defn repeating-failure?
   "Whether this branch's LAST turn was already this exact (tool, error) failure.
 

--- a/src/samizdat/agent/tools/tasks.clj
+++ b/src/samizdat/agent/tools/tasks.clj
@@ -189,7 +189,11 @@
                                    {:branch-id (:id branch)
                                     :data {:from (:id held) :to (:id t)
                                            :reason reason}}))
-                  (base/ok (take-task branch t)
+                  (base/ok (take-task (cond-> branch
+                                        ;; the set-down task's statement stops
+                                        ;; being pinned (swd)
+                                        held (state/unpin-task-statement (:id held)))
+                                      t)
                            (str (if held
                                   (str "Set down " (:id held) " and claimed ")
                                   "Claimed ")
@@ -224,7 +228,11 @@
                     ;; context block asks for the next one instead of pointing
                     ;; at finished work.
                     branch (cond-> branch
-                             (= (:id t) (:id (:task branch))) (assoc :task nil))]
+                             (= (:id t) (:id (:task branch)))
+                             (-> (assoc :task nil)
+                                 ;; the finished statement stops being pinned,
+                                 ;; so compaction can fold it away (swd)
+                                 (state/unpin-task-statement (:id t))))]
                 (base/ok branch (str "Closed " (task-line t))
                          :progress? true)))))
 

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -118,7 +118,7 @@
     :conn :run-id :config :llm-adapter :llm-config :root :max-turns :abort
     ;; What the beam driver adds
     :problem :beam? :beam-width :turn-workflow :iterating-loop? :git-baseline
-    :repl-session :sessions :engine-sessions :live-branches :in-flight})
+    :repl-session :live-branches :in-flight})
 
 (defn cell-requires
   "The ctx keys `cell-id` declares it reads. `:requires` is mycelium's own

--- a/test/samizdat/kanban_test.clj
+++ b/test/samizdat/kanban_test.clj
@@ -198,3 +198,28 @@
         (is (str/includes? (:result r) "open"))
         (is (not (re-find (re-pattern (str free "[^\\n]*@")) (:result r)))
             "an unclaimed task shows no holder")))))
+
+(deftest a-superseded-task-statement-is-unpinned-for-compaction
+  ;; The claim pins its statement forever, and switch/close never released
+  ;; it — a branch that switched twice carried three permanent "your task
+  ;; is…" blocks, the earlier two wrong (karamazov-swd). Un-pinning is a
+  ;; metadata flip (prepare projects role+content only, so no wire byte
+  ;; changes); the stale statement then compacts away like any aged-out
+  ;; message, while the CURRENT task's statement stays pinned.
+  (with-run [c rid]
+    (let [t1 (tasks/create! c {:title "first" :contract "c1"})
+          t2 (tasks/create! c {:title "second" :contract "c2"})
+          b (:branch (run-task c rid (branch) {:action "claim" :id t1}))
+          b (:branch (run-task c rid b {:action "switch" :id t2
+                                        :reason "first was blocked"}))
+          by-task (fn [id] (first (filter #(= id (:task-id %)) (:messages b))))]
+      (testing "switch releases the old statement and pins the new one"
+        (is (false? (boolean (:pinned? (by-task t1))))
+            "the set-down task's statement is compactable now")
+        (is (str/includes? (:content (by-task t1)) "c1")
+            "its content is untouched — the flip is metadata only")
+        (is (true? (:pinned? (by-task t2)))))
+      (testing "closing the current task releases its statement too"
+        (let [b (:branch (run-task c rid b {:action "close" :id t2}))]
+          (is (false? (boolean (:pinned? (first (filter #(= t2 (:task-id %))
+                                                        (:messages b))))))))))))


### PR DESCRIPTION
Follow-up to the six audit PRs — the two items deferred from the low bundle (blt.38):

- the `sessions`/`engine-sessions` atoms (proof-engine teardown registries with no writers since the engines left) are removed from both drivers, `manifests/ctx-keys`, and the coverage contract (karamazov-w7w)
- `state/unpin-task-statement`: `task switch` and `task close` release the set-down task's pinned statement so compaction can fold it away — a metadata-only flip, so the prefix cache is untouched; the current task's statement stays pinned (karamazov-swd)

Suite: 1338 tests, 4769 assertions, green.