### PR TITLE
Tier 2 curation: pivot tournament, trajectory scoring, behavior-tree board

### DIFF
--- a/docs/RFCS/RFC-011-board-workflow.md
+++ b/docs/RFCS/RFC-011-board-workflow.md
@@ -103,6 +103,26 @@ producing a split both ignored.
 Nested rounds are additive: tasks closed in round *n* stay closed, so a revise
 round works what is left rather than the feature again.
 
+### The behavior-tree variant (`board-bt.edn`)
+
+Same cells, same contract, one structural difference: every action returns to
+a `:board/sense` node that re-derives the loop's position from the blackboard
+and the tasks table each tick, querying preconditions in reverse — unjudged
+outcome → review; revise verdict or fresh claim → work; refused claim → done;
+workable task → claim (Kelley arXiv 2404.07439 Appendix A.2, the implicit
+sequence). In a static world the two manifests are identical; the difference
+appears when the world shifts under the loop (a stale claim released, a task
+closed elsewhere, a crash resumed), where the plain machine continues from
+where it *thinks* it is and this one from where the board actually stands.
+The review-before-done ordering that board.edn enforces as an edge lives here
+in `:board/sense`'s cond order — enforcement moved from structure to data —
+and the root done-check deliberately sits *below* review, because "nothing
+closes unreviewed" outranks reactivity. Selected per-run with
+`:run :loop "board-bt"` or, as the feature loop's implement stage, with
+`:run :board-manifest "board-bt"` (`HARNESS_BOARD_MANIFEST`). An A/B variant
+for the loop-guard epic (karamazov-fut): prefer `board` until it has been
+measured against it.
+
 ## Policy (gates.edn)
 
 | key | what it bounds |

--- a/resources/cells/board.clj
+++ b/resources/cells/board.clj
@@ -219,6 +219,14 @@
                :board/attempts 0
                ;; the previous task's review has nothing to say about this one
                :board/findings nil
+               ;; The previous task's outcome and verdict are cleared with it.
+               ;; The plain manifest never reads them again (its edges carry
+               ;; the position), but the BT variant's :board/sense re-derives
+               ;; position from these keys every tick, and a stale outcome
+               ;; would read as work awaiting review (karamazov-fut).
+               :board/outcome nil
+               :board/decision nil
+               :board/answer nil
                ;; The baseline for THIS task, taken now: the review reads the
                ;; diff its owner produced, not the run's accumulated one.
                :board/baseline (gitdiff/baseline root)
@@ -286,6 +294,10 @@
              :board/branch-id bid
              :board/task (if switched? (:id held) task)
              :board/outcome (:verdict out)
+             ;; A fresh outcome is unjudged by definition; clearing the last
+             ;; review's verdict here is what lets :board/sense (the BT
+             ;; variant) read outcome-with-no-decision as review-due.
+             :board/decision nil
              :board/answer (get-in out [:branch :final-answer])
              :branch (:branch out)))))
 
@@ -372,6 +384,44 @@
                              pass? (conj {:task task :answer answer}))
              :board/left (cond-> (or (:board/left data) [])
                            (= :give-up decision) (conj {:task task :answer answer}))))))
+
+(cell/defcell :board/sense
+  {:doc "The BT variant's one decision point (karamazov-fut, Kelley arXiv
+        2404.07439 Appendix A.2, the implicit sequence): re-derive the board
+        loop's position from the blackboard and the tasks table EVERY tick,
+        instead of latching it in the state machine's edges. Preconditions
+        are queried in reverse — the most downstream applicable action wins —
+        so an action whose precondition stopped holding stops firing, and
+        'keep doing step A because a counter says so' is structurally
+        impossible.
+
+        The order IS the policy:
+          1. an outcome with no verdict  -> review   (unjudged work exists)
+          2. a revise verdict            -> work     (same owner, findings)
+          3. a fresh unworked claim      -> work
+          4. the board refused a claim   -> finish   (:board/next said :empty)
+          5. a workable task exists      -> claim
+          6. otherwise                   -> finish
+
+        The root postcondition (board clear) deliberately sits BELOW review:
+        checking done-ness first would finish the round past the final task's
+        unreviewed diff, and 'nothing reaches done without a critic reading
+        that change' outranks reactivity. Reading order 1 depends on
+        :board/next and :board/work clearing the previous task's outcome and
+        decision — the blackboard hygiene those cells now do for this cell."
+   :effects [:db]
+   :requires [:conn :run-id]}
+  (fn [{:keys [conn run-id]} data]
+    (let [outcome (:board/outcome data)
+          decision (:board/decision data)
+          state (cond
+                  (and outcome (nil? decision)) :review-due
+                  (= :revise decision) :work-due
+                  (and (= :task (:board/verdict data)) (nil? outcome)) :work-due
+                  (= :empty (:board/verdict data)) :done
+                  (seq (workable conn run-id)) :claim-due
+                  :else :done)]
+      (assoc data :board/sense state))))
 
 (cell/defcell :board/finish
   {:doc "End on what the board says: every task closed is a completed run whose

--- a/resources/cells/feature.clj
+++ b/resources/cells/feature.clj
@@ -159,7 +159,12 @@
               ctx (if-let [budget (:feature/turn-budget data)]
                     (assoc ctx :max-turns budget)
                     ctx)
-              out (myc/run-compiled (wf/compiled-manifest "board") ctx
+              ;; Which board manifest implements the round is config, so the
+              ;; BT variant (board-bt) can be A/B'd against the plain board
+              ;; without touching this cell (karamazov-fut).
+              board-manifest (or (get-in ctx [:config :run :board-manifest])
+                                 "board")
+              out (myc/run-compiled (wf/compiled-manifest board-manifest) ctx
                                     {:branch branch :turn 1
                                      :board/nested? true
                                      ;; round-scoped branch ids, and the

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -345,6 +345,35 @@
         (:stuck, :safe-state) read the counter unchanged and so trip sooner
         on expensive loops."}
 
+ :trajectory-score
+ {:value
+  {:repeats 4
+   :stride 5
+   :abandon-below 0.05
+   :criteria
+   ["concrete-output: look only at files written or edited and commands run.
+     HIGH: new or corrected code landing on disk that serves the goal. LOW:
+     steps that read, list, or plan without producing anything on disk.
+     Ignore the agent's own narration."
+    "verification-signal: look only at test and verify command results. HIGH:
+     the suite or a focused test moving from red toward green. LOW: repeated
+     red with the same error, or no verification at all. Ignore claims of
+     success not backed by an actual run."
+    "convergence: look at the sequence of recent steps. HIGH: each step
+     builds on the previous step's result. LOW: repeats of the same call,
+     alternation between two calls, or unconnected jumps. Ignore verbosity."]}
+  :kind :threshold :capability-tunable? true
+  :doc "Continuous trajectory scoring (karamazov-fut, llm-as-a-verifier's
+        ProgressTracker): every :stride-th step judged on steps-so-far,
+        :repeats letter-scale asks averaged, criteria per the verifier
+        TEMPLATE rules (2-4 narrow ones beating one broad one; each says
+        where to look, what is HIGH, what is LOW, what to ignore).
+        :abandon-below is the eventual flat-low-curve decision threshold —
+        shipped as data from day one, CONSULTED BY NOTHING until the signal
+        is validated on baseline runs (samizdat.agent.trajectory/score-run):
+        a completed and an exhausted run must actually separate before any
+        gate or cull reads the number."}
+
  :max-branch-theses
  {:value 4 :kind :cost-ceiling :capability-tunable? false
   :doc "Most theses one branch_theses call may propose. A cost ceiling:

--- a/resources/manifests/board-bt.edn
+++ b/resources/manifests/board-bt.edn
@@ -1,0 +1,58 @@
+;; The BOARD loop, behavior-tree shape (karamazov-fut; Kelley arXiv 2404.07439
+;; Appendix A.2, the implicit sequence). Same cells and same collaboration
+;; contract as board.edn — one owner per task, a critic on every diff — with
+;; one structural difference: position is RE-DERIVED from current state every
+;; tick by :board/sense, instead of latched in the edges.
+;;
+;; board.edn:            work -> review -> next -> work   (the machine
+;;                       remembers where it is)
+;; this manifest:        every action returns to :sense, which asks, in
+;;                       reverse order: unreviewed change? review it. revise
+;;                       verdict or fresh claim? work it. board refused a
+;;                       claim? finish. workable task? claim it. else finish.
+;;
+;; In a static world the two are identical (Kelley's observation); the
+;; difference appears when the world shifts under the loop — a stale claim
+;; released, a task closed by someone else, a crash resumed — where the plain
+;; machine continues from where it THINKS it is and this one continues from
+;; where the board actually stands. What it structurally prevents is the
+;; latched-position loop: an action whose precondition stopped holding cannot
+;; keep firing on the strength of a counter.
+;;
+;; The review-before-done ordering lives in :board/sense's cond, which is why
+;; the work->review invariant is expressed there rather than as an edge here:
+;; enforcement moved from structure to data, and the sense cell's docstring
+;; carries the argument. Select with config :run :loop "board-bt", or as the
+;; feature loop's implement stage with :run :board-manifest "board-bt".
+{:description "The board loop in behavior-tree shape: same owned tasks and per-diff review as board, but the loop's position is re-derived from the board's actual state every tick instead of remembered by the machine. An A/B variant for the loop-guard epic — prefer board until it has been measured against it."
+ :cells {:start  :board/plan
+         :sense  :board/sense
+         :next   :board/next
+         :work   :board/work
+         :review :board/review
+         :finish :board/finish}
+
+ :edges {:start  :sense
+         :sense  {:review-due :review
+                  :work-due   :work
+                  :claim-due  :next
+                  :done       :finish}
+         :next   :sense
+         :work   :sense
+         :review :sense
+         :finish :end}
+
+ :dispatches {:sense [[:review-due (fn [d] (= :review-due (:board/sense d)))]
+                      [:work-due   (fn [d] (= :work-due (:board/sense d)))]
+                      [:claim-due  (fn [d] (= :claim-due (:board/sense d)))]
+                      [:done       (fn [d] true)]]}
+
+ :invariants
+ [{:type :must-follow :if :work :then :sense :enforced true
+   :protects "Every piece of work returns to the sense node, whose ordering
+              (review-due before any new claim) is what guarantees no change
+              reaches the board as done without a critic reading it."}
+
+  {:type :must-precede :cell :next :before :work :enforced true
+   :protects "Work is only ever done under a claimed task, so every change has
+              an owner on the board."}]}

--- a/resources/manual.edn
+++ b/resources/manual.edn
@@ -94,6 +94,12 @@
     :summary "Whether the next call with this signature would be withheld as a repeat, judged against a branch's storm window."}
    {:name samizdat.agent.storm/oscillating?
     :summary "Whether a call would extend an A-B-A-B alternation between two calls — the loop shape no failure-keyed guard can see."}
+   {:name samizdat.agent.tournament/run
+    :summary "Rank N candidates by pairwise comparison at linear cost: a ring pass that cancels positional bias, then everyone against the top-k pivots. The comparator is yours to inject — an LLM judge, a test result, anything returning p(a beats b)."}
+   {:name samizdat.agent.trajectory/score-run
+    :summary "Score a branch's trajectory from the journal on the A-T letter scale, steps-so-far only — the offline validation entry point. Run it over a completed and an exhausted run and compare curves before wiring anything to the number."}
+   {:name samizdat.agent.gates/trajectory-policy
+    :summary "The trajectory-scoring policy from gates.edn: repeats, stride, criteria, and the not-yet-consulted abandon threshold."}
    {:name samizdat.prompt/render
     :summary "Render a prompt resource through selmer. Every harness message the model sees comes through here."}]}
 

--- a/resources/prompts/trajectory-judge.md
+++ b/resources/prompts/trajectory-judge.md
@@ -1,0 +1,24 @@
+You are scoring an agent's PROGRESS toward a goal, judged only on the steps
+taken so far. Do NOT trust the agent's self-assessment or claims of success;
+trust observed output — what actually landed on disk and what commands
+actually reported.
+
+Goal:
+
+{{problem}}
+
+Steps so far (turn, tool, args, outcome):
+
+```
+{{steps}}
+```
+
+Criteria, weighted equally:
+
+{{criteria}}
+
+How much progress has this trajectory made toward the goal, on a scale of A
+to T, where A means no progress at all and T means the goal is fully
+accomplished and verified?
+
+Reply with exactly one letter (A-T) on the last line.

--- a/src/samizdat/agent/gates.clj
+++ b/src/samizdat/agent/gates.clj
@@ -104,6 +104,14 @@
    :exempt-tools (or (tool-vocab :storm-exempt) #{})
    :mutating-tools (or (tool-vocab :storm-mutating) #{})})
 
+(defn trajectory-policy
+  "The trajectory-scoring policy (gates.edn :trajectory-score): repeats,
+  stride, criteria, and the not-yet-consulted :abandon-below threshold.
+  See samizdat.agent.trajectory for why the threshold ships before anything
+  reads it."
+  []
+  (threshold :trajectory-score))
+
 (defn- prompt [name]
   (sp/prompt name))
 

--- a/src/samizdat/agent/tournament.clj
+++ b/src/samizdat/agent/tournament.clj
@@ -1,0 +1,122 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.agent.tournament
+  "The probabilistic pivot tournament (karamazov-fut), ported from
+  llm-as-a-verifier's pivot_tournament.py: rank N candidates by pairwise
+  comparison at linear-in-N cost.
+
+  Why pairwise at all: a single absolute critic score asks the judge to hold
+  a calibration it does not have; a comparison only asks which of two is
+  better, and the measured lift (best-of-5 self-verification 78.7% -> 88.0%
+  against a 96.6% oracle) comes with the SAME model judging its own work.
+
+  Why this shape: a full round-robin costs C(N,2) judge calls. The tournament
+  spends N + k(N-k) + C(k,2): one RING pass around a random Hamiltonian cycle
+  — every candidate judged exactly once in slot A and once in slot B, so
+  positional bias cancels around the ring — then the top-k by mean preference
+  become PIVOTS, and every remaining candidate is judged against every pivot.
+
+  Mechanism only, and pure: the comparator is injected (an LLM judge in
+  production, a rigged Bradley-Terry in tests), the seed comes from policy,
+  and nothing here knows what a candidate is. Soft wins, Bradley-Terry style:
+  a comparison returns p(a beats b) in [0,1] and BOTH candidates book their
+  share, so an uncertain judge moves the ranking less than a confident one.
+
+  Randomness note: the shuffle is a seeded LCG, not Math/random — the caller
+  owns the seed, so a re-run or a resume re-derives the identical ring."
+  (:refer-clojure :exclude [run]))
+
+;; A classic LCG, kept inside 2^31 by the mod rather than by wraparound —
+;; Chez integers are bignums, so shift-based generators would grow without
+;; bound instead of wrapping the way they do on 64-bit words.
+(def ^:private lcg-a 1103515245)
+(def ^:private lcg-c 12345)
+(def ^:private lcg-m 2147483648)
+
+(defn- lcg-next [s]
+  (mod (+ (* lcg-a s) lcg-c) lcg-m))
+
+(defn shuffle-seeded
+  "Fisher-Yates over `coll`, driven by the seed. Same seed, same order."
+  [coll seed]
+  (let [v (vec coll)
+        n (count v)]
+    (loop [v v
+           i (dec n)
+           s (lcg-next (long seed))]
+      (if (pos? i)
+        (let [j (mod s (inc i))]
+          (recur (assoc v i (v j) j (v i)) (dec i) (lcg-next s)))
+        v))))
+
+(defn ring-pairs
+  "The directed edges of a random Hamiltonian cycle over n candidates:
+  n pairs, every candidate exactly once as the first element and once as the
+  second. This is the positional-bias control — a judge that favours slot A
+  favours every candidate equally around the ring."
+  [n seed]
+  (let [p (shuffle-seeded (range n) seed)]
+    (mapv (fn [i] [(p i) (p (mod (inc i) n))]) (range n))))
+
+(defn- book
+  "Book one comparison's soft win into the {index {:w :c}} tally."
+  [acc a b p]
+  (let [p (-> (double p) (max 0.0) (min 1.0))]
+    (-> acc
+        (update-in [a :w] (fnil + 0.0) p)
+        (update-in [a :c] (fnil inc 0))
+        (update-in [b :w] (fnil + 0.0) (- 1.0 p))
+        (update-in [b :c] (fnil inc 0)))))
+
+(defn- mean [{:keys [w c]}]
+  (if (pos? (or c 0)) (/ (double w) c) 0.0))
+
+(defn run
+  "Rank n candidates with the injected comparator.
+
+  opts: :n candidates, :compare (fn [a b] -> p(a beats b) in [0,1]),
+  :pivots k, :seed for the ring. Returns [{:index :score}] best-first,
+  score = mean preference w/c; ties break toward the lower index so the
+  result is total and reproducible."
+  [{:keys [n compare pivots seed]}]
+  (cond
+    (zero? n) []
+    (= 1 n) [{:index 0 :score 1.0}]
+    :else
+    (let [ring (ring-pairs n seed)
+          after-ring (reduce (fn [acc [a b]] (book acc a b (compare a b)))
+                             {} ring)
+          k (min (long pivots) n)
+          by-mean (sort-by (fn [i] [(- (mean (after-ring i))) i]) (range n))
+          pivot-set (set (take k by-mean))
+          non-pivots (remove pivot-set (range n))
+          pivot-pairs (concat
+                       ;; every remaining candidate against every pivot
+                       (for [np non-pivots, p pivot-set] [np p])
+                       ;; and the pivots against each other, each pair once
+                       (let [ps (sort pivot-set)]
+                         (for [i (range (count ps))
+                               j (range (inc i) (count ps))]
+                           [(nth ps i) (nth ps j)])))
+          tally (reduce (fn [acc [a b]] (book acc a b (compare a b)))
+                        after-ring pivot-pairs)]
+      (->> (range n)
+           (map (fn [i] {:index i :score (mean (tally i))}))
+           (sort-by (fn [{:keys [index score]}] [(- score) index]))
+           vec))))

--- a/src/samizdat/agent/trajectory.clj
+++ b/src/samizdat/agent/trajectory.clj
@@ -1,0 +1,117 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.agent.trajectory
+  "Continuous trajectory scoring (karamazov-fut), after llm-as-a-verifier's
+  ProgressTracker: score a branch's steps-so-far on a 20-letter scale with K
+  repeats averaged, so a run carries a NUMBER for 'is this converging'
+  instead of only the counters the stall gates read. The paper's finding:
+  a completed trajectory's score climbs; a doomed one stays flat and low —
+  a flat-low curve is the machine-readable signature of a loop.
+
+  DELIBERATELY NOT WIRED TO ANY DECISION YET. The empirical protocol
+  (karamazov-0j8) validates the signal first: score finished baseline runs
+  offline via `score-run` and check that completed and exhausted runs
+  actually separate, before any gate or cull reads the number. The
+  :abandon-below threshold ships in gates.edn from day one so the eventual
+  wiring is a data edit, but nothing consults it here.
+
+  Mechanism only: the judge is an injected function (an LLM in production, a
+  script in tests); criteria, repeats, stride, and threshold are gates.edn
+  policy (gates/trajectory-policy); the words are
+  resources/prompts/trajectory-judge.md. The judge sees only steps so far —
+  it cannot peek ahead — and is told to trust observed output, never the
+  agent's narration."
+  (:require [clojure.string :as str]
+            [samizdat.agent.gates :as gates]
+            [samizdat.llm.client :as llm]
+            [samizdat.prompt :as prompt]
+            [samizdat.store.journal :as journal]
+            [samizdat.store.runs :as runs]))
+
+(defn parse-letter
+  "The judge's letter, as a value in [0,1]: A = 0 (no progress), T = 1 (goal
+  accomplished and verified). Read from the LAST non-blank line, standalone
+  letters only, so the judge's prose above cannot collide with the scale.
+  nil for an unusable reply — nil and 0.0 mean opposite things, and a broken
+  judge must never read as 'no progress'."
+  [reply]
+  (when (string? reply)
+    (when-let [line (->> (str/split-lines reply)
+                         (map str/trim)
+                         (remove str/blank?)
+                         last)]
+      (let [hits (->> (re-seq #"[A-Za-z]+" line)
+                      (filter #(and (= 1 (count %))
+                                    (<= 0 (- (int (first %)) (int \A)) 19))))]
+        (when-let [l (last hits)]
+          (/ (double (- (int (first l)) (int \A))) 19.0))))))
+
+(defn- snippet [s n]
+  (let [s (str s)]
+    (if (> (count s) n) (str (subs s 0 n) "…") s)))
+
+(defn steps-digest
+  "The steps-so-far block the judge reads: one line per turn — tool, an args
+  snippet, and the outcome. Compact on purpose: the judge is scoring the
+  SHAPE of the trajectory, and full results would drown it (and the token
+  budget) in the very output it is told to distrust the narration of."
+  [rows]
+  (str/join "\n"
+            (map (fn [{:keys [turn tool_name args category result]}]
+                   (str "t" turn " " tool_name " " (snippet args 80)
+                        " -> " category ": " (snippet result 120)))
+                 rows)))
+
+(defn- judge-prompt [{:keys [problem criteria steps]}]
+  (prompt/render "trajectory-judge"
+                 {:problem problem
+                  :criteria (str/join "\n" (map #(str "- " %) criteria))
+                  :steps steps}))
+
+(defn score-rows
+  "Score a trajectory: every :stride-th step is judged on the rows up to and
+  including it, :repeats times, letters averaged. `ask` is the judge —
+  prompt string in, reply string out. Returns [{:turn n :score s|nil}] in
+  order; a nil score means the judge produced nothing parseable at that
+  point, which is a fact about the judge and must never count as progress or
+  its absence."
+  [ask rows {:keys [problem repeats stride criteria]}]
+  (let [rows (vec rows)]
+    (mapv (fn [i]
+            (let [upto (subvec rows 0 (inc i))
+                  p (judge-prompt {:problem problem :criteria criteria
+                                   :steps (steps-digest upto)})
+                  vals (keep parse-letter (doall (repeatedly repeats #(ask p))))]
+              {:turn (:turn (rows i))
+               :score (when (seq vals)
+                        (/ (reduce + 0.0 vals) (count vals)))}))
+          (range (dec stride) (count rows) stride))))
+
+(defn score-run
+  "Score one finished (or live) branch's trajectory from the journal — the
+  offline validation entry point. ctx needs :conn, :llm-adapter,
+  :llm-config; policy comes from gates.edn. Run it over a completed and an
+  exhausted run and compare the curves before letting anything act on them."
+  [{:keys [conn llm-adapter llm-config]} run-id branch-id]
+  (let [rows (journal/branch-turns conn run-id branch-id)
+        run (runs/get-run conn run-id)
+        ask (fn [p] (:content (llm/chat llm-adapter llm-config
+                                        [{:role "user" :content p}])))]
+    (score-rows ask rows (assoc (gates/trajectory-policy)
+                                :problem (:problem run)))))

--- a/src/samizdat/config.clj
+++ b/src/samizdat/config.clj
@@ -192,6 +192,11 @@
                   ;; pin its own via .samizdat/config.edn, and the agent can add
                   ;; or tune manifests at runtime with the `manifest` tool.
                   :loop       (env "HARNESS_LOOP")
+                  ;; Which board manifest the feature loop's implement stage
+                  ;; runs. nil means "board"; "board-bt" is the behavior-tree
+                  ;; variant being A/B'd (karamazov-fut). Per-project via
+                  ;; .samizdat/config.edn like :loop.
+                  :board-manifest (env "HARNESS_BOARD_MANIFEST")
                   ;; The ship gate's test rung, ON by default. `done` is a hard
                   ;; gate on a green test (b1a4b88) — but verify-on? needs a
                   ;; :verify-cmd or this flag, and neither had a default, so the

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -50,7 +50,7 @@
   binary (same reasoning as cells/shipped-cells and prompt/shipped-prompts).
   Pinned against the directory by workflow-test."
   ["loop" "beam" "critic" "orchestrator" "probe" "review" "reviewer"
-   "supervisor" "worker" "team" "board" "feature" "decompose"])
+   "supervisor" "worker" "team" "board" "board-bt" "feature" "decompose"])
 
 (defn manifest-resource
   "The factory resource path a manifest name seeds from, e.g. \"loop\" ->

--- a/src/samizdat/prompt.clj
+++ b/src/samizdat/prompt.clj
@@ -93,6 +93,7 @@
    "task-none"
    "task-reflection"
    "task-reflection-input"
+   "trajectory-judge"
    "task-required"
    "team-worker"
    "turn-deadline"

--- a/test/samizdat/base_test.clj
+++ b/test/samizdat/base_test.clj
@@ -200,6 +200,23 @@
    {:threshold {:all "HTTP status codes and the response-body cap of a
                       transport. Protocol constants, not policy."}}
 
+   "src/samizdat/agent/tournament.clj"
+   {:threshold {1103515245 "The LCG multiplier — a PRNG's algorithm constants,
+                            like a hash function's primes. Retuning them at
+                            runtime cannot express a different policy, only a
+                            broken shuffle; what IS policy (the seed, the
+                            pivot count) the caller injects."
+                12345 "The LCG increment, same reasoning."
+                2147483648 "The LCG modulus (2^31), same reasoning."}}
+
+   "src/samizdat/agent/trajectory.clj"
+   {:threshold {19 "The span of the A-T letter scale: T minus A. Arithmetic of
+                    the alphabet, not a tunable — the scale's GRANULARITY as a
+                    choice lives in the criteria and prompt wording
+                    (gates.edn :trajectory-score), and changing this number
+                    without changing the prompt's 'A to T' would misgrade
+                    every reply."}}
+
    "src/samizdat/llm/client.clj"
    {:threshold {:all "HTTP status classes (200/299/500) and the retry ladder's
                       wall-clock bounds, which RFC-005 fixes deliberately: the

--- a/test/samizdat/board_bt_test.clj
+++ b/test/samizdat/board_bt_test.clj
@@ -1,0 +1,111 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.board-bt-test
+  "The behavior-tree board variant (karamazov-fut): same cells, same
+  collaboration contract as board.edn, but position re-derived from current
+  state every tick by :board/sense. These tests pin two things: the variant
+  completes the same scenarios the plain board does, and the sense node's
+  reverse-order precondition table is exactly the policy its docstring
+  states."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [samizdat.cells :as cells]
+            [samizdat.llm.client :as llm]
+            [samizdat.store.db :as db]
+            [samizdat.store.tasks :as tasks]
+            [samizdat.workflow :as workflow]))
+
+(defn- ships-its-task
+  "An owner that ships immediately, engaging its own task's words so the
+  done-gate accepts the answer (same stub as board-test)."
+  [_ _ messages & _]
+  (let [content (str/join " " (map :content messages))
+        prob (str/trim (or (second (re-find #"## Problem\s+(.+)" content)) "task"))]
+    {:content (str "```tool-call\n{\"name\":\"done\",\"args\":{\"answer\":\"handled "
+                   prob "\"}}\n```")
+     :finish-reason "stop"}))
+
+(defn- run-board-bt
+  [conn opts]
+  (workflow/run! (merge {:conn conn
+                         :config {:run {:loop "board-bt"}}
+                         :llm-adapter :a :llm-config {:max-tokens 16384}
+                         :problem "the feature" :max-turns 6}
+                        opts)))
+
+;; --- the variant completes what the plain board completes -------------------
+
+(deftest the-bt-board-works-a-problem-to-done
+  (with-redefs [llm/chat ships-its-task]
+    (let [conn (db/open! ":memory:")]
+      (run-board-bt conn {})
+      (let [rows (db/fetch conn ["SELECT * FROM tasks ORDER BY created_at, id"])]
+        (is (= 1 (count rows)) "one task, made from the problem")
+        (is (= "done" (:status (first rows)))
+            "sensed claim-due, work-due, review-due in turn, and closed it")))))
+
+(deftest the-bt-board-works-every-seeded-task
+  (with-redefs [llm/chat ships-its-task]
+    (let [conn (db/open! ":memory:")
+          a (tasks/create! conn {:title "storage"})
+          b (tasks/create! conn {:title "handlers"})]
+      (run-board-bt conn {})
+      (is (= "done" (:status (tasks/get-task conn a))))
+      (is (= "done" (:status (tasks/get-task conn b))))
+      (let [branches (map :branch_id (db/fetch conn ["SELECT DISTINCT branch_id FROM turns"]))]
+        (is (= (count branches) (count (distinct branches)))
+            "one owner per task, same as the plain board")))))
+
+;; --- the sense table IS the policy ------------------------------------------
+
+(defn- sense
+  [conn data]
+  (when (nil? (cell/get-cell :board/sense))
+    (cells/load-cells!))
+  (:board/sense (myc/invoke-cell :board/sense
+                                 {:conn conn :run-id "r1"}
+                                 data)))
+
+(deftest sense-preconditions-query-in-reverse-order
+  (let [conn (db/open! ":memory:")]
+    (testing "an empty board with a blank blackboard is done"
+      (is (= :done (sense conn {}))))
+    (testing "a workable task asks for a claim"
+      (tasks/create! conn {:title "t"})
+      (is (= :claim-due (sense conn {}))))
+    (testing "an unjudged outcome outranks everything — including done-ness:
+              the final task's diff is reviewed before the round may finish"
+      (is (= :review-due (sense conn {:board/outcome :done})))
+      (is (= :review-due (sense conn {:board/outcome :error}))
+          "an owner that crashed still faces review, which records give-up"))
+    (testing "a revise verdict sends the same owner back to work"
+      (is (= :work-due (sense conn {:board/outcome :done
+                                    :board/decision :revise}))))
+    (testing "a fresh claim not yet worked goes to work"
+      (is (= :work-due (sense conn {:board/verdict :task}))))
+    (testing "a judged outcome falls through to the next claim"
+      (is (= :claim-due (sense conn {:board/outcome :done
+                                     :board/decision :pass
+                                     :board/verdict :task}))))
+    (testing "the board refusing a claim ends the round even while raw
+              workable rows remain — :board/next's filters (given-up tasks,
+              the runaway cap) are the authority, not the raw query"
+      (is (= :done (sense conn {:board/verdict :empty}))))))

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -116,7 +116,10 @@
             [samizdat.server-test]
             [samizdat.adapter-test]
             [samizdat.proc-test]
+            [samizdat.board-bt-test]
             [samizdat.storm-test]
+            [samizdat.tournament-test]
+            [samizdat.trajectory-test]
             [samizdat.store-test]
             [samizdat.gui-api-test]
             [samizdat.gui-ops-test]
@@ -169,7 +172,10 @@
     mycelium.validate-warn-test
     mycelium.validation-test
     mycelium.workflow-test
+    samizdat.board-bt-test
     samizdat.storm-test
+    samizdat.tournament-test
+    samizdat.trajectory-test
     samizdat.store-test
     samizdat.llm-test
     samizdat.agent-test

--- a/test/samizdat/tournament_test.clj
+++ b/test/samizdat/tournament_test.clj
@@ -1,0 +1,101 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tournament-test
+  "The pivot tournament (karamazov-fut, from llm-as-a-verifier's
+  pivot_tournament.py): best-of-N curation by pairwise comparison at
+  linear-in-N cost. These tests drive it with a rigged comparator — real
+  quality values behind a Bradley-Terry preference — so 'the best candidate
+  wins' is checkable deterministically, per the n=1 measurability rule."
+  (:require [clojure.test :refer [deftest testing is]]
+            [samizdat.agent.tournament :as tournament]))
+
+(defn- bt
+  "A Bradley-Terry comparator over hidden quality scores: p(a beats b)."
+  [quals]
+  (fn [a b]
+    (let [d (- (double (nth quals a)) (double (nth quals b)))]
+      (/ 1.0 (+ 1.0 (Math/exp (- d)))))))
+
+;; --- the seeded shuffle -----------------------------------------------------
+
+(deftest the-shuffle-is-deterministic-and-a-permutation
+  (let [s1 (tournament/shuffle-seeded (range 10) 42)
+        s2 (tournament/shuffle-seeded (range 10) 42)
+        s3 (tournament/shuffle-seeded (range 10) 7)]
+    (is (= s1 s2) "same seed, same order — a resumed run re-derives the ring")
+    (is (= (set (range 10)) (set s1)) "a permutation, nothing lost or invented")
+    (is (not= s1 s3) "a different seed gives a different ring")))
+
+;; --- the ring ---------------------------------------------------------------
+
+(deftest the-ring-visits-every-candidate-once-per-slot
+  ;; The random Hamiltonian cycle is the positional-bias control: every
+  ;; candidate appears exactly once as the first element and once as the
+  ;; second, so slot preference cancels around the ring.
+  (let [pairs (tournament/ring-pairs 6 42)]
+    (is (= 6 (count pairs)))
+    (is (= (set (range 6)) (set (map first pairs))))
+    (is (= (set (range 6)) (set (map second pairs))))
+    (is (every? (fn [[a b]] (not= a b)) pairs))))
+
+;; --- the tournament ---------------------------------------------------------
+
+(deftest the-best-candidate-wins
+  (let [quals [0.1 0.9 0.3 0.2 0.5]
+        ranked (tournament/run {:n 5 :compare (bt quals)
+                                :pivots 2 :seed 42})]
+    (is (= 1 (:index (first ranked)))
+        "the highest hidden quality ranks first")
+    (is (= 5 (count ranked)))
+    (is (apply >= (map :score ranked)) "ranked best-first by mean preference")))
+
+(deftest comparison-count-is-linear-not-quadratic
+  ;; N + k(N-k) + C(k,2), the whole point over round-robin's O(N^2).
+  (let [calls (atom 0)
+        n 8 k 2
+        counting (fn [a b] (swap! calls inc) ((bt (repeat n 0.5)) a b))]
+    (tournament/run {:n n :compare counting :pivots k :seed 42})
+    (is (= (+ n (* k (- n k)) (/ (* k (dec k)) 2)) @calls))))
+
+(deftest small-fields-degenerate-gracefully
+  (is (= [] (tournament/run {:n 0 :compare (fn [_ _] 0.5) :pivots 2 :seed 1})))
+  (is (= [{:index 0 :score 1.0}]
+         (tournament/run {:n 1 :compare (fn [_ _] 0.5) :pivots 2 :seed 1}))
+      "a single candidate wins without a single comparison")
+  (let [ranked (tournament/run {:n 2 :compare (bt [0.1 0.9])
+                                :pivots 2 :seed 1})]
+    (is (= 2 (count ranked)))
+    (is (= 1 (:index (first ranked))))))
+
+(deftest the-comparator-sees-both-orders
+  ;; Both directions of at least one pair get asked across ring + pivot
+  ;; rounds, which is what lets a position-biased judge cancel out.
+  (let [seen (atom #{})
+        n 4
+        f (fn [a b] (swap! seen conj [a b]) 0.5)]
+    (tournament/run {:n n :compare f :pivots 2 :seed 3})
+    (let [pairs @seen
+          both (filter (fn [[a b]] (contains? pairs [b a])) pairs)]
+      (is (seq both) "at least one pair was judged in both A/B orders"))))
+
+(deftest determinism-under-a-fixed-seed
+  (let [quals [0.4 0.6 0.2 0.8 0.5 0.1]
+        r1 (tournament/run {:n 6 :compare (bt quals) :pivots 2 :seed 9})
+        r2 (tournament/run {:n 6 :compare (bt quals) :pivots 2 :seed 9})]
+    (is (= r1 r2))))

--- a/test/samizdat/trajectory_test.clj
+++ b/test/samizdat/trajectory_test.clj
@@ -1,0 +1,117 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.trajectory-test
+  "Continuous trajectory scoring (karamazov-fut, from llm-as-a-verifier's
+  ProgressTracker): a letter-scale judge over steps-so-far, K repeats
+  averaged. The judge is injected, so every behaviour here is deterministic;
+  the flat-low-curve-means-looping claim is what the Qwen campaign validates
+  empirically before any decision is wired to the score."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [samizdat.agent.gates :as gates]
+            [samizdat.agent.trajectory :as trajectory]))
+
+;; --- letter parsing ---------------------------------------------------------
+
+(deftest letters-parse-to-the-unit-interval
+  (testing "the full scale, A worst to T best"
+    (is (= 0.0 (trajectory/parse-letter "A")))
+    (is (= 1.0 (trajectory/parse-letter "T")))
+    (is (< 0.47 (trajectory/parse-letter "K") 0.54)))
+  (testing "the letter is read from the LAST line, so judge prose above it
+            cannot collide with the scale"
+    (is (= 1.0 (trajectory/parse-letter
+                "The Branch Advanced Toward The Goal.\n\nT")))
+    (is (= 0.0 (trajectory/parse-letter "Reasoning: no progress\nScore: A"))))
+  (testing "unparseable replies are nil, never a fabricated number"
+    (is (nil? (trajectory/parse-letter "no letter here 42")))
+    (is (nil? (trajectory/parse-letter "")))
+    (is (nil? (trajectory/parse-letter nil)))
+    (is (nil? (trajectory/parse-letter "U"))
+        "U is off the A-T scale")))
+
+;; --- the steps digest -------------------------------------------------------
+
+(deftest the-digest-sees-only-steps-so-far
+  (let [rows [{:turn 1 :tool_name "read_file" :args "{\"path\": \"a.clj\"}"
+               :category "success" :result (apply str (repeat 500 "x"))}
+              {:turn 2 :tool_name "write_file" :args "{\"path\": \"a.clj\"}"
+               :category "success" :result "wrote"}
+              {:turn 3 :tool_name "shell" :args "{\"command\": \"jolt -M:test\"}"
+               :category "failure" :result "1 failure"}]
+        d (trajectory/steps-digest (take 2 rows))]
+    (is (str/includes? d "read_file"))
+    (is (str/includes? d "write_file"))
+    (is (not (str/includes? d "shell")) "the judge cannot peek ahead")
+    (is (< (count d) 600) "long results are truncated to a snippet")))
+
+;; --- scoring a trajectory ---------------------------------------------------
+
+(defn- scripted-ask
+  "An injected judge: pops replies from the script in order."
+  [replies]
+  (let [q (atom (vec replies))]
+    (fn [_prompt]
+      (let [r (first @q)]
+        (swap! q #(vec (rest %)))
+        r))))
+
+(deftest scores-average-k-repeats-and-skip-unparseable
+  (let [rows [{:turn 1 :tool_name "shell" :args "{}" :category "success"
+               :result "ok"}]
+        ;; K=4: T (1.0), A (0.0), garbage (skipped), K (~0.526)
+        ask (scripted-ask ["T" "A" "nonsense" "K"])
+        scores (trajectory/score-rows ask rows
+                                      {:problem "p" :repeats 4 :stride 1})]
+    (is (= 1 (count scores)))
+    (is (= 1 (:turn (first scores))))
+    (let [s (:score (first scores))]
+      (is (< 0.50 s 0.52) "mean of 1.0, 0.0, 10/19"))))
+
+(deftest all-unparseable-scores-nil-not-zero
+  ;; nil and 0.0 mean opposite things: 0.0 is a judged 'no progress',
+  ;; nil is 'the judge said nothing usable'. Conflating them would let a
+  ;; broken judge abandon healthy branches.
+  (let [rows [{:turn 1 :tool_name "shell" :args "{}" :category "success"
+               :result "ok"}]
+        scores (trajectory/score-rows (scripted-ask ["x" "y"]) rows
+                                      {:problem "p" :repeats 2 :stride 1})]
+    (is (nil? (:score (first scores))))))
+
+(deftest the-stride-scores-every-nth-step
+  (let [rows (mapv (fn [i] {:turn i :tool_name "shell" :args "{}"
+                            :category "success" :result "ok"})
+                   (range 1 7))
+        asks (atom 0)
+        ask (fn [_] (swap! asks inc) "K")
+        scores (trajectory/score-rows ask rows
+                                      {:problem "p" :repeats 1 :stride 3})]
+    (is (= [3 6] (mapv :turn scores))
+        "every 3rd step is scored, judged on the steps up to it")
+    (is (= 2 @asks))))
+
+(deftest the-policy-is-discoverable-in-gates-edn
+  (let [p (gates/trajectory-policy)]
+    (is (pos? (:repeats p)))
+    (is (pos? (:stride p)))
+    (is (number? (:abandon-below p))
+        "the eventual decision threshold ships as data even before any
+         decision is wired to it")
+    (is (seq (:criteria p)) "2-4 narrow criteria, each saying where to look")
+    (is (<= 2 (count (:criteria p)) 4))))


### PR DESCRIPTION
Second tier of the loop-guard epic (karamazov-dct, bead karamazov-fut). Stacked on #10.

- samizdat.agent.tournament: best-of-N curation by pairwise comparison at linear cost (ring pass over a seeded Hamiltonian cycle + top-k pivots, Bradley-Terry soft wins). Comparator injected; deterministic under a seed.
- samizdat.agent.trajectory: continuous progress scoring on the A-T letter scale, K repeats averaged, steps-so-far only, judge told to distrust the agent's narration. score-run scores any run from the journal - the offline validation path.
- board-bt.edn: the board loop as a behavior tree - every action returns to :board/sense, which re-derives position from the board's real state each tick (review-due before any new claim, done-check below review). Same cells as board.edn plus blackboard hygiene in :board/next and :board/work. Select with :run :loop board-bt, or :run :board-manifest board-bt for the feature loop.

Deliberately NOT wired to decisions yet: the tournament replaces no critic call and the trajectory score feeds no gate until the Qwen campaign (karamazov-0j8) validates the signals - the gates.edn policy (:trajectory-score with its unconsulted :abandon-below) ships first so the eventual wiring is a data edit.

Merge gate: signal validation on baseline runs (completed vs exhausted trajectories must separate; board-bt must match board on completion rate across the task shapes). Suite: 1401 tests, 5121 assertions, green.