### PR TITLE
Context overflow is fatal and squeezes the branch, not retried

### DIFF
--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -939,6 +939,20 @@
         Not capability-tunable: these are what the supervisor SEES, and a run
         in trouble is the last one that should be shown less of it."}
 
+ :context-squeeze
+ {:value {:factor 0.5 :min-keep-pairs 1 :min-compaction-chars 5000}
+  :kind :threshold :capability-tunable? true
+  :doc "How hard a context-overflow squeezes a branch's compaction budget
+        (karamazov-d41). When the provider reports the prompt outgrew its
+        window — a DETERMINISTIC failure the retry ladder must not touch —
+        the loop bumps the branch's squeeze level instead of appending a
+        retry message, and render scales :context-budget's :keep-pairs and
+        :compaction-chars by :factor per level, floored at the minimums so
+        a squeezed branch still sees its current exchange. Observed live on
+        the Qwen baseline against llama-server -c 32768: the GLM-sized
+        budget assembled ~33k-token prompts and the branch re-sent them on
+        backoff, burning wall-clock against a wall."}
+
  :context-budget
  {:value {:tool-result-chars   4000
           :file-read-chars     60000

--- a/resources/wordlists.edn
+++ b/resources/wordlists.edn
@@ -176,6 +176,18 @@
  ;; place by being placeholders and nothing else.
  "(?i)none\\.?|n/?a\\.?|\\[.*\\]"
 
+ :context-overflow
+ ;; How providers word a context-window overflow (karamazov-d41). A 500
+ ;; carrying one of these is DETERMINISTIC — the same oversized prompt fails
+ ;; the same way every time — so it must never be retried on backoff (the
+ ;; Qwen baseline burned 3 attempts x up to 32s per turn against llama-server's
+ ;; wall) and instead triggers the context squeeze (gates.edn
+ ;; :context-squeeze). A regex PATTERN STRING matched against the raw
+ ;; response body; it has to track how endpoints actually word it:
+ ;; llama.cpp says 'Context size has been exceeded', OpenAI-compatible
+ ;; servers say 'maximum context length' / 'context_length_exceeded'.
+ "(?i)context (size|length|window)|context_length_exceeded|maximum context"
+
  :shell-refusal
  ;; How the shell policy phrases a refusal. Read to turn a refused command
  ;; into a durable project fact, which is worth more than it looks: it saves

--- a/src/samizdat/agent/infer.clj
+++ b/src/samizdat/agent/infer.clj
@@ -76,6 +76,10 @@
   {:id (:id branch)
    :messages (vec (:messages branch))
    :turns (vec (:turns branch))
+   ;; The overflow squeeze level (state/squeeze-context) rides the tape so
+   ;; render can scale the compaction budget without reaching back into the
+   ;; branch (karamazov-d41).
+   :squeeze (:context-squeeze branch)
    :prefill (:prefill branch)
    :force-tool (:force-tool branch)})
 
@@ -91,6 +95,24 @@
       (assoc :messages (:messages tape))
       (dissoc :prefill :force-tool)))
 
+(defn squeezed-budget
+  "The compaction budget after this tape's overflow squeeze (karamazov-d41).
+
+  A branch that overflowed the provider's window carries a squeeze level
+  (state/squeeze-context); each level scales :keep-pairs and
+  :compaction-chars down by the policy's :factor, floored at the minimums so
+  a squeezed branch still sees its current exchange. Level 0 (or nil) is the
+  budget untouched."
+  [{:keys [keep-pairs compaction-chars]} squeeze
+   {:keys [factor min-keep-pairs min-compaction-chars]}]
+  (let [scale (if (pos? (or squeeze 0))
+                (Math/pow (double factor) (double squeeze))
+                1.0)]
+    {:keep-pairs (max (long min-keep-pairs)
+                      (long (* keep-pairs scale)))
+     :threshold-chars (max (long min-compaction-chars)
+                           (long (* compaction-chars scale)))}))
+
 (defn render
   "The tape as it goes to the wire: older turns compacted, recent ones
   verbatim. The tape's own array is untouched, so the journal and a resume
@@ -100,10 +122,11 @@
   llm.message is pure message shaping and stays that way, so the numbers that
   decide how much history survives are supplied by the caller that knows about
   policy. gates.edn :context-budget owns them."
-  [{:keys [messages turns]}]
-  (let [{:keys [keep-pairs compaction-chars]} (gates/threshold :context-budget)]
-    (message/compact messages turns {:keep-pairs keep-pairs
-                                     :threshold-chars compaction-chars})))
+  [{:keys [messages turns squeeze]}]
+  (message/compact messages turns
+                   (squeezed-budget (gates/threshold :context-budget)
+                                    squeeze
+                                    (gates/threshold :context-squeeze))))
 
 ;; --- the effect seam --------------------------------------------------------
 

--- a/src/samizdat/agent/loop.clj
+++ b/src/samizdat/agent/loop.clj
@@ -347,10 +347,18 @@
                          {:branch-id (:id branch) :turn turn
                           :tool-name "__provider_error__" :result error
                           :category "neutral"})
-   (state/add-message branch "user"
-                      (str "[harness] The provider call failed: " error
-                           " Try again.")
-                      {:turn turn})))
+   (if (= :context-overflow reason)
+     ;; The prompt outgrew the window. 'Try again' is exactly wrong here —
+     ;; the failure is upstream of the model seeing anything, the next
+     ;; assemble would be just as oversized, and APPENDING a message grows
+     ;; the very thing that overflowed. Squeeze the branch's compaction
+     ;; budget instead (karamazov-d41): the next render fits, and the model
+     ;; continues none the wiser, which is how compaction always works.
+     (state/squeeze-context branch)
+     (state/add-message branch "user"
+                        (str "[harness] The provider call failed: " error
+                             " Try again.")
+                        {:turn turn}))))
 
 (defn absorb-response
   "Fold the model's response into the branch.

--- a/src/samizdat/agent/state.clj
+++ b/src/samizdat/agent/state.clj
@@ -585,6 +585,19 @@
   (cond-> (update branch :artifacts conj artifact)
     (:tier artifact) (update :tiers-seen (fnil conj #{}) (:tier artifact))))
 
+(defn squeeze-context
+  "Tighten this branch's compaction budget one notch (karamazov-d41).
+
+  Set by the loop when the provider says the prompt outgrew its context
+  window. The squeeze level scales the gates.edn :context-budget compaction
+  numbers down (infer/render applies gates.edn :context-squeeze), so the
+  NEXT assemble fits where this one did not — recovery is harness-side and
+  invisible to the model, exactly like compaction always is. Never unwound:
+  a branch that hit the wall once will grow back into it, and the level is
+  the durable record that it did."
+  [branch]
+  (update branch :context-squeeze (fnil inc 0)))
+
 (defn add-turn
   "Record one turn on the branch. `entry` carries :turn, :tool, :category, and
   for a failure the :error it produced — the last so `repeating-failure?` can

--- a/src/samizdat/llm/client.clj
+++ b/src/samizdat/llm/client.clj
@@ -41,8 +41,10 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [jolt.http-client :as http]
+            [samizdat.lexicon :as lexicon]
             [samizdat.llm.adapter :as adapter]
             [samizdat.llm.message :as message]
+            [samizdat.util :as util]
             [samizdat.session :as session]))
 
 (def default-max-retries 2)
@@ -92,6 +94,25 @@
                       parse-long)]
     (when-let [s (or secs reset)]
       (* 1000 (max 0 s)))))
+
+(def ^:private context-overflow-re
+  ;; wordlists.edn :context-overflow — how endpoints word a window overflow.
+  ;; Data, because the wording is theirs to change and the supervisor's to
+  ;; track (karamazov-d41).
+  (util/generation-cache lexicon/gen
+                         #(re-pattern (lexicon/wordlist :context-overflow))))
+
+(defn context-overflow?
+  "Whether this response body says the prompt outgrew the context window.
+
+  A 500 wearing this message is DETERMINISTIC — the same oversized prompt
+  fails identically every time — so retrying it on backoff burns wall-clock
+  to learn nothing. Observed live on the Qwen baseline (run b8a2b72c,
+  llama-server -c 32768): a branch past the wall re-sent the same prompt
+  three times with up to 32s of backoff per turn (karamazov-d41). Matched on
+  the RAW body so an undecodable error page still classifies."
+  [raw-body]
+  (boolean (re-find (context-overflow-re) (str raw-body))))
 
 (defn classify
   "Decide what to do about a non-2xx response.
@@ -171,13 +192,19 @@
            :error (str (adapter/display-name adapter)
                        " reply had no completion in it: "
                        (subs (str (:body resp)) 0 (min 300 (count (str (:body resp))))))}))
-      {:outcome (classify adapter status decoded)
-       :headers (:headers resp)
-       :error (str (adapter/display-name adapter) " error " status
-                   (when-let [m (adapter/error-message adapter decoded)] (str " — " m))
-                   (when-not decoded
-                     (str " — " (subs (str (:body resp))
-                                      0 (min 300 (count (str (:body resp))))))))})))
+      ;; A context overflow outranks the status-code ladder: it is the one
+      ;; 5xx that is deterministic, and the reason travels from where it is
+      ;; detected so the loop can respond by compacting rather than retrying
+      ;; (karamazov-d41).
+      (let [overflow? (context-overflow? (:body resp))]
+        (cond-> {:outcome (if overflow? :fatal (classify adapter status decoded))
+                 :headers (:headers resp)
+                 :error (str (adapter/display-name adapter) " error " status
+                             (when-let [m (adapter/error-message adapter decoded)] (str " — " m))
+                             (when-not decoded
+                               (str " — " (subs (str (:body resp))
+                                                0 (min 300 (count (str (:body resp))))))))}
+          overflow? (assoc :reason :context-overflow))))))
 
 ;; --- the public surface -----------------------------------------------------
 

--- a/test/samizdat/infer_test.clj
+++ b/test/samizdat/infer_test.clj
@@ -10,7 +10,9 @@
   what a turn would do without running one."
   (:require [clojure.test :refer [deftest is testing]]
             [samizdat.agent.infer :as infer]
+            [samizdat.agent.loop :as aloop]
             [samizdat.agent.state :as state]
+            [samizdat.store.journal :as journal]
             [samizdat.tape :as tape]))
 
 (defn- fenced
@@ -44,8 +46,10 @@
                  :prefill "```tool-call\n"
                  :force-tool {:name "done"})
         t (infer/of-branch b)]
-    (is (= #{:id :messages :turns :prefill :force-tool} (set (keys t)))
-        "nothing else about a branch can change what the model is sent")
+    (is (= #{:id :messages :turns :prefill :force-tool :squeeze} (set (keys t)))
+        "nothing else about a branch can change what the model is sent —
+         :squeeze is on the list because the overflow squeeze legitimately
+         changes how much history the wire sees (karamazov-d41)")
     (is (= "B1" (:id t)))
     (is (= "```tool-call\n" (:prefill t)))))
 
@@ -177,3 +181,46 @@
         _ (infer/ab (fn [_] (replying "ok" seen)) base-tape [:a])]
     (is (= 2 (count (:messages (first @seen))))
         "no probe turn is invented when the caller did not ask for one")))
+
+;; --- the context squeeze (karamazov-d41) ------------------------------------
+
+(deftest the-overflow-squeeze-scales-the-compaction-budget
+  (let [budget {:keep-pairs 10 :compaction-chars 50000}
+        policy {:factor 0.5 :min-keep-pairs 1 :min-compaction-chars 5000}]
+    (testing "no squeeze, no change"
+      (is (= {:keep-pairs 10 :threshold-chars 50000}
+             (infer/squeezed-budget budget nil policy)))
+      (is (= {:keep-pairs 10 :threshold-chars 50000}
+             (infer/squeezed-budget budget 0 policy))))
+    (testing "each level halves"
+      (is (= {:keep-pairs 5 :threshold-chars 25000}
+             (infer/squeezed-budget budget 1 policy)))
+      (is (= {:keep-pairs 2 :threshold-chars 12500}
+             (infer/squeezed-budget budget 2 policy))))
+    (testing "the floors hold no matter how deep the squeeze"
+      (is (= {:keep-pairs 1 :threshold-chars 5000}
+             (infer/squeezed-budget budget 9 policy))
+          "a squeezed branch still sees its current exchange"))))
+
+(deftest the-squeeze-rides-the-tape
+  (let [b (-> (state/new-branch {:id "B1" :problem "p"})
+              state/squeeze-context
+              state/squeeze-context)]
+    (is (= 2 (:context-squeeze b)))
+    (is (= 2 (:squeeze (infer/of-branch b))))))
+
+(deftest a-context-overflow-squeezes-instead-of-asking-for-a-retry
+  (with-redefs [journal/record-turn! (fn [& _] nil)]
+    (let [b (state/new-branch {:id "B1" :problem "p"})
+          n (count (:messages b))]
+      (testing "overflow: squeeze, and DO NOT append — a message grows the
+                very thing that overflowed, and the model never saw the
+                failure anyway"
+        (let [b' (aloop/provider-error-step {} b 3 "context exceeded"
+                                            :context-overflow)]
+          (is (= 1 (:context-squeeze b')))
+          (is (= n (count (:messages b'))))))
+      (testing "any other provider failure keeps the try-again message"
+        (let [b' (aloop/provider-error-step {} b 3 "boom" :call-failed)]
+          (is (nil? (:context-squeeze b')))
+          (is (= (inc n) (count (:messages b')))))))))

--- a/test/samizdat/llm_test.clj
+++ b/test/samizdat/llm_test.clj
@@ -38,6 +38,21 @@
 
 (defn- fenced [body] (str "prose before\n```tool-call\n" body "\n```\nprose after"))
 
+(deftest a-context-overflow-is-recognized-from-the-body
+  ;; karamazov-d41: a 500 wearing this message is deterministic — the same
+  ;; oversized prompt fails identically every time — so post-once classifies
+  ;; it :fatal with :reason :context-overflow instead of walking the backoff
+  ;; ladder. The wording is wordlists.edn data, because it is the endpoints'
+  ;; to change.
+  (is (client/context-overflow?
+       "{\"error\":{\"message\":\"Context size has been exceeded.\"}}")
+      "llama-server's wording")
+  (is (client/context-overflow?
+       "This model's maximum context length is 32768 tokens"))
+  (is (client/context-overflow? "code: context_length_exceeded"))
+  (is (not (client/context-overflow? "internal server error")))
+  (is (not (client/context-overflow? nil))))
+
 (deftest a-fence-marker-inside-a-json-string-is-content-not-a-closer
   ;; Qwen baseline run b8a2b72c (karamazov-hpv): the mdlite task builds a
   ;; MARKDOWN CONVERTER, so the file being written contains literal ``` —


### PR DESCRIPTION
karamazov-d41, observed live on the Qwen baseline: branches past llama-server's 32k wall re-sent the same oversized prompt on backoff, and the retry busy-loop starved the harness HTTP thread. Overflow is now recognized from the body (wordlists.edn data), classified fatal with a typed reason, and the loop's response is a compaction squeeze (gates.edn :context-squeeze) instead of a retry message - harness-side recovery, invisible to the model. Suite: 1371 tests green.