### PR TITLE
The supervisor sees the failures, and can open them

### DIFF
--- a/resources/cells/repair.clj
+++ b/resources/cells/repair.clj
@@ -1,0 +1,59 @@
+;; samizdat - a self-hosting agentic harness
+;; SPDX-License-Identifier: GPL-3.0-or-later
+;;
+;; The tool-call REPAIR LADDER as cells. The rungs themselves are core
+;; mechanism (samizdat.llm.fence) — string-aware scanners any workflow needs
+;; to receive a call at all — but WHICH rungs run, and in what order, is a
+;; composition, and composition is this layer's business. The `repair`
+;; manifest wires these in order; the system installs the compiled manifest
+;; into fence's repair seam at startup, so editing the manifest (or one of
+;; these cells) through the ordinary mutation path changes how the very next
+;; malformed call is repaired — no rebuild, no restart.
+;;
+;; Two rules every rung honors:
+;;   - each rung is validated by the caller's re-parse, never by its own
+;;     optimism (dirge's valid-but-wrong lesson: a repair that produces
+;;     parseable output can still produce the WRONG output, so the ladder
+;;     only ever makes a parse possible, and repairs that could fabricate
+;;     content — closing an unterminated string — are refused in the rung).
+;;   - the data map carries :body and nothing else is touched, so a rung a
+;;     project adds composes without knowing its neighbours.
+(ns cells.repair
+  (:require [mycelium.cell :as cell]
+            [samizdat.llm.fence :as fence]))
+
+(cell/defcell :repair/control-chars
+  {:doc "Escape raw newlines, carriage returns and tabs inside string
+        literals — the dominant malformation when a model hands over
+        multi-line code. First, so every later rung sees intact string
+        boundaries."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/repair-control-chars)))
+
+(cell/defcell :repair/trailing-commas
+  {:doc "Drop commas that sit directly before a } or ], outside strings —
+        interior ones too, since a mid-body trailing comma survives any
+        repair that only looks at the tail."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/strip-trailing-commas)))
+
+(cell/defcell :repair/dangling-key
+  {:doc "Complete a body that stops right after a key with null, so the
+        closers can land and the tool's own missing-argument check names
+        exactly which argument was lost. Refuses a body that stops inside a
+        string — that is the truncation shape, and half a file written as a
+        success costs the work."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/fill-dangling-key)))
+
+(cell/defcell :repair/close-unbalanced
+  {:doc "Append the } and ] the body is missing, counted outside strings.
+        Last, after the dangling key is filled, or the closers would end an
+        object mid-entry. Only ever adds; a body ending inside a string is
+        left for the parse error to report."
+   :pure true
+   :requires []}
+  (fn [_ data] (update data :body fence/close-unbalanced)))

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -1068,6 +1068,19 @@
         Not capability-tunable: these are what the supervisor SEES, and a run
         in trouble is the last one that should be shown less of it."}
 
+ :supervisor-digest
+ {:value {:per-kind 4 :chars 220}
+  :kind :threshold :capability-tunable? true
+  :doc "How many failure exemplars of each kind the run-health digest shows
+        the supervisor, and how much of each failure's text. The digest used
+        to carry only RATES — 'this branch thrashed 8 times' — and a rate
+        says something is wrong where the exemplar says what: the parse
+        error's own complaint, the provider's own words, the failing tool's
+        result, each with the journal row id fetch_turn takes. Newest last,
+        per kind, because the three kinds are fixed in different places (a
+        parse failure in the prompt/format, a provider failure at the
+        endpoint, a tool failure in the work itself)."}
+
  :context-squeeze
  {:value {:factor 0.5 :min-keep-pairs 1 :min-compaction-chars 5000}
   :kind :threshold :capability-tunable? true

--- a/resources/manifests/repair.edn
+++ b/resources/manifests/repair.edn
@@ -1,0 +1,25 @@
+;; The tool-call repair ladder, as a composition (karamazov-avk follow-up).
+;;
+;; A malformed tool-call body flows through these rungs in order; the caller
+;; (fence/repair-json, via the seam the system installs at startup) re-parses
+;; the result and repairs are only ever accepted when the re-parse succeeds.
+;; The rungs are core scanners in samizdat.llm.fence; the cells are thin
+;; wrappers in resources/cells/repair.clj; THIS file is the decision — which
+;; rungs, in what order. Drop, reorder, or add a rung through the ordinary
+;; manifest mutation path and the next malformed call takes the new ladder.
+;;
+;; Order is load-bearing: control-chars first so every later string-aware
+;; scan sees intact string boundaries, closers last so they land after the
+;; dangling key is filled. If you add a rung, say here what it fixes and why
+;; its position is right — the next editor gets the reasoning, not just the
+;; wiring.
+{:description "The tool-call repair ladder: escape control characters inside strings, drop trailing commas, fill a dangling key with null, append missing closers. Edited like any manifest; the next malformed call takes the new ladder. Repairs must only make a parse possible - a rung that could fabricate content does not belong on it."
+ :cells {:start    :repair/control-chars
+         :commas   :repair/trailing-commas
+         :dangling :repair/dangling-key
+         :closers  :repair/close-unbalanced}
+
+ :edges {:start    :commas
+         :commas   :dangling
+         :dangling :closers
+         :closers  :end}}

--- a/resources/manual.edn
+++ b/resources/manual.edn
@@ -109,5 +109,13 @@
     :summary "Append a note to the run's journal. The durable record a later run reads back."}
    {:name samizdat.store.journal/artifacts
     :summary "Every artifact this run banked, across all branches."}
+   {:name samizdat.store.journal/branch-turns
+    :summary "One branch's turns as light rows — tool, args, category, result — the query to reach for when a failure report names a branch and you want its whole trajectory, not one turn."}
+   {:name samizdat.store.journal/gate-tally
+    :summary "Fired / met / met-late / unmet per gate for a run — whether the steering is being obeyed, per steer."}
+   {:name samizdat.agent.telemetry/failure-exemplars
+    :summary "The concrete failures behind the rates over any set of turn rows — parse errors, provider failures, tool failures, each with the turn and branch to fetch."}
+   {:name samizdat.session/render
+    :summary "The live session tally since a named mark — what changed while your last adjustment was in force."}
    {:name samizdat.events/subscribe
     :summary "A channel of every event published from now on, for watching a run without polling."}]}]

--- a/resources/prompts/fetch-turn-miss.md
+++ b/resources/prompts/fetch-turn-miss.md
@@ -1,0 +1,1 @@
+{% if cross %}No turn {{turn}} on branch {{branch}}.{% else %}No turn {{turn}} on this branch. The digest lists your own turns as t1, t2, …; pass `branch` to read a specific turn of another branch — for example one a failure report names.{% endif %}

--- a/resources/prompts/roles/supervisor.md
+++ b/resources/prompts/roles/supervisor.md
@@ -19,13 +19,20 @@ round should try something the last one didn't. Giving up is the last resort,
 not the reflex.
 
 You are given a run-health digest — worker outcomes, per-branch thrash, the
-review and critic decisions, the revision history, and the signals already
-flagged. Read it and **diagnose**: is the loop converging, or is something
-wrong? Look past the symptom to the cause. "No implementor shipped" is a symptom;
-the cause might be a turn cap that's too tight, a prompt that lets workers wander
-off-task, a decomposition that split the work badly, or a tool that keeps
-mis-parsing. You can look closer — read the journal, read a branch's transcript,
-read a cell or a prompt — before you decide.
+review and critic decisions, the revision history, the signals already
+flagged, and the run's FAILURES: the actual parse errors, provider failures
+and tool failures, in their own words, each with the journal row id that
+`fetch_turn` takes. **Start with the failures, not the catalog.** Browsing
+every workflow tells you what exists; the failure tells you where the
+problem is. Read the failure's own words, pull the full turn when the
+snippet isn't enough, and only then reach for the surface that governs it —
+a parse failure lives in the prompt or the call format, a provider failure
+at the endpoint or the context budget, a tool failure in the work or the
+tool. Look past the symptom to the cause: "no implementor shipped" is a
+symptom; the cause might be a turn cap that's too tight, a prompt that lets
+workers wander off-task, a decomposition that split the work badly, or a
+tool that keeps mis-parsing. A diagnosis that names a specific failing turn
+beats one that names a rate.
 
 ## The architecture you are steering
 

--- a/resources/prompts/run-health.md
+++ b/resources/prompts/run-health.md
@@ -5,6 +5,21 @@ Reviewer: {{reviewer}}   Critic: {{critic}}
 
 Per branch (turns / mechanics-thrash / shipped?):
 {{per-branch}}
-
+{% if failures %}
+Failures this run, newest last. Start HERE: read the failure's own words,
+then `fetch_turn({turn: N, branch: "B"})` for the full record, then fix the
+cause at the surface that governs it — a parse failure lives in the prompt
+or call format, a provider failure at the endpoint or the context budget, a
+tool failure in the work or the tool.
+{% if failures.parse %}
+Calls that did not parse ({{failures.parse.count}} total):
+{{failures.parse.lines}}
+{% endif %}{% if failures.provider %}
+Provider failures ({{failures.provider.count}} total):
+{{failures.provider.lines}}
+{% endif %}{% if failures.tool %}
+Tool failures ({{failures.tool.count}} total):
+{{failures.tool.lines}}
+{% endif %}{% endif %}
 Signals:
 {% if signals %}{{signals}}{% else %}- none flagged; the loop looks healthy{% endif %}

--- a/src/samizdat/agent/telemetry.clj
+++ b/src/samizdat/agent/telemetry.clj
@@ -11,10 +11,57 @@
   Pure over already-extracted facts + journal rows, so it is testable without a
   run. The supervisor is a general reasoning agent; this only gives it eyes."
   (:require [clojure.string :as str]
+            [samizdat.agent.gates :as gates]
             [samizdat.lexicon :as lexicon]
             [samizdat.prompt :as prompt]))
 
 (defn- s [x] (when x (str/lower-case (str (if (keyword? x) (name x) x)))))
+
+(defn failure-exemplars
+  "The concrete failures behind the rates, newest last, each carrying its
+  journal row id so `fetch_turn` can pull the full record.
+
+  A rate tells the supervisor something is wrong; the exemplar tells it
+  WHAT. The live session that motivated this (2026-08-27) found a parser
+  bug and a context-overflow retry loop by reading the actual failing rows
+  — the parse error's own complaint, the provider's own words — none of
+  which the digest carried. The supervisor's job is exactly that
+  read-the-failure-then-fix-the-cause loop, so the digest now leads with
+  the failures. Three kinds, because their fixes live in different places:
+  a call that did not parse is a format/prompt problem, a provider failure
+  is an endpoint problem, a tool failure is the work itself going wrong.
+
+  Returns DATA — {:parse :provider :tool}, each {:count n :lines s} or
+  absent — and the run-health template owns the words around it, so the
+  section headings the supervisor reads are prompts/ prose like everything
+  else it reads. Pure over the rows; caps are gates.edn :supervisor-digest
+  policy."
+  [rows {:keys [per-kind chars]}]
+  (let [snip (fn [x] (let [t (str/replace (str x) #"\s+" " ")]
+                       (if (> (count t) chars)
+                         (str (subs t 0 chars) "…")
+                         t)))
+        line (fn [r note]
+               (str "- turn " (:turn r) " (" (:branch_id r) ", row " (:id r)
+                    (when-let [t (:tool_name r)] (str ", " t)) "): "
+                    (snip note)))
+        kind (fn [lines]
+               (when (seq lines)
+                 {:count (count lines)
+                  :lines (str/join "\n" (take-last per-kind lines))}))
+        parse (for [r rows :when (= "__parse_error__" (:tool_name r))]
+                (line r (or (not-empty (str (:parse_error r))) (:result r))))
+        provider (for [r rows :when (= "__provider_error__" (:tool_name r))]
+                   (line r (:result r)))
+        tool (for [r rows
+                   :when (and (= "failure" (str (:category r)))
+                              (not (str/starts-with? (str (:tool_name r)) "__")))]
+               (line r (:result r)))
+        m (cond-> {}
+            (kind parse) (assoc :parse (kind parse))
+            (kind provider) (assoc :provider (kind provider))
+            (kind tool) (assoc :tool (kind tool)))]
+    (not-empty m)))
 
 (defn branch-health
   "Per-branch health from journal turn rows: turns taken, how many were
@@ -103,5 +150,8 @@
                             (for [[b h] health]
                               (str "- " b ": " (:turns h) " turns, "
                                    (:mechanics h) " thrash, shipped=" (:shipped? h))))
+      :failures (failure-exemplars rows (gates/threshold :supervisor-digest))
       :signals (when (seq sigs)
                  (str/join "\n" (map #(str "- " %) sigs)))})))
+;; NOTE: run-health.md destructures :failures itself ({{failures.parse.count}}
+;; etc.) — the map is the seam, the words are the template's.

--- a/src/samizdat/agent/tools/journal.clj
+++ b/src/samizdat/agent/tools/journal.clj
@@ -6,6 +6,7 @@
   (:require
             [clojure.string :as str]
             [samizdat.agent.tools.base :as base]
+            [samizdat.prompt :as prompt]
             [samizdat.store.journal :as journal]
             [samizdat.llm.message :as message]))
 
@@ -77,16 +78,30 @@
     (base/malformed branch m)
     (let [raw (str/trim (str (base/arg ctx :turn)))
           n (parse-long (str/replace raw #"^t" ""))
+          ;; An explicit :branch reads ANOTHER branch's turn — the diagnosis
+          ;; affordance the run-health digest's failure exemplars point at:
+          ;; the supervisor is handed "turn 3 (T0, ...)" and has to be able
+          ;; to open it, or the digest points at records its reader cannot
+          ;; reach. Deliberate and auditable (the fetch is itself a journalled
+          ;; turn); the DEFAULT stays own-branch, so sibling isolation — what
+          ;; crosses between peers is the settled-state block — still holds
+          ;; unless a branch asks for a specific other turn by name.
+          bid (or (some-> (base/arg ctx :branch) str str/trim not-empty)
+                  (:id branch))
           t (when (and conn run-id n)
-              (journal/branch-turn conn run-id (:id branch) n))]
+              (journal/branch-turn conn run-id bid n))]
       (if-not t
-        ;; :mechanics for the same reason as fetch_artifact's miss.
-        (base/malformed branch (str "No turn " raw " on this branch. The digest lists"
-                          " your own turns as t1, t2, …; a sibling's turns are"
-                          " not readable here — what crossed from them is in"
-                          " the settled-state block."))
+        ;; :mechanics for the same reason as fetch_artifact's miss. The words
+        ;; are prompts/fetch-turn-miss.md — the prose ratchet's rule.
+        (base/malformed branch
+                        (prompt/render "fetch-turn-miss"
+                                       {:turn raw
+                                        :branch bid
+                                        :cross (not= bid (:id branch))}))
         (base/ok branch
-            (str "t" (:turn t) " " (:tool_name t)
+            (str "t" (:turn t)
+                 (when (not= bid (:id branch)) (str " [" bid "]"))
+                 " " (:tool_name t)
                  " → " (or (:category t) "neutral")
                  (when (seq (str (:args t))) (str "\n\nARGUMENTS\n" (:args t)))
                  ;; Reasoning is stripped: it is 96% of stored assistant text

--- a/src/samizdat/cells.clj
+++ b/src/samizdat/cells.clj
@@ -105,7 +105,8 @@
   these and wins, and in a source checkout the dir scan reads the very same
   files, so a shipped cell edited in place is picked up from disk."
   ["cells/beam.clj" "cells/board.clj" "cells/critic.clj" "cells/decompose.clj"
-   "cells/feature.clj" "cells/loop.clj" "cells/probe.clj" "cells/team.clj"])
+   "cells/feature.clj" "cells/loop.clj" "cells/probe.clj" "cells/repair.clj"
+   "cells/team.clj"])
 
 (defn- shipped-sources
   "The shipped cells as {:id :content} — read from the classpath (embedded or

--- a/src/samizdat/llm/fence.clj
+++ b/src/samizdat/llm/fence.clj
@@ -218,19 +218,50 @@
       (str input " null")
       input)))
 
-(defn repair-json
-  "One repair pass over a tool-call body, cheapest and safest first: control
-  characters inside strings, trailing commas, a dangling key at the end,
-  then unbalanced closers. Order matters — every later scan has to see the
-  string boundaries the control-char pass leaves intact, and the closers
-  must be appended after the dangling key is filled or they would close an
-  object mid-entry."
+(defn default-repair
+  "The built-in repair ladder, cheapest and safest first: control characters
+  inside strings, trailing commas, a dangling key at the end, then
+  unbalanced closers. Order matters — every later scan has to see the string
+  boundaries the control-char pass leaves intact, and the closers must be
+  appended after the dangling key is filled or they would close an object
+  mid-entry.
+
+  This is the FALLBACK composition. The rungs are mechanism — lego blocks —
+  but which rungs run, and in what order, is a composition, and composition
+  is the workflow layer's business: resources/manifests/repair.edn wires the
+  same rungs as cells, the system installs it below, and a project can
+  reorder, drop, or add a rung at runtime through the ordinary manifest
+  mutation path. This chain exists so a bare REPL, a unit test, or a broken
+  repair manifest still parses calls."
   [^String input]
   (-> input
       repair-control-chars
       strip-trailing-commas
       fill-dangling-key
       close-unbalanced))
+
+(def ^:private installed-repair (atom nil))
+
+(defn install-repair!
+  "Install the workflow-layer repair composition — a fn from body to
+  repaired body, typically one that runs the project's `repair` manifest.
+  nil uninstalls. The seam is an install point rather than a require because
+  fence sits below the workflow layer in the require graph and must not
+  reach up into it."
+  [f]
+  (reset! installed-repair f))
+
+(defn repair-json
+  "One repair pass over a tool-call body: the installed composition when a
+  system has installed one, else the built-in default. FAIL-OPEN, and that
+  is load-bearing: a repair manifest the agent broke mid-edit must degrade
+  to the default chain, never take parsing down with it — the mutation
+  protocol validates saves, but the seam does not get to assume it."
+  [^String input]
+  (if-let [f @installed-repair]
+    (let [out (try (f input) (catch Throwable _ nil))]
+      (if (string? out) out (default-repair input)))
+    (default-repair input)))
 
 (defn- parse-error [msg extra]
   (merge {:name "__parse_error__" :args {} :parse-error msg} extra))

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -50,7 +50,8 @@
   binary (same reasoning as cells/shipped-cells and prompt/shipped-prompts).
   Pinned against the directory by workflow-test."
   ["loop" "beam" "critic" "orchestrator" "probe" "review" "reviewer"
-   "supervisor" "worker" "team" "board" "board-bt" "feature" "decompose"])
+   "supervisor" "worker" "team" "board" "board-bt" "feature" "decompose"
+   "repair"])
 
 (defn manifest-resource
   "The factory resource path a manifest name seeds from, e.g. \"loop\" ->

--- a/src/samizdat/prompt.clj
+++ b/src/samizdat/prompt.clj
@@ -49,6 +49,7 @@
    "experiment-tool"
    "explore-cap"
    "failure-log"
+   "fetch-turn-miss"
    "file-thrash"
    "file-tool"
    "fork-thesis"

--- a/src/samizdat/system.clj
+++ b/src/samizdat/system.clj
@@ -41,7 +41,10 @@
             [samizdat.lexicon :as lexicon]
             [samizdat.config :as config]
             [samizdat.llm.client :as llm-client]
+            [samizdat.llm.fence :as fence]
             [samizdat.llm.registry :as registry]
+            [samizdat.manifests :as manifests]
+            [mycelium.core :as myc]
             [samizdat.session :as session]
             [samizdat.lsp.client :as lsp-client]
             [samizdat.store.db :as db]
@@ -139,6 +142,17 @@
          ;; (a bare REPL, a unit test) the same reads fall back to the
          ;; templates, which is what the harness did before the store existed.
          _ (bind-project! c)
+         ;; The repair ladder is a COMPOSITION, so the workflow layer owns it:
+         ;; the `repair` manifest wires the fence's rung fns as cells, and
+         ;; this install is how the fence — which sits below the workflow
+         ;; layer and cannot require it — runs the project's version. Resolved
+         ;; per call through compiled-manifest, so a manifest or cell edit
+         ;; takes effect on the very next malformed call; fence's repair-json
+         ;; fails open to its built-in chain if the manifest is broken.
+         _ (fence/install-repair!
+            (fn [body]
+              (:body (myc/run-compiled (manifests/compiled-manifest "repair")
+                                       {} {:body body}))))
          server (adapter/run-server handler {:port (get-in cfg [:http :port])})]
      (reset! system {:config cfg :conn c :server server})
      (log/info "samizdat up on port" (get-in cfg [:http :port])
@@ -178,6 +192,10 @@
                                  (log/warn "run" rid "did not stop within 15s;"
                                            "closing the system under it")))))]
                        ["http server" #(adapter/stop-server (:server s))]
+                       ;; Uninstall so a bare REPL after stop! parses with the
+                       ;; built-in chain instead of resolving manifests against
+                       ;; an unbound store.
+                       ["repair seam" #(fence/install-repair! nil)]
                        ["lsp clients" #(lsp-client/shutdown-all!)]
                        ;; Unbind BEFORE the connection closes: a userspace read
                        ;; against a closed handle would throw where the same

--- a/test/samizdat/agent_test.clj
+++ b/test/samizdat/agent_test.clj
@@ -693,6 +693,32 @@
                                :tool-name "fetch_turn" :args {:id "t999"}})]
         (is (= :mechanics (:category r)) "same for a turn that is not there")))))
 
+(deftest fetch-turn-reads-another-branch-by-name
+  ;; The run-health digest hands the supervisor "turn 3 (T0, ...)"; without
+  ;; the :branch arg the reader could not open the very record the report
+  ;; names — a digest pointing at turns its reader cannot reach.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})
+          sup (state/new-branch {:id "S0" :problem "p"})]
+      (runs/open-branch! c rid {:branch-id "S0"})
+      (runs/open-branch! c rid {:branch-id "T0"})
+      (journal/record-turn! c rid {:branch-id "T0" :turn 3 :tool-name "shell"
+                                   :args "{\"command\": \"make\"}"
+                                   :result "make: no rule to make target"
+                                   :category "failure"})
+      (testing "an explicit branch opens the named record"
+        (let [r (tools/run-tool {:branch sup :conn c :run-id rid
+                                 :tool-name "fetch_turn"
+                                 :args {:turn 3 :branch "T0"}})]
+          (is (= :neutral (:category r)))
+          (is (str/includes? (str (:result r)) "make: no rule"))
+          (is (str/includes? (str (:result r)) "[T0]")
+              "labelled, so the reader knows whose turn it is looking at")))
+      (testing "the default stays own-branch"
+        (let [r (tools/run-tool {:branch sup :conn c :run-id rid
+                                 :tool-name "fetch_turn" :args {:turn 3}})]
+          (is (= :mechanics (:category r)) "S0 has no turn 3 of its own"))))))
+
 ;; --- the ship gate's test rung: done is not terminal until tests pass --------
 
 (deftest done-is-a-hard-gate-on-a-green-test-run

--- a/test/samizdat/base_test.clj
+++ b/test/samizdat/base_test.clj
@@ -537,10 +537,7 @@
    #{
     " Ids come from the settled-state block: `a#12` for"
     " it inherited. A run cannot reach another run's"
-    " not readable here — what crossed from them is in"
-    " on this branch. The digest lists"
     " something this run established, `s#7` for something"
-    " your own turns as t1, t2, …; a sibling's turns are"
     "CONFIRMED (inherited from the seed run)"
     }
    "src/samizdat/agent/tools/lsp.clj"

--- a/test/samizdat/repair_test.clj
+++ b/test/samizdat/repair_test.clj
@@ -1,0 +1,83 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.repair-test
+  "The repair ladder as a composition: rungs are core fns, cells wrap them,
+  the `repair` manifest wires them, and fence's seam runs the installed
+  composition with the built-in chain as the fail-open fallback."
+  (:require [clojure.test :refer [deftest testing is]]
+            [mycelium.cell :as cell]
+            [mycelium.core :as myc]
+            [samizdat.cells :as cells]
+            [samizdat.llm.fence :as fence]
+            [samizdat.manifests :as manifests]))
+
+(defn- manifest-repair
+  "Run one body through the compiled repair manifest, as the installed seam
+  does."
+  [body]
+  (when (nil? (cell/get-cell :repair/control-chars))
+    (cells/load-cells!))
+  (:body (myc/run-compiled (manifests/compiled-manifest "repair")
+                           {} {:body body})))
+
+(def ^:private fixtures
+  ["{\"name\": \"t\", \"args\": {\"code\": \"(+ 1\n2)\"}}"     ; raw newline
+   "{\"name\": \"t\", \"args\": {\"a\": [1, 2,], \"b\": 3,}}"  ; trailing commas
+   "{\"name\": \"t\", \"args\": {\"op\":"                      ; dangling key
+   "{\"name\": \"t\", \"args\": {\"a\": 1}"                    ; missing closer
+   "{\"name\": \"t\", \"args\": {\"s\": \"half"])              ; ends in string
+
+(deftest the-manifest-composition-matches-the-built-in-chain
+  ;; Same rungs, same order — the manifest is the same ladder expressed as
+  ;; data. If this ever diverges, either the manifest was edited (fine, and
+  ;; this test is the notice that the factory default moved) or a rung
+  ;; changed without its cell (a bug).
+  (doseq [f fixtures]
+    (is (= (fence/default-repair f) (manifest-repair f))
+        (pr-str f))))
+
+(deftest every-rung-cell-is-pure
+  ;; A repair rung that declared effects could be soaked, journalled, and
+  ;; retried — none of which a string transform needs, and purity is what
+  ;; lets the mutation protocol validate an edited rung cheaply.
+  (when (nil? (cell/get-cell :repair/control-chars))
+    (cells/load-cells!))
+  (doseq [id [:repair/control-chars :repair/trailing-commas
+              :repair/dangling-key :repair/close-unbalanced]]
+    (is (:pure (cell/get-cell id)) (str id))))
+
+(deftest the-seam-prefers-the-installed-composition-and-fails-open
+  (try
+    (testing "an installed composition is what repair-json runs"
+      (fence/install-repair! (fn [body] (str body "]")))
+      (is (= "x]" (fence/repair-json "x"))))
+    (testing "a broken composition falls back to the built-in chain"
+      (fence/install-repair! (fn [_] (throw (ex-info "boom" {}))))
+      (is (= (fence/default-repair "{\"a\": 1,}")
+             (fence/repair-json "{\"a\": 1,}"))))
+    (testing "a composition returning a non-string falls back too"
+      (fence/install-repair! (fn [_] nil))
+      (is (= (fence/default-repair "{\"a\": 1")
+             (fence/repair-json "{\"a\": 1"))))
+    (testing "uninstalled, the default chain runs"
+      (fence/install-repair! nil)
+      (is (= (fence/default-repair "{\"a\": 1,}")
+             (fence/repair-json "{\"a\": 1,}"))))
+    (finally
+      (fence/install-repair! nil))))

--- a/test/samizdat/telemetry_test.clj
+++ b/test/samizdat/telemetry_test.clj
@@ -50,3 +50,56 @@
     (is (str/includes? d "Reviewer: pass"))
     (is (str/includes? d "Critic: ship"))
     (is (str/includes? d "revision 1"))))
+
+;; --- failure exemplars: the digest leads with the problem, not the rate -----
+
+(deftest failure-exemplars-carry-the-turn-and-the-words
+  (let [rows [{:id 1 :turn 1 :branch_id "B1" :tool_name "shell"
+               :category "success" :result "ok"}
+              {:id 2 :turn 2 :branch_id "B1" :tool_name "__parse_error__"
+               :category "mechanics"
+               :parse_error "JSON error (end-of-file inside string)"}
+              {:id 3 :turn 3 :branch_id "B1" :tool_name "__provider_error__"
+               :category "neutral"
+               :result "local error 500 — Context size has been exceeded"}
+              {:id 4 :turn 4 :branch_id "B1" :tool_name "shell"
+               :category "failure" :result "make: no rule to make target"}]
+        out (telemetry/failure-exemplars rows {:per-kind 3 :chars 120})]
+    (testing "each kind appears in its own words with a fetchable row id"
+      (is (str/includes? (get-in out [:parse :lines]) "row 2"))
+      (is (str/includes? (get-in out [:parse :lines]) "end-of-file inside string"))
+      (is (str/includes? (get-in out [:provider :lines]) "row 3"))
+      (is (str/includes? (get-in out [:provider :lines]) "Context size"))
+      (is (str/includes? (get-in out [:tool :lines]) "row 4"))
+      (is (str/includes? (get-in out [:tool :lines]) "make: no rule")))
+    (testing "successes are not failures"
+      (is (not-any? #(str/includes? (str (get-in out [% :lines])) "row 1")
+                    [:parse :provider :tool])))))
+
+(deftest failure-exemplars-cap-newest-last-and-count-the-rest
+  (let [rows (for [i (range 10)]
+               {:id i :turn i :branch_id "B1" :tool_name "__parse_error__"
+                :category "mechanics" :parse_error (str "boom-" i)})
+        out (telemetry/failure-exemplars rows {:per-kind 2 :chars 60})]
+    (is (= 10 (get-in out [:parse :count]))
+        "the count survives the cap, so the scale is never hidden")
+    (is (str/includes? (get-in out [:parse :lines]) "boom-9") "newest kept")
+    (is (not (str/includes? (get-in out [:parse :lines]) "boom-0"))
+        "oldest dropped")))
+
+(deftest a-clean-run-has-no-failures-section
+  (is (nil? (telemetry/failure-exemplars
+             [{:id 1 :turn 1 :branch_id "B1" :tool_name "shell"
+               :category "success" :result "ok"}]
+             {:per-kind 3 :chars 120}))))
+
+(deftest the-digest-leads-with-the-failures
+  (let [d (telemetry/digest {:results [{:status :exhausted}]
+                             :review :revise :critic nil :revision 0}
+                            [{:id 7 :turn 3 :branch_id "T0"
+                              :tool_name "__parse_error__" :category "mechanics"
+                              :parse_error "JSON error (missing entry in object)"}])]
+    (is (str/includes? d "Failures this run"))
+    (is (str/includes? d "row 7"))
+    (is (str/includes? d "missing entry in object"))
+    (is (str/includes? d "fetch_turn"))))

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -118,6 +118,7 @@
             [samizdat.proc-test]
             [samizdat.board-bt-test]
             [samizdat.finalization-test]
+            [samizdat.repair-test]
             [samizdat.storm-test]
             [samizdat.tournament-test]
             [samizdat.trajectory-test]
@@ -175,6 +176,7 @@
     mycelium.workflow-test
     samizdat.board-bt-test
     samizdat.finalization-test
+    samizdat.repair-test
     samizdat.storm-test
     samizdat.tournament-test
     samizdat.trajectory-test


### PR DESCRIPTION
The run-health digest now leads with capped failure exemplars (parse / provider / tool, in their own words, with turn+branch addresses); fetch_turn grows an optional branch arg so the supervisor can actually open the records a report names (own-branch default keeps sibling isolation); the investigation queries (branch-turns, gate-tally, failure-exemplars, session/render) join manual.edn; the supervisor role prompt starts from failures, not the workflow catalog. Pointers plus tools, not an info dump - the supervisor decides what to examine. Suite: 1422 tests, 5250 assertions green.