### PR TITLE
Skip the cell reload when nothing changed

### DIFF
--- a/src/samizdat/cell_prelude.clj
+++ b/src/samizdat/cell_prelude.clj
@@ -19,13 +19,15 @@
   reuses it. A preload, not a dependency — nothing here is called; the `require`
   is the whole point. Add a namespace here whenever a new shipped cell reaches
   for one that nothing in src already pulls in."
-  (:require [samizdat.agent.decompose]
+  (:require [samizdat.agent.compaction]
+            [samizdat.agent.decompose]
             ;; cells/oversight.clj reads the run's own health to decide
             ;; whether the harness needs looking at.
             [samizdat.agent.gates]
             [samizdat.agent.gitdiff]
             [samizdat.agent.judge]
             [samizdat.agent.planner]
+            [samizdat.agent.reflect]
             [samizdat.agent.telemetry]
             [samizdat.engine.proc]))
 

--- a/src/samizdat/cells.clj
+++ b/src/samizdat/cells.clj
@@ -74,6 +74,30 @@
 
 (defn loaded [] @loaded-cells)
 
+;; What the last SUCCESSFUL load put in the registry, for the skip in
+;; load-cells!: the sources as [[id content] …] in load order, and the spec
+;; object each loaded cell id resolved to once every source was in.
+(defonce ^:private last-load (atom nil))
+
+(defn- unchanged-since-last-load?
+  "True when `sources` are the last successful load's sources — same ids, same
+  content, same order — AND the registry still resolves every cell that load
+  registered to the very spec object it registered.
+
+  The first half is the files. The second is the registry, which is global
+  mutable state: a test or another workflow may have registered its own cell
+  under one of our ids, or removed one, and unchanged files are no proof the
+  LOOP's cells are present. That was compile-loop's reason for loading before
+  every compile; it is kept here as the guard, so the load happens exactly
+  when it would change something. A defcell registers its spec through
+  `constantly`, so the object the registry answers with is the one we
+  recorded until somebody re-registers the id (karamazov-3n4n)."
+  [sources]
+  (when-let [{last-sources :sources specs :specs} @last-load]
+    (and (= last-sources (mapv (juxt :id :content) sources))
+         (let [live (:specs (cell/registry-snapshot))]
+           (every? (fn [[id spec]] (identical? spec (get live id))) specs)))))
+
 (defn loaded-file-content
   "The content of every cell file as it was at the last successful load — the
   last-good disk state, for the mutation protocol to restore on a rollback."
@@ -209,6 +233,8 @@
              (set (map #(last (str/split (str %) #"/")) files)))
             (for [p files] {:id p :content (slurp p) :file? true}))))
 
+(declare load-sources!)
+
 (defn load-cells!
   "Load the project's cells into the live image, registering them.
 
@@ -227,16 +253,29 @@
 
   Transactional either way: on any error the registry is restored to its prior
   state and the error rethrown, so a bad cell never half-loads. Returns the
-  loaded map {cell-id {:source name}}."
+  loaded map {cell-id {:source name}}.
+
+  Free when nothing changed: the same sources as the last successful load,
+  with the registry still holding what that load registered, return that
+  load's map without evaluating a file (unchanged-since-last-load?).
+  compile-loop calls this before every compile, and re-evaluating twelve
+  files cost about a second each time — most of the test suite's minutes."
   ([] (load-cells! nil))
   ([dirs]
-   (let [snapshot (cell/registry-snapshot)
-         ;; nil means "the project"; an explicit dir list means the legacy
-         ;; scan. Distinguishing on the ARGUMENT rather than on a flag keeps
-         ;; every existing caller and test meaning exactly what it meant.
-         sources (if (nil? dirs)
+   ;; nil means "the project"; an explicit dir list means the legacy scan.
+   ;; Distinguishing on the ARGUMENT rather than on a flag keeps every
+   ;; existing caller and test meaning exactly what it meant.
+   (let [sources (if (nil? dirs)
                    (project-sources default-dirs)
                    (dir-sources dirs))]
+     (if (unchanged-since-last-load? sources)
+       @loaded-cells
+       (load-sources! dirs sources)))))
+
+(defn- load-sources!
+  "The full load: every source evaluated in order, transactionally."
+  [dirs sources]
+   (let [snapshot (cell/registry-snapshot)]
      (try
        (let [loaded (reduce (fn [acc src]
                               (into acc (for [id (load-source! src)]
@@ -257,9 +296,13 @@
          (reset! loaded-content
                  (into {} (for [src sources :when (or (:file? src) (:store? src))]
                             [(:id src) (:content src)])))
+         (reset! last-load
+                 {:sources (mapv (juxt :id :content) sources)
+                  :specs (select-keys (:specs (cell/registry-snapshot))
+                                      (keys loaded))})
          loaded)
        (catch Throwable e
          (cell/registry-restore! snapshot)
          (throw (ex-info (str "cell load failed; registry rolled back: "
                               (ex-message e))
-                         {:dirs dirs} e)))))))
+                         {:dirs dirs} e))))))

--- a/src/samizdat/manifests.clj
+++ b/src/samizdat/manifests.clj
@@ -491,9 +491,11 @@
   ;; Load the cells before every compile. The cell registry is global mutable
   ;; state, and a non-empty registry is not proof the LOOP's cells are present
   ;; (a test or another workflow may have registered different ones) — so this
-  ;; always loads rather than guarding on emptiness. Idempotent, cheap, and it
-  ;; picks up any edited cell, which is the hot-reload the mutation protocol
-  ;; builds on.
+  ;; always asks rather than guarding on emptiness. The loader does the work
+  ;; only when a file or the registry changed since its last load, so this is
+  ;; free on the common path and still the hot-reload the mutation protocol
+  ;; builds on. Before that skip it re-evaluated twelve files every time,
+  ;; about a second, and that was most of the test suite (karamazov-3n4n).
    (cells/load-cells!)
    (compile-definition definition opts)))
 

--- a/test/samizdat/cells_test.clj
+++ b/test/samizdat/cells_test.clj
@@ -71,6 +71,13 @@
   ;; "Could not locate … on the source roots". samizdat.cell-prelude exists to
   ;; pull those onto the compile graph; samizdat.agent.decompose had fallen
   ;; off it. Walk the requires rather than trusting the list stays current.
+  ;;
+  ;; Reachability is FROM THE BINARY'S ENTRY: `jolt build -m samizdat.core`
+  ;; embeds that namespace's require closure and nothing else, so that is what
+  ;; must already have loaded these. Without this require the test only
+  ;; passed after other namespaces in the suite had loaded the harness, and
+  ;; failed 23 times on its own.
+  (require 'samizdat.core)
   (let [required (->> cells/shipped-cells
                       (keep clojure.java.io/resource)
                       (mapcat #(re-seq #"\[(samizdat\.[a-z0-9.-]+)" (slurp %)))
@@ -131,6 +138,57 @@
     (cell-file! d :hot/x "(fn [_ data] (assoc data :v 2))")
     (cells/load-cells! [d])
     (is (= 2 (:v ((:handler (cell/get-cell :hot/x)) {} {}))))))
+
+;; --- an unchanged load does no work ------------------------------------------
+
+(defn- token-of
+  "The per-load token a generated cell closes over: a load-string makes a new
+  one, a skipped load keeps the old one — proof of a reload that no jolt
+  version can fake by handing back the same fn object."
+  [id]
+  (:token ((:handler (cell/get-cell id)) {} {})))
+
+(def ^:private tokened "(let [t (Object.)] (fn [_ data] (assoc data :token t)))")
+
+(deftest an-unchanged-source-set-is-not-reloaded
+  ;; compile-loop reloads the cells before EVERY compile, and a reload that
+  ;; re-evaluated twelve files when nothing had changed cost about a second —
+  ;; 168 times over in three test namespaces alone (karamazov-3n4n). The
+  ;; unchanged case must be free.
+  (let [d (str @tmp "/cells")]
+    (cell-file! d :same/a tokened)
+    (let [first-load (cells/load-cells! [d])
+          t1 (token-of :same/a)]
+      (is (= first-load (cells/load-cells! [d])) "the second load reports the same cells")
+      (is (identical? t1 (token-of :same/a)) "and did not re-evaluate the file")
+      (testing "an edit still reloads"
+        (cell-file! d :same/a "(let [t (Object.)] (fn [_ data] (assoc data :token t :v 2)))")
+        (cells/load-cells! [d])
+        (is (not (identical? t1 (token-of :same/a))))
+        (is (= 2 (:v ((:handler (cell/get-cell :same/a)) {} {}))))))))
+
+(deftest a-registry-touched-by-someone-else-is-reloaded
+  ;; The registry is global mutable state, and unchanged files are not proof
+  ;; the LOOP's cells are present: a test or another workflow may have
+  ;; registered its own under one of our ids, or removed one. Only a registry
+  ;; still holding exactly what the last load registered may be skipped.
+  (let [d (str @tmp "/cells")]
+    (cell-file! d :ours/a tokened)
+    (cell-file! d :ours/b tokened)
+    (cells/load-cells! [d])
+    (let [t1 (token-of :ours/a)]
+      (testing "an id re-registered by another party"
+        (cell/defcell :ours/a {:doc "an impostor" :pure true}
+          (fn [_ data] (assoc data :who :them)))
+        (is (= :them (:who ((:handler (cell/get-cell :ours/a)) {} {}))))
+        (cells/load-cells! [d])
+        (is (nil? (:who ((:handler (cell/get-cell :ours/a)) {} {}))) "ours is back")
+        (is (not (identical? t1 (token-of :ours/a))) "by a real reload"))
+      (testing "an id removed by another party"
+        (cell/remove-cell! :ours/b)
+        (is (nil? (cell/get-cell :ours/b)))
+        (cells/load-cells! [d])
+        (is (some? (cell/get-cell :ours/b)))))))
 
 ;; --- the shipped loop cells load from resources -----------------------------
 


### PR DESCRIPTION
compile-loop loads the cells before every compile, and the loader re-evaluated all twelve files through load-string each time, about a second. Counted: 85 loads in feature-test (84 s of its 148), 55 in manifest-test (52 of 59), 28 in board-test (27 of 40). That was most of the suite's minutes.

The loader now records the last successful load's sources and the spec object each id resolved to, and returns that load's map when the sources are byte-identical and the registry still answers every id with the same object. defcell registers through constantly, so identity holds until somebody re-registers the id. Any file edit, or another party writing to or removing from the registry, takes the full transactional path as before; two tests pin both.

Locally, with the skip: feature-test 148 s -> 68 s, manifest-test 59 -> 9, board-test 40 -> 15, team-test 32 -> 9, control-test 24 -> 6.

Also: cells-test's reachability check now requires samizdat.core first. It only passed after other namespaces had loaded the harness, and on its own it caught two prelude gaps, agent.compaction and agent.reflect.
