### PR TITLE
The repair ladder is a composition, so it lives in a manifest

### DIFF
--- a/resources/cells/repair.clj
+++ b/resources/cells/repair.clj
@@ -1,0 +1,59 @@
+;; samizdat - a self-hosting agentic harness
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; The tool-call REPAIR LADDER as cells. The rungs themselves are core
+;; mechanism (samizdat.llm.fence) — string-aware scanners any workflow needs
+;; to receive a call at all — but WHICH rungs run, and in what order, is a
+;; composition, and composition is this layer's business. The `repair`
+;; manifest wires these in order; the system installs the compiled manifest
+;; into fence's repair seam at startup, so editing the manifest (or one of
+;; these cells) through the ordinary mutation path changes how the very next
+;; malformed call is repaired — no rebuild, no restart.
+;;
+;; Two rules every rung honors:
+;;   - each rung is validated by the caller's re-parse, never by its own
+;;     optimism (dirge's valid-but-wrong lesson: a repair that produces
+;;     parseable output can still produce the WRONG output, so the ladder
+;;     only ever makes a parse possible, and repairs that could fabricate
+;;     content — closing an unterminated string — are refused in the rung).
+;;   - the data map carries :body and nothing else is touched, so a rung a
+;;     project adds composes without knowing its neighbours.
+(ns cells.repair
+  (:require [mycelium.cell :as cell]
+            [samizdat.llm.fence :as fence]))
+
+(cell/defcell :repair/control-chars
+  {:doc "Escape raw newlines, carriage returns and tabs inside string
+        literals — the dominant malformation when a model hands over
+        multi-line code. First, so every later rung sees intact string
+        boundaries."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/repair-control-chars)))
+
+(cell/defcell :repair/trailing-commas
+  {:doc "Drop commas that sit directly before a } or ], outside strings —
+        interior ones too, since a mid-body trailing comma survives any
+        repair that only looks at the tail."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/strip-trailing-commas)))
+
+(cell/defcell :repair/dangling-key
+  {:doc "Complete a body that stops right after a key with null, so the
+        closers can land and the tool's own missing-argument check names
+        exactly which argument was lost. Refuses a body that stops inside a
+        string — that is the truncation shape, and half a file written as a
+        success costs the work."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/fill-dangling-key)))
+
+(cell/defcell :repair/close-unbalanced
+  {:doc "Append the } and ] the body is missing, counted outside strings.
+        Last, after the dangling key is filled, or the closers would end an
+        object mid-entry. Only ever adds; a body ending inside a string is
+        left for the parse error to report."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/close-unbalanced)))

--- a/resources/manifests/repair.edn
+++ b/resources/manifests/repair.edn
@@ -1,0 +1,25 @@
+;; The tool-call repair ladder, as a composition (karamazov-avk follow-up).
+;;
+;; A malformed tool-call body flows through these rungs in order; the caller
+;; (fence/repair-json, via the seam the system installs at startup) re-parses
+;; the result and repairs are only ever accepted when the re-parse succeeds.
+;; The rungs are core scanners in samizdat.llm.fence; the cells are thin
+;; wrappers in resources/cells/repair.clj; THIS file is the decision — which
+;; rungs, in what order. Drop, reorder, or add a rung through the ordinary
+;; manifest mutation path and the next malformed call takes the new ladder.
+;;
+;; Order is load-bearing: control-chars first so every later string-aware
+;; scan sees intact string boundaries, closers last so they land after the
+;; dangling key is filled. If you add a rung, say here what it fixes and why
+;; its position is right — the next editor gets the reasoning, not just the
+;; wiring.
+{:description "The tool-call repair ladder: escape control characters inside strings, drop trailing commas, fill a dangling key with null, append missing closers. Edited like any manifest; the next malformed call takes the new ladder. Repairs must only make a parse possible - a rung that could fabricate content does not belong on it."
+ :cells {:start    :repair/control-chars
+         :commas   :repair/trailing-commas
+         :dangling :repair/dangling-key
+         :closers  :repair/close-unbalanced}
+
+ :edges {:start    :commas
+         :commas   :dangling
+         :dangling :closers
+         :closers  :end}}

--- a/src/samizdat/cells.clj
+++ b/src/samizdat/cells.clj
@@ -105,7 +105,8 @@
   these and wins, and in a source checkout the dir scan reads the very same
   files, so a shipped cell edited in place is picked up from disk."
   ["cells/beam.clj" "cells/board.clj" "cells/critic.clj" "cells/decompose.clj"
-   "cells/feature.clj" "cells/loop.clj" "cells/probe.clj" "cells/team.clj"])
+   "cells/feature.clj" "cells/loop.clj" "cells/probe.clj" "cells/repair.clj"
+   "cells/team.clj"])
 
 (defn- shipped-sources
   "The shipped cells as {:id :content} — read from the classpath (embedded or

--- a/src/samizdat/llm/fence.clj
+++ b/src/samizdat/llm/fence.clj
@@ -218,19 +218,50 @@
       (str input " null")
       input)))
 
-(defn repair-json
-  "One repair pass over a tool-call body, cheapest and safest first: control
-  characters inside strings, trailing commas, a dangling key at the end,
-  then unbalanced closers. Order matters — every later scan has to see the
-  string boundaries the control-char pass leaves intact, and the closers
-  must be appended after the dangling key is filled or they would close an
-  object mid-entry."
+(defn default-repair
+  "The built-in repair ladder, cheapest and safest first: control characters
+  inside strings, trailing commas, a dangling key at the end, then
+  unbalanced closers. Order matters — every later scan has to see the string
+  boundaries the control-char pass leaves intact, and the closers must be
+  appended after the dangling key is filled or they would close an object
+  mid-entry.
+
+  This is the FALLBACK composition. The rungs are mechanism — lego blocks —
+  but which rungs run, and in what order, is a composition, and composition
+  is the workflow layer's business: resources/manifests/repair.edn wires the
+  same rungs as cells, the system installs it below, and a project can
+  reorder, drop, or add a rung at runtime through the ordinary manifest
+  mutation path. This chain exists so a bare REPL, a unit test, or a broken
+  repair manifest still parses calls."
   [^String input]
   (-> input
       repair-control-chars
       strip-trailing-commas
       fill-dangling-key
       close-unbalanced))
+
+(def ^:private installed-repair (atom nil))
+
+(defn install-repair!
+  "Install the workflow-layer repair composition — a fn from body to
+  repaired body, typically one that runs the project's `repair` manifest.
+  nil uninstalls. The seam is an install point rather than a require because
+  fence sits below the workflow layer in the require graph and must not
+  reach up into it."
+  [f]
+  (reset! installed-repair f))
+
+(defn repair-json
+  "One repair pass over a tool-call body: the installed composition when a
+  system has installed one, else the built-in default. FAIL-OPEN, and that
+  is load-bearing: a repair manifest the agent broke mid-edit must degrade
+  to the default chain, never take parsing down with it — the mutation
+  protocol validates saves, but the seam does not get to assume it."
+  [^String input]
+  (if-let [f @installed-repair]
+    (let [out (try (f input) (catch Throwable _ nil))]
+      (if (string? out) out (default-repair input)))
+    (default-repair input)))
 
 (defn- parse-error [msg extra]
   (merge {:name "__parse_error__" :args {} :parse-error msg} extra))

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -50,7 +50,8 @@
   binary (same reasoning as cells/shipped-cells and prompt/shipped-prompts).
   Pinned against the directory by workflow-test."
   ["loop" "beam" "critic" "orchestrator" "probe" "review" "reviewer"
-   "supervisor" "worker" "team" "board" "board-bt" "feature" "decompose"])
+   "supervisor" "worker" "team" "board" "board-bt" "feature" "decompose"
+   "repair"])
 
 (defn manifest-resource
   "The factory resource path a manifest name seeds from, e.g. \"loop\" ->

--- a/src/samizdat/system.clj
+++ b/src/samizdat/system.clj
@@ -41,7 +41,10 @@
             [samizdat.lexicon :as lexicon]
             [samizdat.config :as config]
             [samizdat.llm.client :as llm-client]
+            [samizdat.llm.fence :as fence]
             [samizdat.llm.registry :as registry]
+            [samizdat.manifests :as manifests]
+            [mycelium.core :as myc]
             [samizdat.session :as session]
             [samizdat.lsp.client :as lsp-client]
             [samizdat.store.db :as db]
@@ -139,6 +142,17 @@
          ;; (a bare REPL, a unit test) the same reads fall back to the
          ;; templates, which is what the harness did before the store existed.
          _ (bind-project! c)
+         ;; The repair ladder is a COMPOSITION, so the workflow layer owns it:
+         ;; the `repair` manifest wires the fence's rung fns as cells, and
+         ;; this install is how the fence — which sits below the workflow
+         ;; layer and cannot require it — runs the project's version. Resolved
+         ;; per call through compiled-manifest, so a manifest or cell edit
+         ;; takes effect on the very next malformed call; fence's repair-json
+         ;; fails open to its built-in chain if the manifest is broken.
+         _ (fence/install-repair!
+            (fn [body]
+              (:body (myc/run-compiled (manifests/compiled-manifest "repair")
+                                       {} {:body body}))))
          server (adapter/run-server handler {:port (get-in cfg [:http :port])})]
      (reset! system {:config cfg :conn c :server server})
      (log/info "samizdat up on port" (get-in cfg [:http :port])
@@ -178,6 +192,10 @@
                                  (log/warn "run" rid "did not stop within 15s;"
                                            "closing the system under it")))))]
                        ["http server" #(adapter/stop-server (:server s))]
+                       ;; Uninstall so a bare REPL after stop! parses with the
+                       ;; built-in chain instead of resolving manifests against
+                       ;; an unbound store.
+                       ["repair seam" #(fence/install-repair! nil)]
                        ["lsp clients" #(lsp-client/shutdown-all!)]
                        ;; Unbind BEFORE the connection closes: a userspace read
                        ;; against a closed handle would throw where the same

--- a/test/samizdat/repair_test.clj
+++ b/test/samizdat/repair_test.clj
@@ -1,0 +1,83 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.repair-test
+  "The repair ladder as a composition: rungs are core fns, cells wrap them,
+  the `repair` manifest wires them, and fence's seam runs the installed
+  composition with the built-in chain as the fail-open fallback."
+  (:require [clojure.test :refer [deftest testing is]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [samizdat.cells :as cells]
+            [samizdat.llm.fence :as fence]
+            [samizdat.manifests :as manifests]))
+
+(defn- manifest-repair
+  "Run one body through the compiled repair manifest, as the installed seam
+  does."
+  [body]
+  (when (nil? (cell/get-cell :repair/control-chars))
+    (cells/load-cells!))
+  (:body (myc/run-compiled (manifests/compiled-manifest "repair")
+                           {} {:body body})))
+
+(def ^:private fixtures
+  ["{\"name\": \"t\", \"args\": {\"code\": \"(+ 1\n2)\"}}"     ; raw newline
+   "{\"name\": \"t\", \"args\": {\"a\": [1, 2,], \"b\": 3,}}"  ; trailing commas
+   "{\"name\": \"t\", \"args\": {\"op\":"                      ; dangling key
+   "{\"name\": \"t\", \"args\": {\"a\": 1}"                    ; missing closer
+   "{\"name\": \"t\", \"args\": {\"s\": \"half"])              ; ends in string
+
+(deftest the-manifest-composition-matches-the-built-in-chain
+  ;; Same rungs, same order — the manifest is the same ladder expressed as
+  ;; data. If this ever diverges, either the manifest was edited (fine, and
+  ;; this test is the notice that the factory default moved) or a rung
+  ;; changed without its cell (a bug).
+  (doseq [f fixtures]
+    (is (= (fence/default-repair f) (manifest-repair f))
+        (pr-str f))))
+
+(deftest every-rung-cell-is-pure
+  ;; A repair rung that declared effects could be soaked, journalled, and
+  ;; retried — none of which a string transform needs, and purity is what
+  ;; lets the mutation protocol validate an edited rung cheaply.
+  (when (nil? (cell/get-cell :repair/control-chars))
+    (cells/load-cells!))
+  (doseq [id [:repair/control-chars :repair/trailing-commas
+              :repair/dangling-key :repair/close-unbalanced]]
+    (is (:pure (cell/get-cell id)) (str id))))
+
+(deftest the-seam-prefers-the-installed-composition-and-fails-open
+  (try
+    (testing "an installed composition is what repair-json runs"
+      (fence/install-repair! (fn [body] (str body "]")))
+      (is (= "x]" (fence/repair-json "x"))))
+    (testing "a broken composition falls back to the built-in chain"
+      (fence/install-repair! (fn [_] (throw (ex-info "boom" {}))))
+      (is (= (fence/default-repair "{\"a\": 1,}")
+             (fence/repair-json "{\"a\": 1,}"))))
+    (testing "a composition returning a non-string falls back too"
+      (fence/install-repair! (fn [_] nil))
+      (is (= (fence/default-repair "{\"a\": 1")
+             (fence/repair-json "{\"a\": 1"))))
+    (testing "uninstalled, the default chain runs"
+      (fence/install-repair! nil)
+      (is (= (fence/default-repair "{\"a\": 1,}")
+             (fence/repair-json "{\"a\": 1,}"))))
+    (finally
+      (fence/install-repair! nil))))

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -118,6 +118,7 @@
             [samizdat.proc-test]
             [samizdat.board-bt-test]
             [samizdat.finalization-test]
+            [samizdat.repair-test]
             [samizdat.storm-test]
             [samizdat.tournament-test]
             [samizdat.trajectory-test]
@@ -175,6 +176,7 @@
     mycelium.workflow-test
     samizdat.board-bt-test
     samizdat.finalization-test
+    samizdat.repair-test
     samizdat.storm-test
     samizdat.tournament-test
     samizdat.trajectory-test


### PR DESCRIPTION
Follow-up to #15 from the core-vs-userspace rule of thumb: rungs are lego blocks (core fns), the ladder is a composition (repair.edn manifest + pure cells), installed at start through a fail-open seam and resolved through the userspace store per call - the agent can drop, reorder, or add a rung at runtime through the ordinary manifest mutation path. Suite: 1417 tests green.