### PR TITLE
Fence closer scan is string-aware

### DIFF
--- a/src/samizdat/llm/fence.clj
+++ b/src/samizdat/llm/fence.clj
@@ -177,6 +177,40 @@
 (def ^:private opener-re #"```tool-call\s*\r?\n|<tool-call>\s*")
 (def ^:private closer-re #"```|</tool[-_]calls?>")
 
+(def ^:private closer-tokens
+  ["```" "</tool-call>" "</tool_call>" "</tool-calls>" "</tool_calls>"])
+
+(defn- closer-token-at
+  "The closer token starting at index i and ending by `bound`, or nil."
+  [^String s i bound]
+  (some (fn [^String t]
+          (let [e (+ i (count t))]
+            (when (and (<= e bound) (= t (subs s i e)))
+              t)))
+        closer-tokens))
+
+(defn- string-aware-closer
+  "Index of the first closer OUTSIDE a JSON string literal in s[from..to),
+  or nil.
+
+  Same state machine as close-unbalanced, for the same reason: a ``` inside
+  a content string is text, not structure. The mdlite dogfood run
+  (karamazov-hpv) made this concrete — the file being written was a MARKDOWN
+  CONVERTER, its code contained literal ``` in its own fence handling, and
+  the raw closer scan cut six valid calls mid-string, each reported back as
+  a parse error the model had not made. Any task whose files mention code
+  fences (markdown tooling, docs, READMEs) produces this shape."
+  [^String s from to]
+  (loop [i from, in-string? false, escaped? false]
+    (when (< i to)
+      (let [ch (.charAt s i)]
+        (cond
+          escaped? (recur (inc i) in-string? false)
+          (= \\ ch) (recur (inc i) in-string? true)
+          (= \" ch) (recur (inc i) (not in-string?) false)
+          (and (not in-string?) (closer-token-at s i to)) i
+          :else (recur (inc i) in-string? false))))))
+
 (defn extract-fences
   "Every tool-call fence body in the response, in order.
 
@@ -203,8 +237,16 @@
            :let [next-open (if (< (inc i) (count opens))
                              (first (nth opens (inc i)))
                              n)
-                 m (re-matcher closer-re (subs s body-start next-open))
-                 closer (when (.find m) (+ body-start (.start m)))]
+                 ;; String-aware first: a closer inside a JSON string literal
+                 ;; is content (karamazov-hpv). The raw scan stays as the
+                 ;; fallback for a body whose string never closes — an
+                 ;; unterminated string ahead of a real closer is the
+                 ;; truncation shape, and it must keep earning its parse
+                 ;; error rather than quietly becoming a no-call.
+                 closer (or (string-aware-closer s body-start next-open)
+                            (let [m (re-matcher closer-re
+                                                (subs s body-start next-open))]
+                              (when (.find m) (+ body-start (.start m)))))]
            :when closer]
        (str/trim (subs s body-start closer))))))
 

--- a/test/samizdat/llm_test.clj
+++ b/test/samizdat/llm_test.clj
@@ -38,6 +38,40 @@
 
 (defn- fenced [body] (str "prose before\n```tool-call\n" body "\n```\nprose after"))
 
+(deftest a-fence-marker-inside-a-json-string-is-content-not-a-closer
+  ;; Qwen baseline run b8a2b72c (karamazov-hpv): the mdlite task builds a
+  ;; MARKDOWN CONVERTER, so the file being written contains literal ``` —
+  ;; (not= l "```") in its code-block handling — and the closer scan took the
+  ;; first ``` after the opener, cutting the call mid-string. 6 of that run's
+  ;; 8 parse errors were this shape, each at a quarter of the token cap: the
+  ;; JSON was valid and the harness cut it. The closer scan must be
+  ;; string-aware, same state machine as close-unbalanced.
+  (let [resp (str "```tool-call\n"
+                  "{\"name\": \"write_file\", \"args\": {\"path\": \"a.clj\","
+                  " \"content\": \"(= l \\\"```\\\")\\n\"}}\n"
+                  "```")
+        p (fence/parse-tool-call resp {})]
+    (is (= "write_file" (:name p)))
+    (is (str/includes? (str (get-in p [:args :content])) "```")
+        "the backticks arrive as file content"))
+  (testing "an XML closer inside a string is content too"
+    (let [p (fence/parse-tool-call
+             (str "```tool-call\n"
+                  "{\"name\": \"write_file\", \"args\": {\"path\": \"a.md\","
+                  " \"content\": \"about </tool-call> tags\"}}\n"
+                  "```")
+             {})]
+      (is (= "write_file" (:name p)))))
+  (testing "an unterminated string ahead of a raw closer still earns its
+            parse error — the raw-closer fallback keeps the truncation shape
+            reported rather than silently becoming a no-call"
+    (let [p (fence/parse-tool-call
+             (str "```tool-call\n"
+                  "{\"name\": \"write_file\", \"args\": {\"content\": \"half a file\n"
+                  "```")
+             {})]
+      (is (= "__parse_error__" (:name p))))))
+
 (deftest prefill-plus-think-plus-real-call-parses
   ;; The live self-building run (2026-08-21) thrashed on this: after a parse
   ;; error the loop prefills "```tool-call\n" to force a bare call, but GLM is


### PR DESCRIPTION
Found while classifying the Qwen baseline's ~16% parse-error rate (karamazov-hpv): 6 of 8 failures were the extractor cutting a VALID call at a ``` inside a JSON string value - the mdlite task is a markdown converter, so its own code contains fence literals. The closer scan now uses the same in-string state machine as close-unbalanced, with the raw scan kept as fallback so truncated replies still earn their parse error. Verified against the run's actual failing turn (parses into the full 6.6k-char write_file). Suite: 1367 tests green on main + this fix.

Should merge to main ahead of the tier PRs (#10-#12) and both campaign arms should run with it - it removes a harness artifact from the parse-error signal the guard experiments read.