### PR TITLE
Move ffi/write's value argument before the offset

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,9 @@
-{:paths ["src" "vendor" "resources"]
+{;; jolt.ffi/write takes the value BEFORE the offset as of jolt 0.8.0, and the
+ ;; two spellings are both integers — an older runtime writes to the wrong
+ ;; place rather than failing. Declare the floor so it refuses instead.
+ :jolt/min-version "0.8.0"
+
+ :paths ["src" "vendor" "resources"]
 
  ;; Git deps are fetched into ~/.jolt/gitlibs by jolt. Full SHAs only —
  ;; `git fetch` can't resolve short ones.

--- a/deps.edn
+++ b/deps.edn
@@ -8,31 +8,32 @@
  ;; Git deps are fetched into ~/.jolt/gitlibs by jolt. Full SHAs only —
  ;; `git fetch` can't resolve short ones.
  :deps {;; provider calls (clj-http-lite over jolt.ffi sockets + OpenSSL + libz)
-        ;; v0.0.3 honours :conn-timeout: it bounds the connect itself through a
-        ;; non-blocking socket, which needs jolt 0.6.8's :varargs FFI marker
-        ;; (fcntl is variadic, and on Apple arm64 a fixed-arity binding
-        ;; silently corrupts the stack-passed argument).
+        ;; :conn-timeout is honoured from v0.0.3 on: the connect itself is
+        ;; bounded through a non-blocking socket, which needs jolt 0.6.8's
+        ;; :varargs FFI marker (fcntl is variadic, and on Apple arm64 a
+        ;; fixed-arity binding silently corrupts the stack-passed argument).
         jolt-lang/http-client
         {:git/url "https://github.com/jolt-lang/http-client"
-         :git/tag "v0.0.3"
-         :git/sha "add8184b819b69dcfed1305b9577eb8794f76409"}
+         :git/tag "v0.0.6"
+         :git/sha "177b1ce4e529ffe052e6a1b7b103ed924de535f6"}
 
         ;; durable sessions: jdbc.core over the system libsqlite3 via jolt.ffi
         jolt-lang/db
         {:git/url "https://github.com/jolt-lang/db"
-         :git/sha "c3ed5b333b5feed615d49c118493a00edc537739"}
+         :git/tag "v0.4.0"
+         :git/sha "d85f391ca521da389b935c38f3d78b30eaa23208"}
 
         ;; nREPL middleware (sessions, interruptible eval, completion, lookup) so
         ;; an editor can drive the running harness. See core/start-nrepl!.
         jolt-lang/nrepl
         {:git/url "https://github.com/jolt-lang/nrepl"
-         :git/sha "10bf63fd19f66b39587f4a5756d0644231b2d4c1"}
+         :git/sha "9cc45acc7a241ff9704e8f43e2c4fb90f7bd819c"}
 
         ;; OpenSSL/SecureRandom shims. http-client pulls this in too; jolt.deps
         ;; reconciles the duplicate libssl/libcrypto natives to a single load.
         jolt-lang/jolt-crypto
         {:git/url "https://github.com/jolt-lang/jolt-crypto"
-         :git/sha "1ab72aa5f73be7ec41f01086953ffb43ecd3d84e"}
+         :git/sha "584a4d32094f0a72613d028deb944de00cd9fc11"}
 
          org.clojure/data.json
          {:git/url "https://github.com/clojure/data.json"

--- a/src/samizdat/smoke.clj
+++ b/src/samizdat/smoke.clj
@@ -27,6 +27,10 @@
   as skipped when the toolchain is absent, since only Phase 5 needs it."
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [jolt.http-client :as http]
             [jolt.process :as p]

--- a/src/samizdat/store/artifacts.clj
+++ b/src/samizdat/store/artifacts.clj
@@ -35,6 +35,10 @@
   (:require [clojure.set]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.lexicon :as lexicon]
             [samizdat.llm.message :as message]

--- a/src/samizdat/store/db.clj
+++ b/src/samizdat/store/db.clj
@@ -26,6 +26,10 @@
   question; readers open their own connections."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.store.migrations :as migrations]))
 
@@ -108,8 +112,12 @@
   ([conn q] (with-conn (jdbc/execute! conn q)))
   ([conn q opts] (with-conn (jdbc/execute! conn q opts))))
 
-(defn last-insert-id [conn]
-  (with-conn (jdbc/last-insert-id conn)))
+(defn last-insert-id
+  "clojure.jdbc has no last-insert-id — it was jolt-lang/db's own helper, and it
+  called sqlite's last_insert_rowid(). Asking for that directly keeps every call
+  site here meaning what it said."
+  [conn]
+  (with-conn (:id (jdbc/fetch-one conn "select last_insert_rowid() as id"))))
 
 (defn now
   "An ISO-8601 timestamp. One function so every table sorts the same way."

--- a/src/samizdat/store/failures.clj
+++ b/src/samizdat/store/failures.clj
@@ -30,6 +30,10 @@
   require the exact indexed values back. Sync is app-managed here, no triggers."
   (:require [clojure.string :as str]
             [clojure.tools.logging :as log]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.lexicon :as lexicon]
             [samizdat.prompt :as prompt]

--- a/src/samizdat/store/interventions.clj
+++ b/src/samizdat/store/interventions.clj
@@ -29,6 +29,10 @@
   supervisor, because a run that is wedged is exactly the run that will never
   reach another boundary to drain a queue at."
   (:require [clojure.data.json :as json]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.store.db :as db]
             [samizdat.store.journal :as journal]))

--- a/src/samizdat/store/journal.clj
+++ b/src/samizdat/store/journal.clj
@@ -31,6 +31,10 @@
   (:require [clojure.data.json :as json]
             [clojure.string :as str]
             [clojure.tools.logging :as log]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.events :as events]
             [samizdat.session :as session]

--- a/src/samizdat/store/runs.clj
+++ b/src/samizdat/store/runs.clj
@@ -31,6 +31,10 @@
             ;; :retention :run-record-days break every subsequent run start
             ;; (karamazov-blt.31).
             [clojure.tools.logging :as log]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.store.db :as db]
             [samizdat.store.journal :as journal]

--- a/test/samizdat/adapter_test.clj
+++ b/test/samizdat/adapter_test.clj
@@ -42,14 +42,14 @@
 ;; make-sockaddr (macOS wants sin_len in byte 0, Linux starts at the family).
 (defn- sockaddr [port]
   (let [sa (ffi/alloc 16)]
-    (dotimes [i 16] (ffi/write sa :uint8 i 0))
+    (dotimes [i 16] (ffi/write sa :uint8 0 i))
     (if macos?
-      (do (ffi/write sa :uint8 0 16) (ffi/write sa :uint8 1 af-inet))
-      (ffi/write sa :uint8 0 af-inet))
-    (ffi/write sa :uint8 2 (bit-and (bit-shift-right port 8) 0xff))
-    (ffi/write sa :uint8 3 (bit-and port 0xff))
-    (ffi/write sa :uint8 4 127) (ffi/write sa :uint8 5 0)
-    (ffi/write sa :uint8 6 0)   (ffi/write sa :uint8 7 1)
+      (do (ffi/write sa :uint8 16 0) (ffi/write sa :uint8 af-inet 1))
+      (ffi/write sa :uint8 af-inet 0))
+    (ffi/write sa :uint8 (bit-and (bit-shift-right port 8) 0xff) 2)
+    (ffi/write sa :uint8 (bit-and port 0xff) 3)
+    (ffi/write sa :uint8 127 4) (ffi/write sa :uint8 0 5)
+    (ffi/write sa :uint8 0 6)   (ffi/write sa :uint8 1 7)
     sa))
 
 (defn- connect!
@@ -64,8 +64,8 @@
         (throw (ex-info "connect() failed" {})))
       (ffi/free sa))
     (let [tv (ffi/alloc 16)]
-      (ffi/write tv :int64 0 5)
-      (ffi/write tv :int64 8 0)
+      (ffi/write tv :int64 5 0)
+      (ffi/write tv :int64 0 8)
       (adapter/c-setsockopt fd sol-socket so-rcvtimeo tv 16)
       (ffi/free tv))
     fd))

--- a/test/samizdat/store_test.clj
+++ b/test/samizdat/store_test.clj
@@ -26,6 +26,10 @@
   failure mode stays loud."
   (:require [clojure.test :refer [deftest testing is]]
             [clojure.string :as str]
+            ;; db.jdbc registers the java.sql shim clojure.jdbc compiles against and
+            ;; points connection construction at the native driver; it has to load
+            ;; before jdbc.core.
+            [db.jdbc]
             [jdbc.core :as jdbc]
             [samizdat.agent.gates :as gates]
             [samizdat.agent.loop :as branch-loop]

--- a/vendor/ring_chez/adapter.clj
+++ b/vendor/ring_chez/adapter.clj
@@ -96,14 +96,14 @@
 ;; Linux: bytes0-1 = family (little-endian, so byte0 = AF_INET).
 (defn- make-sockaddr [port]
   (let [sa (ffi/alloc 16)]
-    (dotimes [i 16] (ffi/write sa :uint8 i 0))
+    (dotimes [i 16] (ffi/write sa :uint8 0 i))
     (if macos?
-      (do (ffi/write sa :uint8 0 16) (ffi/write sa :uint8 1 AF-INET))
-      (ffi/write sa :uint8 0 AF-INET))
-    (ffi/write sa :uint8 2 (bit-and (bit-shift-right port 8) 0xff))   ; port hi (network order)
-    (ffi/write sa :uint8 3 (bit-and port 0xff))                       ; port lo
-    (ffi/write sa :uint8 4 127) (ffi/write sa :uint8 5 0)             ; 127.0.0.1
-    (ffi/write sa :uint8 6 0)   (ffi/write sa :uint8 7 1)
+      (do (ffi/write sa :uint8 16 0) (ffi/write sa :uint8 AF-INET 1))
+      (ffi/write sa :uint8 AF-INET 0))
+    (ffi/write sa :uint8 (bit-and (bit-shift-right port 8) 0xff) 2)   ; port hi (network order)
+    (ffi/write sa :uint8 (bit-and port 0xff) 3)                       ; port lo
+    (ffi/write sa :uint8 127 4) (ffi/write sa :uint8 0 5)             ; 127.0.0.1
+    (ffi/write sa :uint8 0 6)   (ffi/write sa :uint8 1 7)
     sa))
 
 (defn- listen-socket [port]
@@ -113,7 +113,7 @@
   (let [fd (c-socket AF-INET (bit-or SOCK-STREAM sock-cloexec) 0)]
     (when (neg? fd) (throw (ex-info "socket() failed" {})))
     (let [opt (ffi/alloc 4)]
-      (ffi/write opt :int 0 1)
+      (ffi/write opt :int 1 0)
       (c-setsockopt fd sol-socket so-reuse opt 4)
       (ffi/free opt))
     (let [sa (make-sockaddr port)]
@@ -137,8 +137,8 @@
   [fd ms]
   (try
     (let [tv (ffi/alloc 16)]
-      (ffi/write tv :int64 0 (quot (long ms) 1000))
-      (ffi/write tv :int64 8 (* 1000 (rem (long ms) 1000)))  ; tv_usec is µs
+      (ffi/write tv :int64 (quot (long ms) 1000) 0)
+      (ffi/write tv :int64 (* 1000 (rem (long ms) 1000)) 8)  ; tv_usec is µs
       (try (c-setsockopt fd sol-socket so-rcvtimeo tv 16)
            (finally (ffi/free tv))))
     (catch Throwable _ nil)))


### PR DESCRIPTION
jolt 0.8.0 changes `jolt.ffi/write` from `(write p type offset value)` to
`(write p type value offset)`, matching
[babashka.ffi](https://github.com/babashka/ffi) so a signature written for either
FFI means the same thing. Landed in jolt-lang/jolt#802.

Every call site here is rewritten — **19 across 2 file(s)**.

```clojure
;; before                          ;; after
(ffi/write p :int 4 fd)            (ffi/write p :int fd 4)
```

## Why this needs a version floor

The two spellings cannot be told apart at runtime — an offset and a value are
both integers — so an older jolt running this code would write to the wrong place
and report nothing. `deps.edn` therefore declares:

```clojure
:jolt/min-version "0.8.0"
```

which a jolt from 0.8.0 on refuses to run below (jolt-lang/jolt#804). An older
jolt does not know the key and ignores it, so the floor protects from that
release forward rather than retroactively; the change itself is in jolt's
CHANGELOG. **Merge once jolt 0.8.0 is released.**

## What did not change

`read` is unchanged, `write-field` is unchanged, and the offset stays spelled
out rather than dropped to the new 3-argument form — so a column of writes into
one struct stays a column, and the diff is a pure argument swap.

## How this was checked

The rewrite is an s-expression transform, not a regex: each `write` form is
parsed, its last two arguments swapped, and single-line gaps normalised to one
space (the old spelling was often a column table with the offsets aligned, and
swapping strands that padding mid-form). Across all nineteen repositories there
was exactly one multi-line `write` form, fixed by hand.

Every rewritten file in this repo was then read back with jolt's own reader —
2082 forms across the whole migration, none unreadable — and the affected
namespaces loaded against a jolt built from #802.