### PR TITLE
An XML call inside a fence is the call it unmistakably is

### DIFF
--- a/src/samizdat/llm/fence.clj
+++ b/src/samizdat/llm/fence.clj
@@ -586,15 +586,25 @@
           ;; The guidance the model reads is prompts/ data (parse-error-causes,
           ;; parse-error-repaired), like every other word it sees — the
           ;; prose-backlog ratchet in base-test is what moved it out of here.
+          ;; A fence body that is not JSON but carries a complete <invoke> is
+          ;; the call it unmistakably is — the same reasoning that accepts
+          ;; mixed fence wrappers. Live on arm-1 (run e0c7662f): after a
+          ;; parse error the recovery PREFILLS the fence open, and a model
+          ;; following the multi-line guidance writes its XML call inside
+          ;; it; reading that as broken JSON looped the recovery on its own
+          ;; advice. Tried only where the JSON path has already failed, so a
+          ;; well-formed JSON fence never reaches it.
+          (let [fail (fn [msg]
+                       (if-let [x (xml-call body)]
+                         (merge base (assoc x :xml-call? true))
+                         (parse-error msg base)))]
           (if-not needed-repair?
-            (parse-error
-             (prompt/render "parse-error-causes" {:error (:error first-try)})
-             base)
+            (fail
+             (prompt/render "parse-error-causes" {:error (:error first-try)}))
             (let [second-try (read-json repaired)]
               (if-not (:ok second-try)
-                (parse-error
-                 (prompt/render "parse-error-repaired" {:error (:error first-try)})
-                 base)
+                (fail
+                 (prompt/render "parse-error-repaired" {:error (:error first-try)}))
                 (let [parsed (:value second-try)]
                   (if (and (map? parsed)
                            (string? (:name parsed))
@@ -603,7 +613,7 @@
                            {:name (:name parsed)
                             :args (let [a (:args parsed)] (if (map? a) a {}))})
                     (parse-error "tool-call body must be a JSON object with a non-empty `name` string"
-                                 base))))))))))))
+                                 base)))))))))))))
 
 (defn signals
   "The mechanics signals from one parse, for the capability tier.

--- a/test/samizdat/llm_test.clj
+++ b/test/samizdat/llm_test.clj
@@ -72,6 +72,36 @@
                   " \"args\": {\"content\": \"half\n```") {})]
       (is (= "__parse_error__" (:name p))))))
 
+(deftest an-xml-call-inside-a-fence-is-the-call-it-unmistakably-is
+  ;; Live on arm-1 (run e0c7662f, turns 7-8): after a parse error the
+  ;; recovery PREFILLS "```tool-call\n", and the model — following the
+  ;; multi-line guidance — wrote its XML call inside that forced-open fence.
+  ;; The fence outranks the XML rung, so the body was read as broken JSON
+  ;; and the recovery looped on its own advice. A fence body that is not
+  ;; JSON but carries a complete <invoke> is unmistakable in intent — the
+  ;; same reasoning that accepts mixed fence wrappers.
+  (let [resp (str "```tool-call\n"
+                  "Prose first, because the fence was prefilled.\n"
+                  "<invoke name=\"write_file\">\n"
+                  "<parameter name=\"path\">a.clj</parameter>\n"
+                  "<parameter name=\"content\">(ns a)\n(defn f [x]\n  (str \"hi \" x))\n</parameter>\n"
+                  "</invoke>\n"
+                  "```")
+        p (fence/parse-tool-call resp {})]
+    (is (= "write_file" (:name p)))
+    (is (str/includes? (str (get-in p [:args :content])) "(defn f [x]")
+        "raw newlines and quotes arrive unescaped, as the XML form promises")
+    (is (:xml-call? p)))
+  (testing "a fence body that is neither JSON nor an invoke still earns its
+            parse error"
+    (let [p (fence/parse-tool-call "```tool-call\njust prose\n```" {})]
+      (is (= "__parse_error__" (:name p)))))
+  (testing "a well-formed JSON fence is untouched by the new rung"
+    (let [p (fence/parse-tool-call
+             "```tool-call\n{\"name\": \"eval\", \"args\": {\"code\": \"(+ 1 2)\"}}\n```" {})]
+      (is (= "eval" (:name p)))
+      (is (not (:xml-call? p))))))
+
 (deftest a-context-overflow-is-recognized-from-the-body
   ;; karamazov-d41: a 500 wearing this message is deterministic — the same
   ;; oversized prompt fails identically every time — so post-once classifies


### PR DESCRIPTION
Live-run find on arm-1: the parse-error recovery prefills the fence, the model writes its XML call inside it (as the multi-line guidance teaches), and the fence path read it as broken JSON - a recovery loop made of two features each working as designed. A fence body that fails both JSON passes now falls through to the XML rung. Hot-patched into the running arm already; suite 1423 tests green.