### PR TITLE
A terminal UI over ftxui, with its layout in userspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,15 @@ jolt tui           # the terminal UI; SAMIZDAT_URL / HARNESS_PORT point it at a 
 jolt tui-test      # the TUI's toolkit-bound tests: real FTXUI widgets, headless
 ```
 
+The TUI's own arrangement is EDN, and it comes from three places, most local
+first: `$SAMIZDAT_TUI_LAYOUT` or `.samizdat/tui.edn` (a person's, re-read
+whenever it changes, so an edit lands on the next frame); `GET
+/v1/harness/layout` (the project's stored `tui` policy — how the AGENT
+rearranges its own UI, served because a front end holds no database handle);
+then `resources/tui.edn` off the classpath. Adding a widget means registering
+a `:widget/*` tag in `tui/samizdat/tui/widgets.clj` and naming it in a layout
+— the core owns what a widget IS, the layout owns where it goes.
+
 `jolt tui-test` is separate from `jolt test` because it loads ftxui. It covers
 the one claim the data tests cannot make — that a CLICK reaches the fold, which
 is not the same claim as the widget returning a `:collapsible` with the right

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,32 @@ A new test namespace must be added to `test/samizdat/test_runner.clj` in BOTH
 places — the `:require` list and the `namespaces` vector — or it silently never
 runs.
 
+### The two front ends
+
+`gui/` (GTK) and `tui/` (terminal) are optional components and strict HTTP
+clients of the server. Their toolkits live only under `:gui` / `:tui`, so
+`jolt serve` and `jolt test` never load one. Their SOURCE paths are on the
+test path, which is why everything in them except the toolkit's own run loop
+is written toolkit-free — the TUI's widgets return hiccup, and hiccup is
+data, so the suite covers them with no terminal and no cmake.
+
+```bash
+jolt tui           # the terminal UI; SAMIZDAT_URL / HARNESS_PORT point it at a server
+jolt tui-test      # the TUI's toolkit-bound tests: real FTXUI widgets, headless
+```
+
+`jolt tui-test` is separate from `jolt test` because it loads ftxui. It covers
+the one claim the data tests cannot make — that a CLICK reaches the fold, which
+is not the same claim as the widget returning a `:collapsible` with the right
+`:on-change`. Anything about the TUI that can be checked as data belongs in the
+main suite instead.
+
+The TUI has one prerequisite the rest of the repo does not: ftxui-jolt binds
+a C++ shim that has to be COMPILED. `jolt native` in its checkout builds it
+(cmake 3.14+ and a C++17 compiler); it is a `:local/root` dep until it tags a
+release. If `native/build` carries a `CMakeCache.txt` from a different path,
+`rm -rf native/build` first.
+
 ## Live development over nREPL
 
 Develop against a running image, not by paying startup per command. Start a

--- a/deps.edn
+++ b/deps.edn
@@ -122,7 +122,12 @@
 
  :nrepl/middleware [nrepl.middleware/default-middleware]
 
- :aliases {:test {:extra-paths ["test" "gui"]
+ ;; "gui" and "tui" are SOURCE paths here, not their toolkits: neither
+ ;; alias's deps ride along. That is the discipline both front ends keep —
+ ;; everything except the toolkit's own run loop is written toolkit-free
+ ;; (the TUI's widgets return hiccup, which is data), so the suite covers
+ ;; them without cmake, GTK, or a terminal.
+ :aliases {:test {:extra-paths ["test" "gui" "tui"]
                   :main-opts ["-m" "samizdat.test-runner"]}
            ;; The dev tree (the nREPL client, the ebb spike) plus the tests, so
            ;; a live image can run the suite without paying startup — with
@@ -166,7 +171,36 @@
                    {:git/url "https://github.com/jolt-lang/glimmer-gl.git"
                     :git/tag "v0.1.0"
                     :git/sha "ae9a53291c553e89dde79a90389224f46e5e7fa8"}}
-                  :main-opts ["-m" "samizdat.gui.core"]}}
+                  :main-opts ["-m" "samizdat.gui.core"]}
+
+           ;; The TUI, on the same terms as the GUI: its own source root, its
+           ;; own toolkit dep, and a strict HTTP client of the server. `jolt
+           ;; serve` and `jolt -M:test` never load it.
+           ;;
+           ;; :local/root while ftxui-jolt is unreleased. It carries a C++
+           ;; shim that has to be COMPILED (`jolt native` in its checkout,
+           ;; needing cmake and a C++17 compiler) — a git dep would resolve
+           ;; the sources into ~/.jolt/gitlibs with no build step and fail at
+           ;; the first FFI call. Pin a :git/sha here once it tags a release
+           ;; that ships the shared object.
+           :tui  {:extra-paths ["tui"]
+                  :extra-deps
+                  {jlt-commons/ftxui-jolt
+                   {:local/root "/Users/yogthos/src/jlt-commons/ftxui-jolt"}}
+                  :main-opts ["-m" "samizdat.tui.core"]}
+
+           ;; The half of the TUI the main suite cannot cover: what the
+           ;; TOOLKIT does with the hiccup — that a click on a fold's header
+           ;; actually opens it. It drives real FTXUI widgets headlessly, so
+           ;; it needs no terminal, but it does need the compiled shim, which
+           ;; is why it is its own alias rather than part of `jolt test`.
+           ;;
+           ;;     jolt tui-test
+           :tui-test {:extra-paths ["tui" "test-tui"]
+                      :extra-deps
+                      {jlt-commons/ftxui-jolt
+                       {:local/root "/Users/yogthos/src/jlt-commons/ftxui-jolt"}}
+                      :main-opts ["-m" "samizdat.tui.test-runner"]}}
 
  :tasks {serve {:doc "start the harness (HTTP + nREPL) and park"
                 :main-opts ["-m" "samizdat.core"]}
@@ -182,5 +216,9 @@
           ;; environment where 1024 exceeds the hard limit still runs.
           test  "(ulimit -n 1024 2>/dev/null; jolt -M:test)"
          gui   "jolt -M:gui"
+         tui   "jolt -M:tui"
+         ;; A shell string, not :main-opts: a task's main-opts cannot carry an
+         ;; -M alias, and this one needs the ftxui dep.
+         tui-test "jolt -M:tui-test"
          export {:doc "runs that shipped and verified, as JSONL trajectories — or with --verdicts, every judgement labelled by its outcome: jolt export <db> [out.jsonl] [--verdicts]"
                  :main-opts ["-m" "samizdat.export"]}}}

--- a/docs/RFCS/RFC-003-security-model.md
+++ b/docs/RFCS/RFC-003-security-model.md
@@ -128,7 +128,23 @@ flowchart LR
     toolcall --> split
     split --> root
     root --> redact
+
+    ask[ask_human: parks on an operator's answer]
+    operator[a person at a front end]
+    toolcall --> ask
+    ask --> operator
+    operator --> redact
 ```
+
+`ask_human` is the one node whose input never came off the machine: it puts a
+question on an in-memory queue and waits, and what comes back is what a person
+typed. It still passes through `redact`, for the same reason every other node
+does — the boundary is about what reaches the model, not about whether the
+source is trusted, and an operator can paste a secret into an answer as easily
+as a file can contain one. Its reach is bounded by a deadline in gates.edn
+(`:approval`), so it is a node that always terminates: an unattended run
+resolves to the stated default rather than parking forever. Blocking is off
+unless a project turns it on.
 
 The `eval` node and its three edges were absent from this graph until this RFC
 was written, which is how the property they violated stayed believed for four

--- a/gui/samizdat/gui/api.clj
+++ b/gui/samizdat/gui/api.clj
@@ -17,182 +17,28 @@
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 
 (ns samizdat.gui.api
-  "The GUI's HTTP client over the run API, plus the journal poll loop.
+  "The GUI's names for the run API client.
 
-  Deliberately toolkit-free — http-client and JSON only, no glimmer requires
-  — so the headless test suite covers it without loading GTK, and so the
-  model/view split stays honest: everything the GUI knows arrives through
-  these functions, and everything it does goes back through them. The
-  server neither knows nor cares that a GUI exists.
+  The client itself is `samizdat.api.client`, in the base: how to reach the
+  server is mechanism, and it is the same question for every front end. This
+  namespace was that code until the TUI arrived and would have had to copy
+  it — two poll loops and two cursor implementations, drifting.
 
-  Every call returns {:ok true :body ...} or {:ok false :error ...} — a
-  dead or absent server is a value the UI renders, never a throw that
-  takes the window down."
-  (:require ;; the java.time.* host shim, before data.json — see samizdat.store.journal
-            [jolt.time]
-            [clojure.data.json :as json]
-            [jolt.http-client :as http]))
+  Kept as a namespace rather than deleted so the GUI and its tests read the
+  same as they did. New front ends call `samizdat.api.client` directly."
+  (:require [samizdat.api.client :as client]))
 
-(def ^:private opts
-  {:socket-timeout 10000 :conn-timeout 3000 :throw-exceptions false})
+(def list-runs      client/list-runs)
+(def models         client/models)
+(def journal-since  client/journal-since)
+(def branch-detail  client/branch-detail)
+(def start-run!     client/start-run!)
+(def intervene!     client/intervene!)
+(def abort!         client/abort!)
+(def resume!        client/resume!)
+(def poll-step      client/poll-step)
+(def start-poller!  client/start-poller!)
 
-(defn- decode [s]
-  (try (json/read-str (str s) :key-fn keyword) (catch Throwable _ nil)))
-
-(defn- result [r]
-  (if (<= 200 (:status r 0) 299)
-    {:ok true :body (decode (:body r))}
-    {:ok false :error (str "HTTP " (:status r)
-                           (some->> (:body r) decode :error :message (str ": ")))}))
-
-(defn- GET [base path]
-  (try (result (http/get (str base path) opts))
-       (catch Throwable e {:ok false :error (ex-message e)})))
-
-(defn- POST
-  ([base path body] (POST base path body nil))
-  ([base path body socket-timeout-ms]
-   (try (result (http/post (str base path)
-                           (cond-> (assoc opts
-                                          :headers {"Content-Type" "application/json"}
-                                          :body (json/write-str (or body {})))
-                             socket-timeout-ms (assoc :socket-timeout socket-timeout-ms))))
-        (catch Throwable e {:ok false :error (ex-message e)}))))
-
-(defn list-runs [base] (GET base "/v1/runs"))
-
-(defn models
-  "{:current \"...\" :models [...]} — what the provider serves, for the picker.
-  Not /v1/models, which answers what this harness serves and is a different
-  question."
-  [base]
-  (GET base "/v1/harness/models"))
-
-(defn journal-since
-  "Everything after `cursor`, the polling UI's one read."
-  ([base run-id cursor] (journal-since base run-id cursor 200))
-  ([base run-id cursor limit]
-   (GET base (str "/v1/runs/" run-id "/journal?since=" (or cursor 0)
-                  "&limit=" limit))))
-
-(defn branch-detail
-  "Every turn and artifact for a branch, in full. Deliberately given a
-  longer socket timeout than the rest: the response carries every result
-  string and every encoding, which on a long run is hundreds of kilobytes
-  and takes seconds. The GUI renders live activity from the event stream
-  meanwhile, so this arriving late costs nothing."
-  [base run-id branch-id]
-  (try (result (http/get (str base "/v1/runs/" run-id "/branches/" branch-id)
-                         (assoc opts :socket-timeout 45000)))
-       (catch Throwable e {:ok false :error (ex-message e)})))
-
-(def start-timeout-ms
-  "How long to wait for POST /v1/runs.
-
-  Deliberately longer than the 30s api.control/start-run! itself waits on
-  (deref promised 30000). That endpoint does not answer when the run row is
-  written — beam/run! opens every branch in the beam first and only then
-  calls on-start — so a start can legitimately take tens of seconds, and how
-  long depends on the beam width and on what else the machine is doing.
-
-  Under the shared 10s default this reported a failure for a run that was
-  starting normally: the row was already committed, so the user was told the
-  run had failed AND left with a live run consuming provider spend, with the
-  same request succeeding under curl. Any client bound tighter than the
-  server's own budget has that bug; this one has to outlast it."
-  40000)
-
-(defn start-run!
-  "Start a fresh run and return its id in the body.
-
-  The server answers 503 when the beam does not come up inside its 30s window,
-  which `result` already turns into {:ok false}. It used to answer 200 with an
-  `{:error ...}` body instead, so a plain 2xx was not proof a run existed; the
-  unwrap below is kept as a belt-and-braces check on that older shape, since a
-  caller that mistakes a refusal for a started run goes on to poll a run id
-  that is nil."
-  [base body]
-  (let [r (POST base "/v1/runs" body start-timeout-ms)]
-    (if (and (:ok r) (get-in r [:body :error]))
-      {:ok false :error (get-in r [:body :error])}
-      r)))
-
-(defn intervene!
-  "A human directive, applied at the branch's next turn boundary. `branch-id`
-  nil targets the whole run."
-  [base run-id {:keys [branch-id kind payload]}]
-  (POST base (str "/v1/runs/" run-id "/interventions")
-        (cond-> {:kind (or kind "message") :payload payload}
-          branch-id (assoc :branch_id branch-id))))
-
-(defn abort! [base run-id]
-  (POST base (str "/v1/runs/" run-id "/abort") {}))
-
-(defn resume!
-  "Resume a crashed run; with `max-turns`, extend an exhausted one's budget."
-  ([base run-id] (resume! base run-id nil))
-  ([base run-id max-turns]
-   (POST base (str "/v1/runs/" run-id "/resume")
-         (if max-turns {:max_turns max-turns} {}))))
-
-;; --- the poll loop -----------------------------------------------------------
-
-(def base-interval-ms 1500)
-(def max-backoff-ms 30000)
-
-(defn poll-step
-  "Fold one journal fetch into the loop state {:cursor :interval-ms}.
-
-  Pure, so the loop's whole policy is testable offline: events advance the
-  cursor and reset the interval; an empty batch keeps both; a failure marks
-  the state disconnected and doubles the interval up to the cap — the
-  cursor survives an outage, so nothing is missed when the server returns."
-  [{:keys [cursor interval-ms] :as state} {:keys [ok body]}]
-  (if ok
-    (let [events (vec (:events body))]
-      (assoc state
-             :cursor (or (:id (peek events)) cursor 0)
-             :interval-ms base-interval-ms
-             :connected? true
-             :events events))
-    (assoc state
-           :events []
-           :connected? false
-           :interval-ms (min max-backoff-ms
-                             (* 2 (max base-interval-ms
-                                       (or interval-ms base-interval-ms)))))))
-
-(defn start-poller!
-  "Tail `run-id`'s journal on a background thread.
-
-  Calls (on-events events) for every non-empty batch and (on-status state)
-  after every step. Callbacks are guarded — one throw used to kill the
-  future silently, leaving the header saying \"tailing\" over a frozen
-  graph (code-review-2026-08 #5). @running is rechecked after the fetch
-  too: a batch landing after stop! belongs to a run the UI has already
-  left, and delivering it folded the old run's events into the new one.
-  glimmer marshals ratom writes made off the main thread onto the GTK
-  loop itself, so callbacks may swap! UI state directly.
-  Returns {:stop! (fn [])}; stopping is cooperative at the next wakeup."
-  [{:keys [base run-id on-events on-status]}]
-  (let [running (atom true)
-        guard (fn [f]
-                (when f
-                  (fn [& args]
-                    (try (apply f args)
-                         (catch Throwable e
-                           (println "[gui.api] poller callback failed:"
-                                    (ex-message e)))))))]
-    (let [on-events (guard on-events)
-          on-status (guard on-status)]
-      (future
-        (loop [state {:cursor 0 :interval-ms base-interval-ms}]
-          (when @running
-            (let [state (poll-step state (journal-since base run-id (:cursor state)))]
-              (when (and @running on-events (seq (:events state)))
-                (on-events (:events state)))
-              (when (and @running on-status)
-                (on-status (dissoc state :events)))
-              (Thread/sleep (:interval-ms state))
-              (recur state)))))
-      {:stop! (fn [] (reset! running false))})))
+(def start-timeout-ms client/start-timeout-ms)
+(def base-interval-ms client/base-interval-ms)
+(def max-backoff-ms   client/max-backoff-ms)

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -1515,6 +1515,67 @@
         spinning. The abort flag is read on the same pass, so a paused run
         stays stoppable."}
 
+ :approval
+ {:value {:mode :refuse :wait-ms 300000 :on-timeout :deny}
+  :kind :threshold :capability-tunable? false
+  :provenance ["karamazov-whbw.3"]
+  :doc "Whether a command the policy wants to ASK about waits for a person.
+
+        `:refuse` is the default and is what this harness has always done:
+        the call is refused, the refusal teaches the retry, and a human adds
+        a grant afterwards without the run ever stopping. Runs are
+        unattended by design and a feature landing must not change that —
+        an upgrade that silently started blocking would hang every campaign.
+
+        `:mode :block` parks the branch on the question instead, for when
+        somebody is watching. What makes that safe is the other two keys.
+        `wait-ms` bounds every wait — five minutes, long enough for someone
+        to come back to the terminal, short enough that a run left alone
+        loses one command rather than the night. `on-timeout` says what an
+        unanswered question resolves to: `:deny` keeps the refusal (and the
+        model is told nobody was there, so it reads as an absence rather
+        than a rule), `:allow` lets an unattended run proceed for a project
+        that would rather have that.
+
+        A run that ends releases its waiters regardless — see
+        samizdat.approval/abandon!."}
+
+ :modified-files-shown
+ {:value 60
+  :kind :cost-ceiling :capability-tunable? false
+  :provenance ["karamazov-whbw.8"]
+  :doc "How many changed paths the run detail reports.
+
+        A cap on a response, not a judgement about the work: a long run
+        touches hundreds of files and a front end draws a panel's worth.
+        Newest first, so what the cap drops is the oldest change — the one
+        least likely to be what someone is looking at."}
+
+ :step-ring
+ {:value {:capacity 512 :max-runs 16 :pump-ms 250}
+  :kind :cost-ceiling :capability-tunable? false
+  :provenance ["karamazov-whbw.2"]
+  :doc "The live manifest-state trace a front end draws: how many steps are
+        kept per run, and how many runs' rings the process holds at once.
+
+        Memory, not truth. The durable record of what a turn did is the turns
+        table; a step is the implementer moving between cells and is worth a
+        frame of a UI and nothing after that. So this bounds an in-memory ring
+        and the loss is a UI that says it fell behind, never a run that
+        forgets what it did.
+
+        `capacity` at 512 is roughly forty turns of the factory loop, which
+        walks about fourteen cells a turn — enough that a client attaching to
+        a run in progress sees real history rather than the current cell.
+
+        `max-runs` exists because forget! is called when a run ends and a
+        server that is never told must still not grow. The oldest ring goes.
+
+        `pump-ms` is how often the bus is drained into the rings. Well under
+        any client's poll interval, so the wait a person sees is their own
+        poll and not this; short enough that the bus's own sliding window
+        cannot overflow between drains on a wide beam."}
+
  :run-health
  {:value
   {:thrash-min-turns 4

--- a/resources/prompts/ask-tool.md
+++ b/resources/prompts/ask-tool.md
@@ -1,0 +1,22 @@
+{% if needs-questions %}
+`ask_human` needs `questions`: a list, each entry with a `question` and
+optionally `options` for the person to pick from.
+
+    ask_human({"questions": [{"question": "which store?",
+                              "options": ["sqlite", "postgres"]}]})
+{% endif %}{% if nobody-configured %}
+There is no human attached to this run, so `ask_human` cannot be answered.
+
+This is the normal state: runs here are autonomous, and nobody is waiting at
+a terminal to answer. Decide it yourself and say in your next message which
+way you went and why — a stated assumption someone can correct later is worth
+more than a question nobody will read.
+
+If the choice genuinely cannot be made without a person, record it as a task
+and carry on with the part that does not depend on it.
+{% endif %}{% if unanswered %}
+Nobody answered within {{seconds}} seconds, so the question has expired.
+
+Do not ask again — the same silence will cost you another {{seconds}} seconds.
+Decide it yourself, say which way you went and why, and continue.
+{% endif %}

--- a/resources/prompts/shell-refused.md
+++ b/resources/prompts/shell-refused.md
@@ -31,5 +31,12 @@ the same job without the shell: `read_file` and `grep` to look around, `eval`
 to run Clojure, including this project's own tests once you have required the
 namespace.
 {% endif %}{% endif %}{% endif %}{% endif %}{% endif %}{% endif %}
-
+{% if note %}
+A person looked at this and said: {{note}}
+{% endif %}{% if unanswered %}
+This run asked a human and nobody answered inside the window, so the refusal
+is an ABSENCE rather than a rule — the command was not judged and refused, it
+was simply never seen. Do not read it as a policy about `{{head}}`. Carry on
+another way, or ask again later if the work genuinely needs it.
+{% endif %}
 Rule: `{{rule}}`

--- a/resources/prompts/system.md
+++ b/resources/prompts/system.md
@@ -213,6 +213,14 @@ websearch({query, num_results?})
     symbol or error string rather than a sentence. Search the WEB; for
     anything in this repo or its reference paths, read it directly — a search
     will not find it and will cost you a turn.
+ask_human({questions})
+    Put a question to the person watching this run and wait for their
+    answer. `questions` is a list of {question, options?}. Most runs have
+    nobody attached and you will be told so immediately — that is the normal
+    answer, not a failure. Use it only where the choice is genuinely not
+    yours to make (which of two products to build, whether to touch
+    something outside the project); decide anything else yourself and say
+    which way you went. Asking costs a turn and establishes nothing.
 shell({command})
     Run a shell command. Read-only inspection (ls, cat, grep, find, git
     status/diff/log) and project tools (jolt test, jolt -e, cargo, pytest,

--- a/resources/tui.edn
+++ b/resources/tui.edn
@@ -8,6 +8,16 @@
 ;; EDN: no rebuild, and the agent can do it to itself at runtime through the
 ;; same seam that carries gates.edn and the manifests.
 ;;
+;; WHICH COPY THE TUI DRAWS, most local first:
+;;
+;;   1. $SAMIZDAT_TUI_LAYOUT, or .samizdat/tui.edn beside the project — a
+;;      person's own, re-read whenever it changes, so an edit shows up on the
+;;      next frame with the TUI still running;
+;;   2. what the harness serves from GET /v1/harness/layout — the stored row
+;;      above, which is how the AGENT rearranges its own UI. The TUI holds no
+;;      database handle, so it asks the server, which does;
+;;   3. this file, off the classpath, which is what draws offline.
+;;
 ;; The vocabulary is ftxui's own (see the ftxui-jolt README): :vbox, :hbox,
 ;; :border, :separator, :flex, :width, anything the toolkit draws. The only
 ;; tags this project adds are `:widget/*`, each standing in for one widget
@@ -43,31 +53,54 @@
  ;;   :widget/gates         gates that fired and predictions still unsettled.
  ;;   :widget/artifacts     claims made, and how each was judged.
  ;;   :widget/runs          the run picker.
+ ;;   :widget/branches      the beam: every branch and what became of it.
+ ;;                         Click one to read it.
  ;;   :widget/approvals     the question a person is being asked, if any: the
  ;;                         permission dialog, or ask_human's questionnaire.
  ;;                         Draws nothing when there is nothing pending.
  ;;   :widget/input         the compose box: interventions, abort, resume.
  ;;   :widget/status        the status line.
 
+ ;; THREE PANELS TO A COLUMN, not five. A bare :height is an EQUALITY
+ ;; constraint in ftxui, so a stack of pinned boxes cannot shrink to fit and
+ ;; the ones at the bottom are simply squeezed to nothing: five in the right
+ ;; gutter drew MODIFIED, CLAIMS and GATES as three empty rules. One flexed
+ ;; panel per column, the rest pinned, and the two diagnostic lists moved to
+ ;; a wide short row where their entries have somewhere to go.
+
  :layout
  [:vbox {:flex true}
 
   [:hbox {:flex true}
 
-   ;; The left gutter: what the agent is doing, and what it is spending.
+   ;; The left gutter: what the agent is doing, what it is spending, and
+   ;; which run all of it is about.
    [:vbox {:width 30}
-    [:widget/activity {:title "ACTIVITY LOG" :flex true}]
-    [:widget/context {:title "CONTEXT"}]]
+    [:widget/activity {:title "ACTIVITY LOG" :flex :grow}]
+    [:widget/context {:title "CONTEXT" :height 7}]
+    [:widget/runs {:title "RUNS" :height 6}]]
 
-   ;; The middle band is the conversation, and it takes the room.
-   [:widget/conversation {:flex true}]
+   ;; The middle band is the conversation, and it takes the room. `:turns` is
+   ;; how far back it draws — the newest that many. Every entry is rebuilt on
+   ;; every frame, so this is a frame-rate number as much as a history one;
+   ;; raise it to scroll further back and pay for it in redraws.
+   [:widget/conversation {:flex true :turns 60}]
 
-   ;; The right gutter: the work, and the rules it is being held to.
+   ;; The right gutter: which branch, what it is working on, what it has
+   ;; changed. BEAM is at the top because it decides what the conversation
+   ;; beside it IS — a run here is several branches, and the one on screen
+   ;; is a choice rather than the only one.
    [:vbox {:width 34}
-    [:widget/tasks {:title "TASKS" :flex true}]
-    [:widget/files {:title "MODIFIED"}]
-    [:widget/artifacts {:title "CLAIMS"}]
-    [:widget/gates {:title "GATES"}]]]
+    [:widget/branches {:title "BEAM" :height 6}]
+    [:widget/tasks {:title "TASKS" :height 8}]
+    [:widget/files {:title "MODIFIED" :flex :grow}]]]
+
+  ;; The run's own account of itself: what it has established, and what it
+  ;; was advised and has not answered. Wide and short — both are short lists
+  ;; of long lines, which is the opposite of what a gutter is for.
+  [:hbox {:height 7}
+   [:widget/artifacts {:title "CLAIMS" :flex true}]
+   [:widget/gates {:title "GATES" :flex true}]]
 
   ;; Above the compose box, because the branch is parked on it and it is the
   ;; only thing on screen that is waiting on you. Invisible when idle.

--- a/resources/tui.edn
+++ b/resources/tui.edn
@@ -1,0 +1,76 @@
+;; The terminal UI's arrangement, as data. This file seeds version 1 of the
+;; "tui" policy table in the project; after that the stored row is
+;; authoritative and this is only the factory default.
+;;
+;; THIS IS USERSPACE. The core implements the widgets — what a conversation
+;; log is, how a diff folds, where the activity trace comes from — and this
+;; file decides which of them appear and where. Rearranging the UI is editing
+;; EDN: no rebuild, and the agent can do it to itself at runtime through the
+;; same seam that carries gates.edn and the manifests.
+;;
+;; The vocabulary is ftxui's own (see the ftxui-jolt README): :vbox, :hbox,
+;; :border, :separator, :flex, :width, anything the toolkit draws. The only
+;; tags this project adds are `:widget/*`, each standing in for one widget
+;; the core implements. Every widget is optional and every one may appear
+;; more than once — two conversation panes side by side is a layout, not a
+;; feature.
+;;
+;; A tag nothing implements draws a complaint in its own box and leaves the
+;; rest of the layout alone; a layout that is not hiccup at all falls back to
+;; this file. A bad edit costs you a panel, never the screen.
+
+{;; How many of the newest turns to fetch the model's PROSE for each poll.
+ ;;
+ ;; The branch listing deliberately leaves assistant and reasoning text out:
+ ;; on one real run that was 5.5MB against 62KB of results, enough that the
+ ;; panel exceeded its socket timeout and never drew at all. So the words are
+ ;; fetched a turn at a time, for the turns a reader is actually on — the
+ ;; newest, since a conversation is read from the bottom. Raise it to scroll
+ ;; back further; every turn added is another request per poll.
+ :prose-turns 12
+
+ ;; --- the widgets in this build ---------------------------------------------
+ ;;
+ ;;   :widget/conversation  the agent's turns: what it said, what it called,
+ ;;                         what came back. Thinking, tool arguments and diffs
+ ;;                         fold; click a header to open one.
+ ;;   :widget/activity      the ACTIVITY LOG — the manifest states the agent is
+ ;;                         walking, newest last (:start :measure :infer :parse
+ ;;                         :dispatch :journal :settle :arbiter :route).
+ ;;   :widget/tasks         the board: what is open, in progress, done.
+ ;;   :widget/files         files this run has written, newest first.
+ ;;   :widget/context       context-window fill, and what the run has spent.
+ ;;   :widget/gates         gates that fired and predictions still unsettled.
+ ;;   :widget/artifacts     claims made, and how each was judged.
+ ;;   :widget/runs          the run picker.
+ ;;   :widget/approvals     the question a person is being asked, if any: the
+ ;;                         permission dialog, or ask_human's questionnaire.
+ ;;                         Draws nothing when there is nothing pending.
+ ;;   :widget/input         the compose box: interventions, abort, resume.
+ ;;   :widget/status        the status line.
+
+ :layout
+ [:vbox {:flex true}
+
+  [:hbox {:flex true}
+
+   ;; The left gutter: what the agent is doing, and what it is spending.
+   [:vbox {:width 30}
+    [:widget/activity {:title "ACTIVITY LOG" :flex true}]
+    [:widget/context {:title "CONTEXT"}]]
+
+   ;; The middle band is the conversation, and it takes the room.
+   [:widget/conversation {:flex true}]
+
+   ;; The right gutter: the work, and the rules it is being held to.
+   [:vbox {:width 34}
+    [:widget/tasks {:title "TASKS" :flex true}]
+    [:widget/files {:title "MODIFIED"}]
+    [:widget/artifacts {:title "CLAIMS"}]
+    [:widget/gates {:title "GATES"}]]]
+
+  ;; Above the compose box, because the branch is parked on it and it is the
+  ;; only thing on screen that is waiting on you. Invisible when idle.
+  [:widget/approvals {}]
+  [:widget/input {}]
+  [:widget/status {}]]}

--- a/src/samizdat/agent/tools.clj
+++ b/src/samizdat/agent/tools.clj
@@ -46,6 +46,7 @@
             [samizdat.lexicon :as lexicon]
             [samizdat.prompt :as prompt]
             [samizdat.agent.tools.base :as base]
+            [samizdat.agent.tools.ask]
             [samizdat.agent.tools.repl]
             [samizdat.agent.tools.files]
             [samizdat.agent.tools.intervene]

--- a/src/samizdat/agent/tools/ask.clj
+++ b/src/samizdat/agent/tools/ask.clj
@@ -1,0 +1,100 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.agent.tools.ask
+  "`ask_human` — put a question to a person and wait for the answer.
+
+  The counterpart to the permission gate, over the same queue in
+  samizdat.approval: that one asks `may I run this`, this one asks `which of
+  these did you want`. Both are bounded by gates.edn `:approval`, and both
+  are OFF unless a project turned them on.
+
+  Off by default matters more here than there. A run is autonomous, and a
+  tool that could park one indefinitely is a way for the model to stop a
+  campaign dead — so with `:mode :refuse` this refuses and says why, and the
+  model goes back to deciding for itself, which is what it was going to have
+  to do anyway.
+
+  :neutral, never :success. Asking establishes nothing: reporting progress
+  would clear the branch's consecutive-failure count and buy it turns for
+  having had a question, which is the well-formed-but-useless call the
+  progress guards exist to catch. The wording is prompts/ask-tool.md."
+  (:require [clojure.string :as str]
+            [samizdat.agent.tools.base :as base]
+            [samizdat.approval :as approval]
+            [samizdat.prompt :as prompt]))
+
+(defn- msg [ctx] (prompt/render "ask-tool" ctx))
+
+(defn- normalize
+  "The questions as a vector of maps, whatever shape the model sent.
+
+  A model that sends one question rather than a list, or a bare string
+  instead of a map, has asked a perfectly clear question — refusing it on
+  shape would spend a turn teaching JSON rather than answering."
+  [qs]
+  (let [qs (cond (nil? qs) []
+                 (sequential? qs) qs
+                 :else [qs])]
+    (->> qs
+         (keep (fn [q]
+                 (cond
+                   (map? q) (let [text (or (:question q) (:text q) (:prompt q))]
+                              (when (not-empty (str text))
+                                {:question (str text)
+                                 :options (mapv str (:options q))
+                                 :multi (boolean (:multi q))}))
+                   (not-empty (str q)) {:question (str q) :options []}
+                   :else nil)))
+         vec)))
+
+(defn- answered
+  "What the branch reads back. The questions are echoed beside the answers:
+  a turn later the model has only this string, and an answer without its
+  question is not something it can act on."
+  [questions answers]
+  (str/join "\n"
+            (map-indexed (fn [i q]
+                           (str (:question q) " → "
+                                (let [a (nth answers i nil)]
+                                  (cond
+                                    (sequential? a) (str/join ", " a)
+                                    (some? a) (str a)
+                                    :else "(no answer)"))))
+                         questions)))
+
+(defmethod base/run-tool "ask_human" [{:keys [branch run-id branch-id] :as ctx}]
+  (let [questions (normalize (base/arg ctx :questions))
+        {:keys [mode wait-ms on-timeout]} (approval/policy)]
+    (cond
+      (empty? questions)
+      (base/malformed branch (msg {:needs-questions true}))
+
+      (not= :block mode)
+      ;; Not a failure and not a refusal of the branch's reasoning: there is
+      ;; simply nobody on the other end. Say so plainly and let it decide.
+      (base/malformed branch (msg {:nobody-configured true}))
+
+      :else
+      (let [id (approval/request! {:run-id run-id :branch-id (or branch-id (:id branch))
+                                   :kind :question :questions questions})
+            answer (approval/await! id wait-ms {:decision (or on-timeout :deny)})]
+        (if (:timed-out answer)
+          (base/malformed branch (msg {:unanswered true
+                                       :seconds (int (/ (or wait-ms 0) 1000))}))
+          (base/ok branch (answered questions (vec (:answers answer)))))))))

--- a/src/samizdat/api/client.clj
+++ b/src/samizdat/api/client.clj
@@ -1,0 +1,245 @@
+;; samizdat - a claim-first verification harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.api.client
+  "The client over the run API, plus the journal poll loop.
+
+  Mechanism, so it lives in the base: how to reach the server is the same
+  question for every front end, and the GUI and the TUI had no business
+  answering it twice. `samizdat.gui.api` is now this namespace under its old
+  names; the TUI calls it directly.
+
+  Deliberately toolkit-free — http-client and JSON only — so the headless
+  suite covers it without loading GTK or a terminal, and so the model/view
+  split stays honest: everything a front end knows arrives through these
+  functions, and everything it does goes back through them. The server
+  neither knows nor cares that a front end exists.
+
+  Every call returns {:ok true :body ...} or {:ok false :error ...} — a dead
+  or absent server is a value the UI renders, never a throw that takes the
+  window down."
+  (:require ;; the java.time.* host shim, before data.json — see samizdat.store.journal
+            [jolt.time]
+            [clojure.data.json :as json]
+            [jolt.http-client :as http]))
+
+(def ^:private opts
+  {:socket-timeout 10000 :conn-timeout 3000 :throw-exceptions false})
+
+(defn- decode [s]
+  (try (json/read-str (str s) :key-fn keyword) (catch Throwable _ nil)))
+
+(defn- result [r]
+  (if (<= 200 (:status r 0) 299)
+    {:ok true :body (decode (:body r))}
+    {:ok false :error (str "HTTP " (:status r)
+                           (some->> (:body r) decode :error :message (str ": ")))}))
+
+(defn- GET [base path]
+  (try (result (http/get (str base path) opts))
+       (catch Throwable e {:ok false :error (ex-message e)})))
+
+(defn- POST
+  ([base path body] (POST base path body nil))
+  ([base path body socket-timeout-ms]
+   (try (result (http/post (str base path)
+                           (cond-> (assoc opts
+                                          :headers {"Content-Type" "application/json"}
+                                          :body (json/write-str (or body {})))
+                             socket-timeout-ms (assoc :socket-timeout socket-timeout-ms))))
+        (catch Throwable e {:ok false :error (ex-message e)}))))
+
+(defn list-runs [base] (GET base "/v1/runs"))
+
+(defn run-detail
+  "One run in full: the row, its branches, artifacts, gates, interventions,
+  the board and the paths it has changed."
+  [base run-id]
+  (GET base (str "/v1/runs/" run-id)))
+
+(defn models
+  "{:current \"...\" :models [...]} — what the provider serves, for the picker.
+  Not /v1/models, which answers what this harness serves and is a different
+  question."
+  [base]
+  (GET base "/v1/harness/models"))
+
+(defn journal-since
+  "Everything after `cursor`, the polling UI's one read."
+  ([base run-id cursor] (journal-since base run-id cursor 200))
+  ([base run-id cursor limit]
+   (GET base (str "/v1/runs/" run-id "/journal?since=" (or cursor 0)
+                  "&limit=" limit))))
+
+(defn steps-since
+  "The live manifest-state trace after `cursor` — the implementer walking its
+  state graph.
+
+  Same cursor contract as `journal-since`, which is the point: a front end
+  runs one poll loop over both feeds. Held in memory by the server and
+  bounded, so the response carries `dropped` when this client fell behind
+  (see samizdat.steps)."
+  ([base run-id cursor] (steps-since base run-id cursor 200))
+  ([base run-id cursor limit]
+   (GET base (str "/v1/runs/" run-id "/steps?since=" (or cursor 0)
+                  "&limit=" limit))))
+
+(defn approvals
+  "Questions this run is waiting on a person to answer — the permission gate
+  and ask_human, which share one queue."
+  [base run-id]
+  (GET base (str "/v1/runs/" run-id "/approvals")))
+
+(defn decide!
+  "Answer one of them. `decision` is :allow / :deny for a permission
+  question, :answer with `answers` for a questionnaire."
+  [base approval-id {:keys [decision note answers]}]
+  (POST base (str "/v1/approvals/" approval-id)
+        (cond-> {:decision (name (or decision :deny))}
+          note (assoc :note note)
+          answers (assoc :answers answers))))
+
+(defn turn-detail
+  "One turn, whole — including the model's prose, which `branch-detail`
+  leaves out because it is the bulk of a long run. Fetched per turn, for the
+  turns actually on screen."
+  [base run-id branch-id turn]
+  (GET base (str "/v1/runs/" run-id "/branches/" branch-id "/turns/" turn)))
+
+(defn branch-detail
+  "Every turn and artifact for a branch, in full. Deliberately given a
+  longer socket timeout than the rest: the response carries every result
+  string and every encoding, which on a long run is hundreds of kilobytes
+  and takes seconds. A front end renders live activity from the event stream
+  meanwhile, so this arriving late costs nothing."
+  [base run-id branch-id]
+  (try (result (http/get (str base "/v1/runs/" run-id "/branches/" branch-id)
+                         (assoc opts :socket-timeout 45000)))
+       (catch Throwable e {:ok false :error (ex-message e)})))
+
+(def start-timeout-ms
+  "How long to wait for POST /v1/runs.
+
+  Deliberately longer than the 30s api.control/start-run! itself waits on
+  (deref promised 30000). That endpoint does not answer when the run row is
+  written — beam/run! opens every branch in the beam first and only then
+  calls on-start — so a start can legitimately take tens of seconds, and how
+  long depends on the beam width and on what else the machine is doing.
+
+  Under the shared 10s default this reported a failure for a run that was
+  starting normally: the row was already committed, so the user was told the
+  run had failed AND left with a live run consuming provider spend, with the
+  same request succeeding under curl. Any client bound tighter than the
+  server's own budget has that bug; this one has to outlast it."
+  40000)
+
+(defn start-run!
+  "Start a fresh run and return its id in the body.
+
+  The server answers 503 when the beam does not come up inside its 30s window,
+  which `result` already turns into {:ok false}. It used to answer 200 with an
+  `{:error ...}` body instead, so a plain 2xx was not proof a run existed; the
+  unwrap below is kept as a belt-and-braces check on that older shape, since a
+  caller that mistakes a refusal for a started run goes on to poll a run id
+  that is nil."
+  [base body]
+  (let [r (POST base "/v1/runs" body start-timeout-ms)]
+    (if (and (:ok r) (get-in r [:body :error]))
+      {:ok false :error (get-in r [:body :error])}
+      r)))
+
+(defn intervene!
+  "A human directive, applied at the branch's next turn boundary. `branch-id`
+  nil targets the whole run."
+  [base run-id {:keys [branch-id kind payload]}]
+  (POST base (str "/v1/runs/" run-id "/interventions")
+        (cond-> {:kind (or kind "message") :payload payload}
+          branch-id (assoc :branch_id branch-id))))
+
+(defn abort! [base run-id]
+  (POST base (str "/v1/runs/" run-id "/abort") {}))
+
+(defn resume!
+  "Resume a crashed run; with `max-turns`, extend an exhausted one's budget."
+  ([base run-id] (resume! base run-id nil))
+  ([base run-id max-turns]
+   (POST base (str "/v1/runs/" run-id "/resume")
+         (if max-turns {:max_turns max-turns} {}))))
+
+;; --- the poll loop -----------------------------------------------------------
+
+(def base-interval-ms 1500)
+(def max-backoff-ms 30000)
+
+(defn poll-step
+  "Fold one journal fetch into the loop state {:cursor :interval-ms}.
+
+  Pure, so the loop's whole policy is testable offline: events advance the
+  cursor and reset the interval; an empty batch keeps both; a failure marks
+  the state disconnected and doubles the interval up to the cap — the
+  cursor survives an outage, so nothing is missed when the server returns."
+  [{:keys [cursor interval-ms] :as state} {:keys [ok body]}]
+  (if ok
+    (let [events (vec (:events body))]
+      (assoc state
+             :cursor (or (:id (peek events)) cursor 0)
+             :interval-ms base-interval-ms
+             :connected? true
+             :events events))
+    (assoc state
+           :events []
+           :connected? false
+           :interval-ms (min max-backoff-ms
+                             (* 2 (max base-interval-ms
+                                       (or interval-ms base-interval-ms)))))))
+
+(defn start-poller!
+  "Tail `run-id`'s journal on a background thread.
+
+  Calls (on-events events) for every non-empty batch and (on-status state)
+  after every step. Callbacks are guarded — one throw used to kill the
+  future silently, leaving the header saying \"tailing\" over a frozen
+  graph (code-review-2026-08 #5). @running is rechecked after the fetch
+  too: a batch landing after stop! belongs to a run the UI has already
+  left, and delivering it folded the old run's events into the new one.
+  glimmer marshals ratom writes made off the main thread onto the GTK
+  loop itself, so callbacks may swap! UI state directly; ftxui's refresh!
+  is thread-safe for the same reason.
+  Returns {:stop! (fn [])}; stopping is cooperative at the next wakeup."
+  [{:keys [base run-id on-events on-status]}]
+  (let [running (atom true)
+        guard (fn [f]
+                (when f
+                  (fn [& args]
+                    (try (apply f args)
+                         (catch Throwable e
+                           (println "[api.client] poller callback failed:"
+                                    (ex-message e)))))))]
+    (let [on-events (guard on-events)
+          on-status (guard on-status)]
+      (future
+        (loop [state {:cursor 0 :interval-ms base-interval-ms}]
+          (when @running
+            (let [state (poll-step state (journal-since base run-id (:cursor state)))]
+              (when (and @running on-events (seq (:events state)))
+                (on-events (:events state)))
+              (when (and @running on-status)
+                (on-status (dissoc state :events)))
+              (Thread/sleep (:interval-ms state))
+              (recur state)))))
+      {:stop! (fn [] (reset! running false))})))

--- a/src/samizdat/api/client.clj
+++ b/src/samizdat/api/client.clj
@@ -99,6 +99,15 @@
    (GET base (str "/v1/runs/" run-id "/steps?since=" (or cursor 0)
                   "&limit=" limit))))
 
+(defn layout
+  "The project's terminal-UI layout, as EDN text under `:layout`.
+
+  A front end holds no database handle, so the stored `tui` policy — the one
+  the agent edits when it rearranges its own UI — is only readable through
+  the server, which is bound to the project."
+  [base]
+  (GET base "/v1/harness/layout"))
+
 (defn approvals
   "Questions this run is waiting on a person to answer — the permission gate
   and ask_human, which share one queue."

--- a/src/samizdat/api/control.clj
+++ b/src/samizdat/api/control.clj
@@ -30,6 +30,7 @@
             [clojure.tools.logging :as log]
             [samizdat.agent.beam :as beam]
             [samizdat.agent.resume :as resume]
+            [samizdat.approval :as approval]
             [samizdat.cancel :as cancel]
             [samizdat.llm.registry :as registry]
             [samizdat.prompt :as prompt]
@@ -122,13 +123,19 @@
                                                               :cancel (fn [] (some-> @cancel* (apply [])))})
                                                       (deliver promised rid))})]
                         (swap! active dissoc (:run-id r))
+                        ;; Release anything parked on a question this run
+                        ;; asked. Without it an aborted or finished run
+                        ;; leaves threads waiting on an answer nobody will
+                        ;; ever give, and the process never gets them back.
+                        (approval/abandon! (:run-id r))
                         r)
                       (catch Throwable e
                         (if (cancel/control-signal? e)
                           (log/info "run aborted:" (ex-message e))
                           (log/error "run failed:" (ex-message e)))
                         (when-let [rid (deref promised 0 nil)]
-                          (swap! active dissoc rid))
+                          (swap! active dissoc rid)
+                          (approval/abandon! rid))
                         {:status :error :error (ex-message e)})))))
         _ (reset! cancel* (:cancel started))
         ;; How long the request waits for the run row before answering 503.

--- a/src/samizdat/api/runs.clj
+++ b/src/samizdat/api/runs.clj
@@ -34,10 +34,22 @@
             [samizdat.store.db :as db]
             [samizdat.store.interventions :as interventions]
             [samizdat.store.journal :as journal]
-            [samizdat.store.runs :as runs]))
+            [samizdat.store.runs :as runs]
+            [samizdat.store.tasks :as tasks]
+            [samizdat.steps :as steps]))
 
 (defn- parse-json [s]
   (when s (try (json/read-str s :key-fn keyword) (catch Throwable _ s))))
+
+(defn- kw-name
+  "A keyword as the name a reader expects — `loop/assemble`, not
+  `:loop/assemble`. `name` drops the namespace and `str` keeps the colon, so
+  neither is right on its own for a namespaced keyword going over the wire."
+  [k]
+  (cond
+    (nil? k) nil
+    (keyword? k) (subs (str k) 1)
+    :else (str k)))
 
 (defn list-runs [conn limit]
   {:runs (mapv (fn [r]
@@ -106,7 +118,13 @@
        :artifacts (mapv #(update % :witness parse-json)
                         (journal/artifacts conn run-id))
        :gates (journal/gate-tally conn run-id)
-       :interventions (interventions/history conn run-id)})))
+       :interventions (interventions/history conn run-id)
+       ;; The board and the tree, for the panels that show what is being
+       ;; worked on and what has changed under it. Both are queries over
+       ;; tables the loop already appends to, so they need no cooperation
+       ;; from the run and work the same on a finished one.
+       :tasks (tasks/board conn {:run-id run-id})
+       :modified (journal/run-writes conn run-id (gates/threshold :modified-files-shown))})))
 
 (defn journal-tail
   "Everything after `since`. The `next` cursor is what the client sends back,
@@ -120,6 +138,50 @@
      :events (mapv #(update % :data parse-json) events)
      :next (or (:id (last events)) (or since 0))
      :count (count events)}))
+
+(defn turn-detail
+  "One turn, whole — including the text `branch-detail` deliberately drops.
+
+  `branch-turns` leaves out assistant_text and reasoning_text because they
+  are the bulk: on one real run, 5.5MB against 62KB of results, enough that
+  the branch panel exceeded its socket timeout and never rendered. But the
+  model's prose is the substance of what a reader is following, so it has to
+  arrive somehow — one turn at a time, for the turns actually on screen.
+
+  This is `fetch_turn`'s query with an HTTP door on it."
+  [conn run-id branch-id turn]
+  (when-let [t (journal/branch-turn conn run-id branch-id turn)]
+    (update t :args parse-json)))
+
+(defn steps-tail
+  "The live manifest-state trace after `since` — the implementer walking its
+  state graph, for a front end to draw.
+
+  Deliberately the same shape as `journal-tail`, down to `next` and `count`,
+  so a client runs one poll loop over both feeds instead of two designs. It
+  takes no `conn`: steps are held in memory by samizdat.steps and are not a
+  durable record (see that namespace on why).
+
+  `dropped` is what this client missed to the ring's bound — 0 while it keeps
+  up. It is reported rather than hidden so a UI can say the trace has a hole
+  in it instead of drawing one that looks continuous."
+  [run-id since limit]
+  (let [{:keys [steps cursor dropped]} (steps/since run-id (or since 0)
+                                                    (max 0 (or limit 200)))]
+    {:run_id run-id
+     ;; Keywords on the bus, strings on the wire: :node, :cell and
+     ;; :transition are what a client renders, and a JSON reader hands back a
+     ;; string either way. `str` on a keyword keeps the colon, so a cell went
+     ;; over as ":loop/assemble" and a panel drew it that way; `kw-name`
+     ;; prints the name, namespace and all.
+     :steps (mapv (fn [s] (-> s
+                              (update :node kw-name)
+                              (update :cell kw-name)
+                              (update :transition kw-name)))
+                  steps)
+     :next cursor
+     :count (count steps)
+     :dropped dropped}))
 
 (defn branch-detail [conn run-id branch-id]
   (when-let [b (runs/get-branch conn run-id branch-id)]

--- a/src/samizdat/approval.clj
+++ b/src/samizdat/approval.clj
@@ -1,0 +1,192 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.approval
+  "Asking a person, with a deadline.
+
+  samizdat runs unattended by design. The shell policy's `:ask` refuses the
+  call and teaches the model to retry; a human adds a grant afterwards and
+  the run never stopped. That is the right default and it stays the default.
+
+  This is the other bet, for when somebody IS watching: the branch parks on
+  a question and a person answers it. What makes that safe rather than a
+  liability is the deadline. Every wait here is bounded by a number in
+  gates.edn and resolves to a STATED default when it expires, and a run that
+  ends releases every waiter it had. A campaign that starts at 3am with
+  nobody at the terminal comes out the far side; it does not hang.
+
+  MECHANISM ONLY. Nothing here decides when to ask — `resolve-ask` reads
+  `:approval` from gates.edn and does what the project said, and the default
+  there is `:refuse`, which is exactly the behaviour the harness had before
+  this namespace existed. A feature landing must not change what an
+  unattended run does.
+
+  Two shapes over one registry: a yes/no on a tool call (the permission
+  gate) and a questionnaire (`ask_human`). They differ only in what the
+  request carries and what the answer carries, so they share the queue, the
+  deadline and the endpoints."
+  (:require [clojure.tools.logging :as log]
+            [samizdat.agent.gates :as gates]))
+
+(defn policy
+  "The approval policy: `{:mode :refuse|:block :wait-ms n :on-timeout
+  :deny|:allow}`, from gates.edn."
+  []
+  (gates/threshold :approval))
+
+;; {id {:id :run-id :branch-id :kind :input :details :reason :questions
+;;      :status :asked-at :promise}}
+(defonce ^:private requests (atom {}))
+
+(defn reset!
+  "Drop every request, releasing anyone waiting. For tests and teardown."
+  []
+  (let [old @requests]
+    (clojure.core/reset! requests {})
+    (doseq [[_ {:keys [promise]}] old]
+      (when promise (deliver promise {:decision :deny :note "harness shutting down"}))))
+  nil)
+
+(defn- new-id []
+  (str (java.util.UUID/randomUUID)))
+
+(defn request!
+  "Register a question and return its id. Does not wait — `await!` does that,
+  so a caller can register, publish, and then park."
+  [{:keys [run-id branch-id kind input details reason questions]}]
+  (let [id (new-id)]
+    (swap! requests assoc id
+           {:id id :run-id run-id :branch-id branch-id
+            :kind (or kind :shell)
+            :input input :details details :reason reason :questions questions
+            :status "pending"
+            :asked-at (System/currentTimeMillis)
+            :promise (promise)})
+    id))
+
+(defn pending
+  "Questions still waiting, for `run-id` — or every one of them when nil.
+
+  Only the ones still unanswered: an entry survives being decided until its
+  waiter has collected the answer (see `decide!`), and showing operators a
+  question that has already been settled would invite a second answer to a
+  decision that has been acted on.
+
+  Without the `:promise`, which is a parked thread and not something to
+  serialise onto a wire."
+  [run-id]
+  (->> (vals @requests)
+       (filter #(= "pending" (:status %)))
+       (filter #(or (nil? run-id) (= run-id (:run-id %))))
+       (sort-by :asked-at)
+       (mapv #(dissoc % :promise))))
+
+(defn decide!
+  "Answer a pending question. True when this call was the one that answered
+  it, false when there was nothing to answer.
+
+  FIRST ANSWER WINS, and a second is refused rather than applied. Two
+  operators with two TUIs open is the ordinary case, and the branch has
+  already resumed on the first answer — a second that overwrote it would be
+  changing a decision that has been acted on.
+
+  The entry is MARKED answered, not removed. Deleting it here lost the race
+  where a person answers between `request!` and `await!`: the promise was
+  delivered to an entry nobody could find any more, and the branch was
+  denied a command a human had just allowed. `await!` retires it once it has
+  collected the answer."
+  [id decision]
+  (let [applied (atom false)]
+    (swap! requests
+           (fn [m]
+             (let [r (get m id)]
+               (if (and r (= "pending" (:status r)))
+                 (do (clojure.core/reset! applied r)
+                     (assoc-in m [id :status] "decided"))
+                 (do (clojure.core/reset! applied false) m)))))
+    (if-let [r @applied]
+      (do (deliver (:promise r) decision) true)
+      false)))
+
+(defn await!
+  "Wait for `id` to be answered, at most `wait-ms`, then `default`.
+
+  The deadline is the point. Returns the decision map either way, so a
+  caller never has to distinguish `answered deny` from `nobody was there`
+  unless it wants to — `:timed-out` on the fallback says which."
+  [id wait-ms default]
+  (if-let [p (:promise (get @requests id))]
+    (let [d (deref p wait-ms ::timeout)]
+      ;; Retire it either way. A question whose asker has stopped waiting is
+      ;; not one a person can still usefully answer, and an answered one has
+      ;; now been collected.
+      (swap! requests dissoc id)
+      (if (= ::timeout d) (assoc default :timed-out true) d))
+    ;; No such request — never registered, or already collected.
+    (assoc default :timed-out true)))
+
+(defn abandon!
+  "Release every waiter on `run-id` — the run is over.
+
+  Without this, an aborted or crashed run leaves threads parked on questions
+  nobody will ever answer, and the process never gets them back."
+  [run-id]
+  (let [gone (filter #(= run-id (:run-id %)) (vals @requests))]
+    (swap! requests #(apply dissoc % (map :id gone)))
+    (doseq [{:keys [promise]} gone]
+      (when promise (deliver promise {:decision :deny :note "the run ended"})))
+    (count gone)))
+
+;; --- the policy seam ---------------------------------------------------------
+
+(defn resolve-ask
+  "Give a person the chance to turn an `:ask` into an `:allow`.
+
+  Returns the decision map, with `:effect` possibly changed and `:note`
+  carrying whatever the person said. Anything that is not an `:ask` passes
+  straight through, and so does an `:ask` when the project has not asked for
+  a person in the loop — which is the default.
+
+  Never throws. This sits in the path of every shell command, and an
+  approval registry that could fail would be a registry that can stop a run
+  from doing anything at all."
+  [{:keys [run-id branch-id]} {:keys [effect input details reason] :as decision}]
+  (let [{:keys [mode wait-ms on-timeout]} (policy)]
+    (if-not (and (= :ask effect) (= :block mode))
+      decision
+      (try
+        (let [id (request! {:run-id run-id :branch-id branch-id :kind :shell
+                            :input input :details details :reason reason})
+              answer (await! id wait-ms {:decision (or on-timeout :deny)})]
+          (cond
+            (= :allow (:decision answer))
+            (assoc decision :effect :allow :note (:note answer))
+
+            ;; An expired wait leaves the ask as the refusal it always was,
+            ;; and says that is why — so the refusal the model reads can
+            ;; mention that nobody was there, rather than reading as a rule.
+            (:timed-out answer)
+            (cond-> (assoc decision :timed-out true)
+              (= :allow on-timeout) (assoc :effect :allow)
+              (:note answer) (assoc :note (:note answer)))
+
+            :else
+            (assoc decision :note (:note answer))))
+        (catch Throwable e
+          (log/warn "approval: asking failed, refusing as usual:" (ex-message e))
+          decision)))))

--- a/src/samizdat/prompt.clj
+++ b/src/samizdat/prompt.clj
@@ -44,7 +44,7 @@
   goes through the userspace seam, which is what decides whether the project's
   version or the template answers."
   [
-   "architect" "assembly"
+   "architect" "ask-tool" "assembly"
    "branch-cap"
    "branch-out"
    "cell-shadowed"

--- a/src/samizdat/security/policy.clj
+++ b/src/samizdat/security/policy.clj
@@ -37,6 +37,7 @@
   (:require [clojure.string :as str]
             [instaparse.combinators :as c]
             [instaparse.core :as insta]
+            [samizdat.approval :as approval]
             [samizdat.engine.proc :as proc]
             [samizdat.lexicon :as lexicon]
             [samizdat.prompt :as prompt]
@@ -626,12 +627,20 @@
   (let [command (str (:command args))
         env (or (:env ctx) (into {} (System/getenv)))
         session (if (and conn run-id) (grants/for-run conn run-id) {:grants []})
-        {:keys [effect head complex? promoted? blocked-segment protected-path
-                malformed rule]}
+        {:keys [head complex? promoted? blocked-segment protected-path
+                malformed rule]
+         :as decided}
         (decide session command)
         rule-text (str/join " " (remove nil? [(name (:name rule)) (:pattern rule)
                                               (:path rule) (:segment rule)
                                               (:index rule)]))
+        ;; A person's chance to turn an :ask into an :allow, bounded by
+        ;; gates.edn :approval. Default `:mode :refuse` means this is
+        ;; identity and the harness behaves exactly as it always has —
+        ;; blocking is something a project opts into, never something a
+        ;; release turns on under an unattended run.
+        {:keys [effect note timed-out]}
+        (approval/resolve-ask ctx (assoc decided :input command :reason rule-text))
         known (secrets/known-values env command)]
     (case effect
       :deny
@@ -668,7 +677,14 @@
                                :markers (when complex?
                                           (str/join " or "
                                                     (map #(str "`" % "`")
-                                                         (complex-markers-in command))))})
+                                                         (complex-markers-in command))))
+                               ;; What a person said when they denied it, and
+                               ;; whether the refusal is a rule or simply
+                               ;; nobody being there. Both are absent under
+                               ;; the default :refuse mode, where the
+                               ;; template renders exactly as before.
+                               :note note
+                               :unanswered timed-out})
        :policy {:effect :ask
                 ;; No grant unlocks a COMPLEX command (invariant 5 downgrades
                 ;; it to :ask even over a grant), so suggesting `head *` for

--- a/src/samizdat/server.clj
+++ b/src/samizdat/server.clj
@@ -39,7 +39,8 @@
             [samizdat.config :as config]
             [samizdat.llm.client :as llm-client]
             [samizdat.store.db :as db]
-            [samizdat.system :as system]))
+            [samizdat.system :as system]
+            [samizdat.userspace :as userspace]))
 
 (defn json-response
   ([body] (json-response 200 body))
@@ -144,6 +145,25 @@
 (defn- gate-table [_req]
   (json-response {:gates (gates/describe) :thresholds (gates/config)}))
 
+(defn layout-body
+  "The project's terminal-UI layout, as the EDN text of its `tui` policy.
+
+  Served rather than read by the front end because only this process is
+  BOUND to the project: `userspace/body` reads the stored row here and falls
+  back to the shipped template, where the same call in the TUI's process —
+  which holds no database handle by design — can only ever see the template.
+  Without this the agent could save a new version of its own UI and nothing
+  would ever draw it.
+
+  Text, not parsed: the server has no business understanding a layout, and a
+  client that is going to `edn/read-string` it anyway gains nothing from a
+  round trip through JSON."
+  []
+  {:layout (userspace/body :policy "tui")})
+
+(defn- layout-table [_req]
+  (json-response (layout-body)))
+
 ;; --- routing ----------------------------------------------------------------
 ;;
 ;; A route is [method pattern handler]. A pattern segment starting with ':'
@@ -173,6 +193,9 @@
    [:get "/v1/models" #'models]
    [:post "/v1/chat/completions" #'chat-completions]
    [:get "/v1/harness/gates" #'gate-table]
+   ;; The terminal UI's own arrangement, so a front end that holds no
+   ;; database handle can still see the version the agent saved.
+   [:get "/v1/harness/layout" #'layout-table]
    [:get "/v1/harness/models" #'harness-models]
    [:get "/v1/runs" (fn [req] (json-response (api-runs/list-runs (system/conn)
                                                                  (long-param req "limit"))))]

--- a/src/samizdat/server.clj
+++ b/src/samizdat/server.clj
@@ -35,6 +35,7 @@
             [samizdat.api.control :as control]
             [samizdat.api.openai :as openai]
             [samizdat.api.runs :as api-runs]
+            [samizdat.approval :as approval]
             [samizdat.config :as config]
             [samizdat.llm.client :as llm-client]
             [samizdat.store.db :as db]
@@ -190,6 +191,20 @@
                                                     (get-in req [:path-params :id])
                                                     (long-param req "since")
                                                     (long-param req "limit"))))]
+   ;; The live manifest-state trace. No conn: steps are held in memory, not
+   ;; journalled — see samizdat.steps.
+   [:get "/v1/runs/:id/steps"
+    (fn [req] (json-response (api-runs/steps-tail (get-in req [:path-params :id])
+                                                  (long-param req "since")
+                                                  (long-param req "limit"))))]
+   ;; One turn, whole. The branch listing drops the model's prose because it
+   ;; is the bulk; this is how a reader gets it back, a turn at a time.
+   [:get "/v1/runs/:id/branches/:branch/turns/:turn"
+    (fn [req] (let [{:keys [id branch turn]} (:path-params req)]
+                (if-let [t (api-runs/turn-detail (system/conn) id branch
+                                                 (parse-long (str turn)))]
+                  (json-response t)
+                  (json-response 404 {:error {:message "no such turn"}}))))]
    [:get "/v1/runs/:id/branches/:branch"
     (fn [req] (let [{:keys [id branch]} (:path-params req)]
                 (if-let [b (api-runs/branch-detail (system/conn) id branch)]
@@ -210,6 +225,27 @@
                                        (get-in req [:path-params :id])
                                        (body-json req))]
                 (json-response (or (:status r) 200) (:body r))))]
+   ;; Questions waiting on a person: the permission gate and ask_human, which
+   ;; share one queue because they differ only in what they carry.
+   [:get "/v1/runs/:id/approvals"
+    (fn [req] (json-response {:approvals (approval/pending
+                                          (get-in req [:path-params :id]))}))]
+   [:get "/v1/approvals"
+    (fn [_] (json-response {:approvals (approval/pending nil)}))]
+   [:post "/v1/approvals/:aid"
+    (fn [req]
+      (let [{:keys [decision note answers]} (body-json req)
+            d (keyword (or decision "deny"))]
+        (if (approval/decide! (get-in req [:path-params :aid])
+                              (cond-> {:decision d}
+                                note (assoc :note note)
+                                answers (assoc :answers answers)))
+          (json-response {:status "decided" :decision (name d)})
+          ;; Gone rather than never-existed: the ordinary cause is a second
+          ;; operator answering a question the first already settled, or a
+          ;; wait that expired. 409 says which, in the house style the other
+          ;; handlers use — a short noun phrase, not a sentence.
+          (json-response 409 {:error {:message "approval not open"}}))))]
    [:get "/v1/interventions/kinds" (fn [_] (json-response (control/kinds)))]])
 
 (defn- match-path [pattern uri]

--- a/src/samizdat/steps.clj
+++ b/src/samizdat/steps.clj
@@ -1,0 +1,237 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.steps
+  "The manifest-state trace, held where an HTTP client can read it.
+
+  `samizdat.events` publishes a STEP for every cell the implementer
+  completes — the state graph being walked, live: :start, :measure, :infer,
+  :parse, :dispatch, :journal, :settle, :arbiter, :route. That bus is
+  in-process, and both front ends are strict HTTP clients with no bus to
+  subscribe to, so the trace they most want to draw was the one thing they
+  could not see.
+
+  This is the buffer between the two. It subscribes to the bus once, keeps a
+  bounded ring per run, and hands out everything after a cursor — the same
+  read the journal tail already gives a polling UI, so a client needs no new
+  machinery to consume it.
+
+  DELIBERATELY NOT DURABLE. A step is worth a frame of a UI and nothing
+  after that; what a turn actually DID is the turns table, which is a
+  different question with a different answer. Writing fourteen rows a turn
+  to record the shape of the graph the manifest already states would be
+  paying storage for a redraw.
+
+  Three properties the ring holds, all of them bounded:
+
+  - A SLOW CLIENT LOSES THE OLDEST, and is told. `:dropped` counts what fell
+    off before the client's cursor, so a UI can say it fell behind instead of
+    drawing a trace with an invisible hole in it. This is the bus's own
+    contract, kept one layer up.
+  - A RUN THAT ENDS FREES ITS RING, through `forget!`.
+  - A PROCESS NEVER TOLD still does not grow: only the newest `max-runs`
+    rings are held, oldest evicted.
+
+  Mechanism only. The numbers are `:step-ring` in gates.edn, and nothing here
+  decides when a step is interesting."
+  (:require [clojure.tools.logging :as log]
+            [samizdat.agent.gates :as gates]
+            [samizdat.events :as events]))
+
+;; No fallback literals. gates.edn is the source for every one of these, the
+;; way beam.clj reads :pause-poll-ms — a default spelled here would be a
+;; second answer to a question resources already answer, and the one nobody
+;; edits when they tune the file.
+(defn- policy [] (gates/threshold :step-ring))
+
+(defn capacity
+  "Steps kept per run."
+  []
+  (:capacity (policy)))
+
+(defn max-runs
+  "How many runs' rings are held at once."
+  []
+  (:max-runs (policy)))
+
+;; {run-id {:seq n :dropped n :buf [step ...]}}, plus ::order — the run ids
+;; oldest-first, so eviction has an answer that does not depend on map order.
+(defonce ^:private rings (atom {::order []}))
+
+(defn reset!
+  "Drop every ring. For tests and for a process reusing the namespace."
+  []
+  (clojure.core/reset! rings {::order []})
+  nil)
+
+(defn run-count []
+  (count (::order @rings)))
+
+(defn- evict-runs
+  "`m` with the oldest rings dropped down to `max-runs`."
+  [m cap]
+  (let [order (::order m)]
+    (if (<= (count order) cap)
+      m
+      (let [drop-n (- (count order) cap)
+            gone (subvec order 0 drop-n)]
+        (assoc (apply dissoc m gone) ::order (subvec order drop-n))))))
+
+(defn- append
+  "Fold one step into a run's ring: a sequence number, and the oldest dropped
+  past the cap. `:dropped` counts evictions for the life of the run, so a
+  client's shortfall is the difference between it and what the client last
+  saw."
+  [{:keys [seq dropped buf] :or {seq 0 dropped 0 buf []}} step cap]
+  (let [seq (inc seq)
+        buf (conj buf (assoc step :seq seq))
+        over (max 0 (- (count buf) cap))]
+    {:seq seq
+     :dropped (+ dropped over)
+     ;; A fresh vector rather than a subvec, whose base would keep every step
+     ;; the run ever took — the same reason events/slide copies.
+     :buf (if (pos? over) (vec (drop over buf)) buf)}))
+
+(defn record!
+  "Take one bus event. Anything that is not a step with a run behind it is
+  dropped: the subscription is to the WHOLE bus, which carries every journal
+  append too, and a ring that took those would evict the trace it exists to
+  hold. A step with no run id is real — events/tracer derefs a promise for it,
+  and the turn manifest is compiled before the run row exists — and filing
+  those under nil would make a ring no client polling a real run ever reads."
+  [{:keys [kind run-id] :as event}]
+  (when (and (= :step kind) (some? run-id))
+    (let [cap (capacity)
+          runs (max-runs)]
+      (swap! rings
+             (fn [m]
+               (-> m
+                   (update run-id append event cap)
+                   (update ::order (fn [o] (if (contains? m run-id) o (conj o run-id))))
+                   (evict-runs runs))))))
+  nil)
+
+(defn since
+  "Everything recorded for `run-id` after `cursor`, at most `limit`.
+
+  Returns {:steps [...] :cursor n :dropped n}. `:cursor` is the sequence
+  number of the last step HANDED OVER, not the last recorded, so a limited
+  response resumes exactly where it stopped. `:dropped` is how many steps
+  were evicted before this client's cursor — 0 when it is keeping up."
+  ([run-id cursor] (since run-id cursor 200))
+  ([run-id cursor limit]
+   (let [{:keys [seq dropped buf] :or {seq 0 dropped 0 buf []}} (get @rings run-id)
+         cursor (or cursor 0)
+         fresh (into [] (comp (filter #(> (:seq %) cursor)) (take limit)) buf)
+         ;; What this client missed: evictions it had not already read past.
+         ;; A client at cursor 0 on a ring that has evicted 5 missed all 5;
+         ;; one that has kept up missed none.
+         missed (max 0 (- dropped cursor))]
+     {:steps fresh
+      :cursor (if (clojure.core/seq fresh) (:seq (peek fresh)) (min cursor seq))
+      :dropped missed})))
+
+(defn forget!
+  "Drop a run's ring.
+
+  NOT called when a run finishes, on purpose: the moment a run ends is
+  exactly when someone opens it to see how it went, and a trace deleted at
+  completion would be empty for every finished run. The `max-runs` bound is
+  what keeps the process honest instead. This is here for a caller that
+  knows it is done with one."
+  [run-id]
+  (swap! rings (fn [m] (-> (dissoc m run-id)
+                           (update ::order (fn [o] (vec (remove #{run-id} o)))))))
+  nil)
+
+;; --- the bus seam ------------------------------------------------------------
+;;
+;; Split into subscribe!/drain! rather than hidden inside a thread, because
+;; the same two calls are how a test drives it deterministically and how the
+;; server's pump drives it on a timer. A pump that owned its own loop would
+;; make the wiring untestable without sleeping.
+
+(defn pump-ms
+  "How often the bus is drained into the rings."
+  []
+  (:pump-ms (policy)))
+
+(defn subscribe!
+  "A bus subscription feeding this ring. Close it with `unsubscribe!`.
+
+  Its window is the ring's own capacity rather than the bus default, so the
+  bus cannot drop a step the ring had room for — `:dropped` would then
+  under-report, and a UI would draw a hole it was never told about."
+  []
+  (events/subscribe (max (capacity) events/buffer-size)))
+
+(defn unsubscribe! [sub]
+  (events/unsubscribe! sub))
+
+(defn drain!
+  "Record everything `sub` has collected since the last drain. Returns how
+  many events were taken (steps and all), so a caller can tell a quiet bus
+  from a stalled one."
+  [sub]
+  (let [batch (events/collect sub)]
+    (run! record! batch)
+    (count batch)))
+
+;; --- the pump ----------------------------------------------------------------
+
+(defonce ^:private pump (atom nil))
+
+(defn pumping? [] (some? @pump))
+
+(defn start-pump!
+  "Drain the bus into the rings on a timer, until `stop-pump!`.
+
+  Idempotent: a second call while one is running is a no-op rather than a
+  second pump. Two pumps on one bus would each take half the events — the
+  bus hands a batch to whoever collects it first — and the rings would carry
+  a trace with gaps that appears only after a restart! that ran start! twice.
+
+  Never throws out of the loop. This runs beside a live run and a pump that
+  died on one malformed event would take the whole trace down with it, which
+  is the failure the tracer's own catch already refuses."
+  []
+  (when-not @pump
+    (let [sub (subscribe!)
+          running (atom true)
+          t (Thread.
+             (fn []
+               (while @running
+                 (try (drain! sub)
+                      (catch Throwable e
+                        (log/warn "steps: drain failed:" (ex-message e))))
+                 (Thread/sleep (pump-ms))))
+             "samizdat-steps-pump")]
+      (.setDaemon t true)
+      (clojure.core/reset! pump {:sub sub :running running :thread t})
+      (.start t)))
+  nil)
+
+(defn stop-pump!
+  "Stop the pump and close its subscription. A no-op when none is running —
+  system/stop! runs best effort over every resource and must not throw here."
+  []
+  (when-let [{:keys [sub running]} @pump]
+    (clojure.core/reset! running false)
+    (unsubscribe! sub)
+    (clojure.core/reset! pump nil))
+  nil)

--- a/src/samizdat/store/journal.clj
+++ b/src/samizdat/store/journal.clj
@@ -42,6 +42,7 @@
             ;; before jdbc.core.
             [db.jdbc]
             [jdbc.core :as jdbc]
+            [samizdat.agent.gates :as gates]
             [samizdat.events :as events]
             [samizdat.session :as session]
             [samizdat.store.db :as db]))
@@ -251,6 +252,33 @@
   (try (some-> (json/read-str (str (:args row)) :key-fn keyword) :path str not-empty)
        (catch Throwable _ nil)))
 
+(defn- writing-tools
+  "The tools that change a file, from gates.edn's `:file-write` vocabulary.
+
+  Read rather than restated. These queries used to name write_file and
+  edit_file inline, which silently excluded `patch` — a writing tool that has
+  been in the vocabulary all along — so an anchored edit by a sibling was
+  invisible to both the collaboration list and the staleness notice: two
+  workers in one file, one of them patching, and neither told. Reading the
+  vocabulary means a project that adds a writing tool gets these for free,
+  which is the drift that produced the gap.
+
+  No fallback list: gates.edn is the source, and a second copy here would be
+  the one nobody edits."
+  []
+  (vec (gates/tool-vocab :file-write)))
+
+(defn- placeholders
+  "`sql` with its `@tools` marker replaced by an IN list of `n` parameters.
+
+  A marker in ONE string literal rather than SQL concatenated around a
+  computed fragment: the vocabulary is data, so its length is not known
+  here, but splitting the query into pieces leaves half-sentences in the
+  source that read as prose to base-test — and, more to the point, makes the
+  query unreadable to whoever has to check it."
+  [sql n]
+  (str/replace sql "@tools" (str/join ", " (repeat n "?"))))
+
 (defn sibling-writes
   "What OTHER branches on this run have done to the tree: one entry per path,
   naming every branch that has changed it and the turn it was last touched,
@@ -274,18 +302,53 @@
   Derived from the journal rather than reported by the branches, so it cannot
   drift from what actually happened and costs no turn to produce."
   [conn run-id branch-id limit]
-  (->> (db/fetch conn ["SELECT branch_id, turn, tool_name, args FROM turns
-                      WHERE run_id = ? AND branch_id <> ?
-                        AND tool_name IN ('write_file', 'edit_file')
-                        AND category = 'success'
-                      ORDER BY turn DESC, id DESC"
-                    run-id (str branch-id)])
+  (->> (let [tools (writing-tools)]
+         (db/fetch conn (into [(placeholders
+                                "SELECT branch_id, turn, tool_name, args FROM turns
+                                  WHERE run_id = ? AND branch_id <> ?
+                                    AND tool_name IN (@tools)
+                                    AND category = 'success'
+                                  ORDER BY turn DESC, id DESC"
+                                (count tools))
+                               run-id (str branch-id)]
+                              tools)))
        (keep (fn [r] (when-let [p (path-of r)]
                        {:branch (:branch_id r) :turn (:turn r) :path p})))
        (reduce (fn [acc {:keys [path branch turn]}]
                  (let [i (first (keep-indexed #(when (= path (:path %2)) %1) acc))]
                    (if i
                      (update-in acc [i :branches] (fn [bs] (if (some #{branch} bs) bs (conj bs branch))))
+                     (conj acc {:path path :turn turn :branches [branch]}))))
+               [])
+       (take limit)
+       vec))
+
+(defn run-writes
+  "Every path this run has changed: one entry per path, naming the branches
+  that touched it and the turn it was last changed, most recently first.
+
+  `sibling-writes` asks what the OTHER branches did, because a worker wants
+  to know who else is in a file. This asks what the RUN did, because someone
+  watching it wants to know what has changed on disk — the same query without
+  the branch exclusion, which is why they sit together."
+  [conn run-id limit]
+  (->> (let [tools (writing-tools)]
+         (db/fetch conn (into [(placeholders
+                                "SELECT branch_id, turn, tool_name, args FROM turns
+                                  WHERE run_id = ?
+                                    AND tool_name IN (@tools)
+                                    AND category = 'success'
+                                  ORDER BY turn DESC, id DESC"
+                                (count tools))
+                               run-id]
+                              tools)))
+       (keep (fn [r] (when-let [p (path-of r)]
+                       {:branch (:branch_id r) :turn (:turn r) :path p})))
+       (reduce (fn [acc {:keys [path branch turn]}]
+                 (let [i (first (keep-indexed #(when (= path (:path %2)) %1) acc))]
+                   (if i
+                     (update-in acc [i :branches]
+                                (fn [bs] (if (some #{branch} bs) bs (conj bs branch))))
                      (conj acc {:path path :turn turn :branches [branch]}))))
                [])
        (take limit)
@@ -306,19 +369,29 @@
   collaborating, and a harness that refuses the write decides for them which
   version wins, which is exactly the judgement it does not have."
   [conn run-id branch-id path]
-  (let [reads (db/fetch conn ["SELECT turn, args FROM turns
-                            WHERE run_id = ? AND branch_id = ?
-                              AND tool_name IN ('read_file', 'write_file', 'edit_file')
-                            ORDER BY turn DESC, id DESC"
-                           run-id (str branch-id)])
+  (let [tools (writing-tools)
+        ;; What counts as having LOOKED: a read, or a write of your own —
+        ;; either way this branch has seen the file at that turn.
+        seen-tools (into ["read_file"] tools)
+        reads (db/fetch conn (into [(placeholders
+                                     "SELECT turn, args FROM turns
+                                       WHERE run_id = ? AND branch_id = ?
+                                         AND tool_name IN (@tools)
+                                       ORDER BY turn DESC, id DESC"
+                                     (count seen-tools))
+                                    run-id (str branch-id)]
+                                   seen-tools))
         last-seen (some (fn [r] (when (= path (path-of r)) (:turn r))) reads)]
     (when last-seen
-      (->> (db/fetch conn ["SELECT branch_id, turn, tool_name, args FROM turns
-                          WHERE run_id = ? AND branch_id <> ? AND turn >= ?
-                            AND tool_name IN ('write_file', 'edit_file')
-                            AND category = 'success'
-                          ORDER BY turn DESC, id DESC"
-                        run-id (str branch-id) (long last-seen)])
+      (->> (db/fetch conn (into [(placeholders
+                                  "SELECT branch_id, turn, tool_name, args FROM turns
+                                    WHERE run_id = ? AND branch_id <> ? AND turn >= ?
+                                      AND tool_name IN (@tools)
+                                      AND category = 'success'
+                                    ORDER BY turn DESC, id DESC"
+                                  (count tools))
+                                 run-id (str branch-id) (long last-seen)]
+                                tools))
            (keep (fn [r] (when (= path (path-of r))
                            {:branch (:branch_id r) :turn (:turn r)
                             :tool (:tool_name r)})))

--- a/src/samizdat/system.clj
+++ b/src/samizdat/system.clj
@@ -46,6 +46,7 @@
             [samizdat.manifests :as manifests]
             [mycelium.core :as myc]
             [samizdat.session :as session]
+            [samizdat.steps :as steps]
             [samizdat.lsp.client :as lsp-client]
             [samizdat.store.db :as db]
             [samizdat.store.runs :as runs]
@@ -196,6 +197,10 @@
             (fn [body]
               (:body (myc/run-compiled (manifests/compiled-manifest "repair")
                                        {} {:body body}))))
+         ;; The manifest-state trace, buffered where an HTTP client can read
+         ;; it. Started before the server, so a client that connects on the
+         ;; first request is not polling a ring nothing is filling yet.
+         _ (steps/start-pump!)
          server (adapter/run-server handler {:port (get-in cfg [:http :port])})]
      (reset! system {:config cfg :conn c :server server})
      (log/info "samizdat up on port" (get-in cfg [:http :port])
@@ -235,6 +240,9 @@
                                  (log/warn "run" rid "did not stop within 15s;"
                                            "closing the system under it")))))]
                        ["http server" #(adapter/stop-server (:server s))]
+                       ;; After the server, so a request in flight can still
+                       ;; read the trace it was serving; the rings go with it.
+                       ["step pump" #(do (steps/stop-pump!) (steps/reset!))]
                        ;; Uninstall so a bare REPL after stop! parses with the
                        ;; built-in chain instead of resolving manifests against
                        ;; an unbound store.

--- a/test-tui/samizdat/tui/mouse_test.clj
+++ b/test-tui/samizdat/tui/mouse_test.clj
@@ -1,0 +1,119 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.mouse-test
+  "The half the main suite cannot see: what the TOOLKIT does with the hiccup.
+
+  Everywhere else the TUI is tested as data — a widget returns a
+  `:collapsible` with an `:on-change`, and that is checked without ftxui.
+  What that cannot tell you is whether a CLICK reaches it. `[:collapsible]`
+  producing the right map is not the same claim as a person being able to
+  open a diff with the mouse, and the second one is the requirement.
+
+  So these drive real FTXUI components headlessly: mount the tree, render a
+  frame, find the row the header landed on, send a real mouse press at those
+  coordinates, and check the fold opened. No terminal needed — but the
+  compiled shim is, which is why this is its own alias."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [ftxui.core :as ui]
+            [samizdat.tui.state :as st]
+            [samizdat.tui.widgets :as w]))
+
+(def ^:private turns
+  [{:turn 1 :tool_name "read_file" :args "{\"path\":\"src/a.clj\"}"
+    :result "(ns a)\n(defn go [])" :category "neutral"}])
+
+(defn- row-of
+  "The 0-based row `needle` appears on in a rendered frame, or nil. How a
+  test finds where to click without hard-coding a layout that will move."
+  [text needle]
+  (first (keep-indexed (fn [i line] (when (str/includes? line needle) i))
+                       (str/split-lines text))))
+
+(deftest clicking-a-fold-header-opens-it
+  ;; The requirement, end to end through FTXUI's own hit testing: a person
+  ;; with a mouse can open a tool result. Nothing here simulates the widget
+  ;; contract — the click goes in as coordinates and the fold opens or it
+  ;; does not.
+  (let [state (atom (assoc (st/initial "b") :branch {:turns turns}))
+        app (fn []
+              (w/conversation
+               (assoc @state :on {:toggle #(swap! state st/toggle-fold %)})
+               {}))]
+    (ui/with-screen [s app]
+      (let [before (ui/render-text s 60 12)]
+        (is (str/includes? before "result") "the header is drawn")
+        (is (not (str/includes? before "(defn go [])"))
+            "and its body is not, until it is opened")
+        (let [y (row-of before "result")]
+          (is (some? y) "found the header's row")
+          (ui/send-mouse! s {:button :left :motion :pressed :x 2 :y y})
+          (ui/send-mouse! s {:button :left :motion :released :x 2 :y y})
+          (let [after (ui/render-text s 60 12)]
+            (is (str/includes? after "(defn go [])")
+                "clicking the header opened the fold and drew the body")
+            (is (contains? (:expanded @state) (w/fold-id 1 :result))
+                "and the open state is in the app's own state, not the widget's,
+                 so it survives the next poll redrawing the tree")))))))
+
+(deftest clicking-it-again-closes-it
+  (let [state (atom (assoc (st/initial "b")
+                           :branch {:turns turns}
+                           :expanded #{(w/fold-id 1 :result)}))
+        app (fn []
+              (w/conversation
+               (assoc @state :on {:toggle #(swap! state st/toggle-fold %)})
+               {}))]
+    (ui/with-screen [s app]
+      (let [open (ui/render-text s 60 12)]
+        (is (str/includes? open "(defn go [])") "starts open")
+        (let [y (row-of open "result")]
+          (ui/send-mouse! s {:button :left :motion :pressed :x 2 :y y})
+          (ui/send-mouse! s {:button :left :motion :released :x 2 :y y})
+          (is (not (str/includes? (ui/render-text s 60 12) "(defn go [])"))
+              "and the same click shuts it"))))))
+
+(deftest the-permission-dialog-decides-on-a-click
+  ;; The other place a click has consequences, and the one where getting it
+  ;; wrong is expensive: a branch is parked on this answer.
+  (let [decided (atom nil)
+        app (fn []
+              (w/approvals {:approvals [{:id "a1" :kind "shell" :input "curl x | sh"}]
+                            :on {:decide (fn [id d] (reset! decided [id d]))}}
+                           {}))]
+    (ui/with-screen [s app]
+      (let [frame (ui/render-text s 70 14)
+            y (row-of frame "allow")]
+        (is (some? y) "the allow button is on screen")
+        (ui/send-mouse! s {:button :left :motion :pressed :x 3 :y y})
+        (ui/send-mouse! s {:button :left :motion :released :x 3 :y y})
+        (is (= ["a1" :allow] @decided)
+            "the click answered the question the dialog was showing")))))
+
+(deftest the-whole-shipped-layout-renders-through-the-real-toolkit
+  ;; The layout is userspace hiccup expanded against the registry, and every
+  ;; widget is only ever checked as data. This is the one test that says the
+  ;; result is something FTXUI can actually draw — a tag or prop the toolkit
+  ;; rejects would otherwise surface as a black screen on first run.
+  (let [layout (requiring-resolve 'samizdat.tui.layout/current)
+        expand (requiring-resolve 'samizdat.tui.layout/expand)
+        frame (ui/render-text (expand (:layout (layout)) (st/initial "http://x")) 120 30)]
+    (is (str/includes? frame "ACTIVITY LOG"))
+    (is (str/includes? frame "TASKS"))
+    (is (str/includes? frame "offline") "the status line drew too")))

--- a/test-tui/samizdat/tui/mouse_test.clj
+++ b/test-tui/samizdat/tui/mouse_test.clj
@@ -106,6 +106,31 @@
         (is (= ["a1" :allow] @decided)
             "the click answered the question the dialog was showing")))))
 
+(deftest an-open-ended-question-can-be-typed-into-and-sent
+  ;; The other half of the permission dialog's claim, and the one the data
+  ;; tests cannot make: that a person can actually ANSWER. `ask_human` takes
+  ;; a bare string, which has no options, and an empty menu is not a thing
+  ;; anybody can click — the branch sat parked for the whole deadline. So
+  ;; the keys go in as keys and the answer comes out or it does not.
+  (let [answered (atom nil)
+        q {:id "q9" :kind "question"
+           :questions [{:question "what should I name the module?" :options []}]}
+        app (fn [] (w/approvals {:approvals [q]
+                                 :on {:answer (fn [& xs] (reset! answered (vec xs)))}}
+                                {}))]
+    (ui/with-screen [s app]
+      (let [frame (ui/render-text s 70 12)]
+        (is (str/includes? frame "what should I name the module?"))
+        ;; Focus the editor, type, send.
+        (let [y (row-of frame "type an answer")]
+          (is (some? y) "the text box is on screen with its prompt")
+          (ui/send-mouse! s {:button :left :motion :pressed :x 3 :y y})
+          (ui/send-mouse! s {:button :left :motion :released :x 3 :y y}))
+        (ui/send-char! s "mycelium")
+        (ui/send-key! s :return)
+        (is (= ["q9" 0 ["mycelium"]] @answered)
+            "what was typed reached the handler that unparks the branch")))))
+
 (deftest the-whole-shipped-layout-renders-through-the-real-toolkit
   ;; The layout is userspace hiccup expanded against the registry, and every
   ;; widget is only ever checked as data. This is the one test that says the

--- a/test-tui/samizdat/tui/test_runner.clj
+++ b/test-tui/samizdat/tui/test_runner.clj
@@ -1,0 +1,36 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.test-runner
+  "`jolt tui-test` — the TUI's toolkit-bound tests.
+
+  Separate from `samizdat.test-runner` because these load ftxui, which needs
+  a compiled C++ shim. The main suite stays buildable with nothing but jolt;
+  everything about the TUI that can be checked as data is over there."
+  (:require [clojure.test :as t]
+            [samizdat.tui.mouse-test]))
+
+(def namespaces '[samizdat.tui.mouse-test])
+
+(defn run []
+  (apply t/run-tests namespaces))
+
+(defn -main [& _]
+  (let [{:keys [fail error]} (run)]
+    (println "----")
+    (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0))))

--- a/test/samizdat/approval_test.clj
+++ b/test/samizdat/approval_test.clj
@@ -1,0 +1,263 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.approval-test
+  "Asking a person, and not waiting forever.
+
+  samizdat runs unattended by design: the shell policy's `:ask` refuses the
+  call and teaches the model to retry, and a human adds a grant afterwards.
+  A blocking gate is the opposite bet, and the whole risk of it is a campaign
+  run that hangs at 3am because nobody was watching.
+
+  So the contract these tests hold is not `a human can approve` — that is the
+  easy half. It is that EVERY WAIT ENDS: bounded by a deadline from
+  gates.edn, resolved to a stated default when it expires, and abandoned
+  wholesale when the run does. A gate that can hang is a worse harness than
+  no gate."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is use-fixtures]]
+            [samizdat.approval :as approval]
+            [samizdat.agent.tools :as tools]
+            [samizdat.security.policy :as policy]))
+
+(use-fixtures :each (fn [f] (approval/reset!) (f) (approval/reset!)))
+
+(defn- req [& {:as over}]
+  (merge {:run-id "r1" :branch-id "B1" :kind :shell
+          :input "rm -rf build" :reason "compound command"}
+         over))
+
+(deftest a-request-is-pending-until-it-is-decided
+  (let [id (approval/request! (req))]
+    (is (string? id))
+    (let [[p] (approval/pending "r1")]
+      (is (= id (:id p)))
+      (is (= "rm -rf build" (:input p)))
+      (is (= "pending" (:status p))))
+    (approval/decide! id {:decision :allow})
+    (is (empty? (approval/pending "r1")) "and gone from the queue once answered")))
+
+(deftest awaiting-returns-the-decision-a-person-made
+  (let [id (approval/request! (req))]
+    (future (Thread/sleep 20) (approval/decide! id {:decision :allow :note "fine"}))
+    (let [d (approval/await! id 3000 {:decision :deny})]
+      (is (= :allow (:decision d)))
+      (is (= "fine" (:note d))))))
+
+(deftest a-wait-that-nobody-answers-ends-at-the-deadline
+  ;; The property the whole design turns on. An unattended campaign run must
+  ;; come out of this, not sit in it.
+  (let [id (approval/request! (req))
+        started (System/currentTimeMillis)
+        d (approval/await! id 120 {:decision :deny :note "nobody answered"})]
+    (is (= :deny (:decision d)))
+    (is (= "nobody answered" (:note d)))
+    (is (< (- (System/currentTimeMillis) started) 3000)
+        "it returned at the deadline rather than blocking")
+    (testing "and the request is retired, not left pending forever"
+      (is (empty? (approval/pending "r1"))))))
+
+(deftest an-answer-that-lands-before-the-wait-is-still-the-answer
+  ;; The race that made the first cut of this wrong. `request!` publishes the
+  ;; question and `await!` parks on it, and a person watching a TUI can
+  ;; answer in between. Removing the entry on decide! delivered the promise
+  ;; to something nobody could find any more, and the branch was DENIED a
+  ;; command a human had just allowed — the worst direction for that bug.
+  (let [id (approval/request! (req))]
+    (approval/decide! id {:decision :allow :note "go ahead"})
+    (let [d (approval/await! id 500 {:decision :deny})]
+      (is (= :allow (:decision d)))
+      (is (not (:timed-out d))))))
+
+(deftest deciding-twice-does-not-change-the-answer
+  ;; Two operators with two TUIs open. The first answer is the answer; the
+  ;; second must not race the branch that already resumed on the first.
+  (let [id (approval/request! (req))]
+    (is (true? (approval/decide! id {:decision :allow})))
+    (is (false? (approval/decide! id {:decision :deny}))
+        "the second is refused rather than silently overwriting")
+    (is (= :allow (:decision (approval/await! id 500 {:decision :deny}))))))
+
+(deftest deciding-something-nobody-asked-is-refused
+  (is (false? (approval/decide! "no-such-id" {:decision :allow}))))
+
+(deftest requests-are-scoped-to-their-run
+  (approval/request! (req))
+  (approval/request! (req :run-id "r2"))
+  (is (= 1 (count (approval/pending "r1"))))
+  (is (= 1 (count (approval/pending "r2"))))
+  (is (= 2 (count (approval/pending nil))) "nil asks for all of them"))
+
+(deftest abandoning-a-run-releases-every-waiter-it-had
+  ;; A run that is aborted or crashes must not leave a thread parked on a
+  ;; question nobody will ever answer.
+  (let [id (approval/request! (req))
+        answer (future (approval/await! id 60000 {:decision :deny}))]
+    (Thread/sleep 20)
+    (approval/abandon! "r1")
+    (is (= :deny (:decision (deref answer 3000 {:decision :hung})))
+        "the waiter came back with the default rather than hanging")
+    (is (empty? (approval/pending "r1")))))
+
+(deftest a-questionnaire-carries-its-questions-and-comes-back-with-answers
+  ;; The other shape of the same machinery: `ask_human` needs structured
+  ;; questions out and structured answers back, not a yes/no.
+  (let [id (approval/request! (req :kind :question
+                                   :questions [{:question "which backend?"
+                                                :options ["sqlite" "postgres"]}]))]
+    (is (= [{:question "which backend?" :options ["sqlite" "postgres"]}]
+           (:questions (first (approval/pending "r1")))))
+    (approval/decide! id {:decision :answer :answers ["sqlite"]})
+    (is (= ["sqlite"] (:answers (approval/await! id 500 {:decision :deny}))))))
+
+;; --- the policy seam ---------------------------------------------------------
+
+(deftest an-ask-is-a-refusal-unless-the-project-asked-for-a-person
+  ;; The default stays what samizdat has always done: refuse and teach. A
+  ;; harness that started blocking because a feature landed would hang every
+  ;; unattended run on upgrade.
+  (let [ask {:effect :ask :input "x"}]
+    (with-redefs [approval/policy (constantly {:mode :refuse :wait-ms 1000
+                                               :on-timeout :deny})]
+      (is (= ask (approval/resolve-ask {:run-id "r1"} ask))
+          "the decision comes back untouched, and nothing was queued")
+      (is (empty? (approval/pending "r1")))))
+  (testing "and anything that is not an ask passes straight through"
+    (let [allow {:effect :allow :input "x"}]
+      (with-redefs [approval/policy (constantly {:mode :block :wait-ms 1000
+                                                 :on-timeout :deny})]
+        (is (= allow (approval/resolve-ask {:run-id "r1"} allow)))
+        (is (empty? (approval/pending "r1")))))))
+
+(deftest in-blocking-mode-an-allow-from-a-person-becomes-an-allow
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 3000
+                                             :on-timeout :deny})]
+    (let [asked (promise)
+          answer (future (approval/resolve-ask {:run-id "r1"} {:effect :ask :input "ls"}))]
+      ;; Wait for the request to appear, then answer it the way a TUI would.
+      (future (loop [] (if-let [p (first (approval/pending "r1"))]
+                         (deliver asked (approval/decide! (:id p) {:decision :allow}))
+                         (do (Thread/sleep 5) (recur)))))
+      (is (= :allow (:effect (deref answer 5000 {:effect :hung})))))))
+
+(deftest in-blocking-mode-nobody-answering-falls-back-to-the-stated-default
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 80
+                                             :on-timeout :deny})]
+    (let [r (approval/resolve-ask {:run-id "r1"} {:effect :ask :input "ls"})]
+      (is (= :ask (:effect r))
+          "an expired wait leaves the ask as the refusal it always was")
+      (is (:timed-out r) "and says that is why, so the refusal can mention it")))
+  (testing "a project that would rather proceed unattended can say so"
+    (with-redefs [approval/policy (constantly {:mode :block :wait-ms 80
+                                               :on-timeout :allow})]
+      (is (= :allow (:effect (approval/resolve-ask {:run-id "r1"}
+                                                   {:effect :ask :input "ls"})))))))
+
+;; --- ask_human ---------------------------------------------------------------
+
+(defn- ask [args]
+  (tools/run-tool {:tool-name "ask_human" :args args
+                   :branch {:id "B1"} :run-id "r1" :branch-id "B1"}))
+
+(deftest ask-human-is-refused-when-nobody-is-there-to-ask
+  ;; The default. A tool that parked an unattended run on a question would be
+  ;; a way for the model to stop a campaign dead, so it has to be opt-in the
+  ;; same way the permission gate is.
+  (with-redefs [approval/policy (constantly {:mode :refuse :wait-ms 1000
+                                             :on-timeout :deny})]
+    (let [r (ask {:questions [{:question "which?" :options ["a" "b"]}]})]
+      (is (= :mechanics (:category r)))
+      (is (str/includes? (str/lower-case (:result r)) "no human"))
+      (is (empty? (approval/pending "r1"))))))
+
+(deftest ask-human-carries-the-questions-and-returns-the-answers
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 5000
+                                             :on-timeout :deny})]
+    (let [result (future (ask {:questions [{:question "which backend?"
+                                            :options ["sqlite" "postgres"]}]}))]
+      (future (loop [] (if-let [p (first (approval/pending "r1"))]
+                         (approval/decide! (:id p) {:decision :answer
+                                                    :answers ["postgres"]})
+                         (do (Thread/sleep 5) (recur)))))
+      (let [r (deref result 8000 ::hung)]
+        (is (not= ::hung r))
+        (is (str/includes? (:result r) "postgres"))
+        (is (= :neutral (:category r))
+            "asking establishes nothing — it must not read as progress")))))
+
+(deftest ask-human-that-nobody-answers-comes-back-and-says-so
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 60
+                                             :on-timeout :deny})]
+    (let [r (deref (future (ask {:questions [{:question "which?"}]})) 5000 ::hung)]
+      (is (not= ::hung r) "the tool returned rather than parking the run")
+      (is (str/includes? (str/lower-case (:result r)) "nobody")))))
+
+(deftest ask-human-needs-questions
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 1000
+                                             :on-timeout :deny})]
+    (is (= :mechanics (:category (ask {}))))))
+
+;; --- the shell path, end to end ---------------------------------------------
+
+(defn- shell [cmd]
+  (policy/run-shell {:args {:command cmd} :run-id "r1" :branch-id "B1" :env {}}))
+
+(deftest by-default-an-unapproved-command-is-refused-exactly-as-before
+  ;; The regression that would matter most: a release must not turn an
+  ;; unattended harness into one that parks on the first unusual command.
+  (let [r (shell "frobnicate --widgets")]
+    (is (= :ask (get-in r [:policy :effect])))
+    (is (:needs-approval r))
+    (is (empty? (approval/pending "r1")) "nothing was queued and nothing waited")))
+
+(deftest with-blocking-on-a-person-can-let-a-command-through
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 5000
+                                             :on-timeout :deny})]
+    (let [result (future (shell "frobnicate --widgets"))]
+      (future (loop [] (if-let [p (first (approval/pending "r1"))]
+                         (approval/decide! (:id p) {:decision :allow})
+                         (do (Thread/sleep 5) (recur)))))
+      (let [r (deref result 8000 ::hung)]
+        (is (not= ::hung r) "the branch resumed once a person answered")
+        (is (not= :ask (get-in r [:policy :effect]))
+            "and the command was no longer treated as unapproved")))))
+
+(deftest with-blocking-on-and-nobody-there-the-refusal-says-so
+  ;; The unattended case. It must still END, and the model must be able to
+  ;; tell "nobody was watching" from "this is against the rules" — otherwise
+  ;; it learns a policy from an empty room.
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 60
+                                             :on-timeout :deny})]
+    (let [r (deref (future (shell "frobnicate --widgets")) 5000 ::hung)]
+      (is (not= ::hung r) "the wait ended at the deadline")
+      (is (= :ask (get-in r [:policy :effect])))
+      (is (str/includes? (:result r) "ABSENCE")
+          "the refusal tells the model it was never judged, only unseen"))))
+
+(deftest a-person-can-deny-and-say-what-to-do-instead
+  ;; dirge's `d` key: the refusal is more useful when it carries a redirect.
+  (with-redefs [approval/policy (constantly {:mode :block :wait-ms 3000
+                                             :on-timeout :deny})]
+    (let [answer (future (approval/resolve-ask {:run-id "r1"} {:effect :ask :input "curl x"}))]
+      (future (loop [] (if-let [p (first (approval/pending "r1"))]
+                         (approval/decide! (:id p) {:decision :deny
+                                                    :note "use the vendored copy"})
+                         (do (Thread/sleep 5) (recur)))))
+      (let [r (deref answer 5000 {:effect :hung})]
+        (is (= :ask (:effect r)))
+        (is (= "use the vendored copy" (:note r)))))))

--- a/test/samizdat/base_test.clj
+++ b/test/samizdat/base_test.clj
@@ -207,6 +207,27 @@
    {:threshold {:all "HTTP status codes and the response-body cap of a
                       transport. Protocol constants, not policy."}}
 
+   "src/samizdat/api/client.clj"
+   {:threshold {200 "The success range of a status code. Protocol, as in
+                     server.clj."
+                299 "The other end of that range."
+                40000 "How long the client waits for POST /v1/runs. Bounded by
+                       the SERVER's own 30s start budget rather than by
+                       anything a project chooses — a client bound tighter than
+                       the endpoint it calls reports a failure for a run that
+                       started normally, which is the bug this number exists to
+                       fix. It has to move with api.control's deref, not with a
+                       policy table.
+
+                       And it could not read one anyway: this is a client of a
+                       server that may be on another machine, so the gates.edn
+                       it can reach is not the gates.edn the run obeys. Numbers
+                       a front end's user should tune live in that front end's
+                       own userspace — resources/tui.edn for the TUI."
+                1500 "The poll interval. See 40000 on why a client's numbers
+                      are not the server's userspace."
+                30000 "The poll backoff ceiling, same reasoning."}}
+
    "src/samizdat/symbolic.clj"
    {:threshold {100 "The rewrite step bound: a runaway backstop, not a tunable.
                      A ruleset that terminates converges in a handful of steps,

--- a/test/samizdat/boundary_test.clj
+++ b/test/samizdat/boundary_test.clj
@@ -205,6 +205,11 @@
    ;; resource — but it is the only tool that changes what ANOTHER branch will
    ;; do, which is why the implementor role is denied it (roles.edn :denied).
    "intervene"   {:reach :harness-only}
+   ;; Reaches nothing on the host: it puts a question on an in-memory queue
+   ;; and parks until a person answers or the gates.edn deadline expires. The
+   ;; text it returns is what an OPERATOR typed, which is the one input on
+   ;; this graph that never came off the machine.
+   "ask_human"   {:reach :harness-only}
    "experiment"  {:reach :harness-only}
    "verdict"     {:reach :harness-only}
    "fetch_turn"  {:reach :harness-only}

--- a/test/samizdat/collab_test.clj
+++ b/test/samizdat/collab_test.clj
@@ -60,6 +60,26 @@
         (turn! solo srid "B1" 1 "write_file" "src/core.clj")
         (is (empty? (journal/sibling-writes solo srid "B1" 8)))))))
 
+(deftest a-sibling-that-patched-a-file-is-reported-like-any-other-writer
+  ;; `patch` is a file-writing tool — it is in gates.edn's :file-write
+  ;; vocabulary beside write_file and edit_file — but sibling-writes named
+  ;; only the other two, so anchored edits were invisible to the one
+  ;; mechanism that tells workers they share a tree. Two workers in one file,
+  ;; one of them patching, and neither was told.
+  ;;
+  ;; The vocabulary is userspace and tunable, so the query reads it rather
+  ;; than restating it: a project that adds a writing tool gets this for free,
+  ;; which is the failure mode that produced the gap in the first place.
+  (let [conn (db/open! ":memory:")
+        rid (runs/start-run! conn {:problem "anchored"})]
+    (turn! conn rid "W1" 1 "read_file" "src/core.clj" :neutral)
+    (turn! conn rid "W2" 2 "patch" "src/core.clj")
+    (let [seen (journal/sibling-writes conn rid "W1" 8)]
+      (is (= ["src/core.clj"] (mapv :path seen)))
+      (is (= ["W2"] (:branches (first seen)))))
+    (testing "and the staleness notice sees it too"
+      (is (= "W2" (:branch (journal/changed-since-read conn rid "W1" "src/core.clj")))))))
+
 (deftest writing-a-file-a-sibling-changed-under-you-says-so
   (let [[conn rid] (fixture)
         ctx {:conn conn :run-id rid :branch {:id "W1"} :args {:path "src/core.clj"}}]

--- a/test/samizdat/server_test.clj
+++ b/test/samizdat/server_test.clj
@@ -19,12 +19,15 @@
 (ns samizdat.server-test
   "The vendored ring adapter's request reader, and the listen socket's
   close-on-exec."
-  (:require [clojure.string :as str]
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
             [clojure.test :refer [deftest testing is]]
             [jolt.process :as p]
             [ring-chez.adapter :as adapter]
             [samizdat.api.control :as control]
-            [samizdat.server :as server]))
+            [samizdat.server :as server]
+            [samizdat.store.db :as db]
+            [samizdat.userspace :as userspace]))
 
 (defn- request [body]
   (str "POST /v1/runs HTTP/1.1\r\n"
@@ -46,6 +49,33 @@
         (is (= 250 (@clamp 250)) "an in-range value passes through")
         (is (= 10000 (@clamp 999999999)) "the ceiling holds")
         (is (= 0 (@clamp -5)) "a negative asks to sleep nothing")))))
+
+(deftest the-harness-serves-the-layout-the-agent-saved
+  ;; The seam that makes "the agent can rearrange its own UI" true. Only the
+  ;; server is BOUND to the project, so only the server can read the stored
+  ;; `tui` policy; the TUI holds no database handle by design and asks. Before
+  ;; this endpoint existed, a saved version was written and nothing ever drew
+  ;; it — the front end's own userspace read could only reach the shipped
+  ;; template, and then cached that for the life of the process.
+  (let [tmp (str (java.io.File/createTempFile "layout" ".sqlite3"))
+        conn (db/open! tmp)
+        prev (userspace/bind! conn)]
+    (try
+      (testing "with nothing saved it is the shipped template, seeded"
+        (let [body (:layout (server/layout-body))]
+          (is (string? body))
+          (is (= (:layout (edn/read-string body))
+                 (:layout (edn/read-string (userspace/template :policy "tui"))))
+              "which is what a fresh project draws")))
+      (testing "and after the agent saves one, it is the agent's"
+        (userspace/save! :policy "tui"
+                         (pr-str {:prose-turns 3 :layout [:vbox [:widget/status {}]]}))
+        (let [spec (edn/read-string (:layout (server/layout-body)))]
+          (is (= [:vbox [:widget/status {}]] (:layout spec)))
+          (is (= 3 (:prose-turns spec)))))
+      (finally
+        (userspace/bind! prev)
+        (db/close conn)))))
 
 (deftest content-length-is-octets-not-characters
   ;; A 3-byte em-dash decodes to one char. Judging completeness by char count

--- a/test/samizdat/steps_test.clj
+++ b/test/samizdat/steps_test.clj
@@ -1,0 +1,188 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.steps-test
+  "The per-run step ring: the manifest-state trace, made readable over HTTP.
+
+  Steps are the implementer walking its state graph — :start, :measure,
+  :infer, :parse, :dispatch — published on the bus by samizdat.events and,
+  until this existed, held by nobody. The GUI and the TUI are both HTTP
+  clients with no bus to subscribe to, so the trace was invisible to the
+  only things that wanted to draw it.
+
+  This is deliberately NOT the journal. A step is worth a frame of a live
+  UI and nothing after that, so it is held in memory, bounded, and dropped
+  with the run — the durable record of what a turn DID is the turns table,
+  which is a different question and already answered."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [samizdat.api.runs :as api-runs]
+            [samizdat.events :as events]
+            [samizdat.steps :as steps]))
+
+(use-fixtures :each (fn [f] (steps/reset!) (f) (steps/reset!)))
+
+(defn- step [run-id node]
+  {:kind :step :run-id run-id :branch-id "b1" :turn 1 :node node
+   :cell :loop/assemble :transition :ok :ms 3})
+
+(deftest a-cursor-tail-returns-only-what-is-new
+  (steps/record! (step "r1" :start))
+  (steps/record! (step "r1" :measure))
+  (let [{:keys [steps cursor]} (steps/since "r1" 0 100)]
+    (is (= [:start :measure] (mapv :node steps))
+        "everything, from a zero cursor")
+    (is (= 2 cursor) "the cursor is the last sequence number handed out")
+    (testing "the same cursor again is empty, not a repeat"
+      (is (= [] (:steps (steps/since "r1" cursor 100)))))
+    (testing "and a step recorded after it arrives on the next poll"
+      (steps/record! (step "r1" :infer))
+      (let [nxt (steps/since "r1" cursor 100)]
+        (is (= [:infer] (mapv :node (:steps nxt))))
+        (is (= 3 (:cursor nxt)))))))
+
+(deftest each-run-has-its-own-ring
+  ;; A shared ring would fold a beam's branches into one another's traces —
+  ;; every run on the server is publishing to the same bus.
+  (steps/record! (step "r1" :start))
+  (steps/record! (step "r2" :infer))
+  (is (= [:start] (mapv :node (:steps (steps/since "r1" 0 100)))))
+  (is (= [:infer] (mapv :node (:steps (steps/since "r2" 0 100)))))
+  (testing "a run nothing was recorded for is empty, not an error"
+    (is (= {:steps [] :cursor 0 :dropped 0} (steps/since "r3" 0 100)))))
+
+(deftest the-ring-drops-the-oldest-and-says-so
+  ;; The contract the bus already keeps: a slow watcher loses the oldest
+  ;; rather than applying backpressure. What it must not do is lose them
+  ;; SILENTLY — a UI that missed steps should be able to say so instead of
+  ;; drawing a trace with a hole in it.
+  (let [cap (steps/capacity)]
+    (dotimes [i (+ cap 5)]
+      (steps/record! (step "r1" (keyword (str "n" i)))))
+    (let [{:keys [steps dropped cursor]} (steps/since "r1" 0 (* 2 cap))]
+      (is (= cap (count steps)) "never more than the cap is retained")
+      (is (= (+ cap 5) cursor) "the cursor still counts everything recorded")
+      (is (= 5 dropped) "and the tail reports what fell off before it")
+      (is (= (keyword (str "n" 5)) (:node (first steps)))
+          "the oldest survivor is the first one not evicted"))))
+
+(deftest a-limit-bounds-one-response-without-losing-the-rest
+  (dotimes [i 10] (steps/record! (step "r1" (keyword (str "n" i)))))
+  (let [{:keys [steps cursor]} (steps/since "r1" 0 4)]
+    (is (= 4 (count steps)))
+    (is (= 4 cursor) "the cursor advances only over what was actually handed over")
+    (is (= [:n4 :n5 :n6 :n7] (mapv :node (:steps (steps/since "r1" cursor 4))))
+        "so the next poll continues where this one stopped")))
+
+(deftest forgetting-a-run-frees-its-ring
+  (steps/record! (step "r1" :start))
+  (steps/forget! "r1")
+  (is (= [] (:steps (steps/since "r1" 0 100)))))
+
+(deftest the-registry-itself-is-bounded
+  ;; forget! is called when a run ends, and a process that never sees a run
+  ;; end must still not grow without bound. The oldest run's ring is the one
+  ;; that goes.
+  (let [n (steps/max-runs)]
+    (dotimes [i (+ n 3)]
+      (steps/record! (step (str "run" i) :start)))
+    (is (= n (steps/run-count)))
+    (is (= [] (:steps (steps/since "run0" 0 100)))
+        "the first run seen is the first evicted")
+    (is (= [:start] (mapv :node (:steps (steps/since (str "run" (+ n 2)) 0 100))))
+        "the newest is still there")))
+
+(deftest only-step-events-are-recorded
+  ;; The subscription is to the whole bus, which carries every journal append
+  ;; too. A ring that took those would evict the trace it exists to hold.
+  (steps/record! {:kind :turn :run-id "r1" :data {:tool "bash"}})
+  (steps/record! (step "r1" :start))
+  (is (= [:start] (mapv :node (:steps (steps/since "r1" 0 100))))))
+
+(deftest a-step-with-no-run-id-is-dropped-rather-than-filed-under-nil
+  ;; events/tracer derefs a promise for the run id, and the turn manifest is
+  ;; compiled BEFORE the run row exists — so a step really can arrive with no
+  ;; run behind it. Filing those under nil would make one ring that every
+  ;; client polling a real run misses anyway.
+  (steps/record! (step nil :start))
+  (is (zero? (steps/run-count))))
+
+(deftest the-tail-endpoint-answers-in-the-shape-a-poller-already-speaks
+  ;; Same contract as journal-tail: `next` is what the client sends back, so
+  ;; the TUI runs one poll loop over two feeds rather than two designs.
+  (steps/record! (step "r1" :start))
+  (steps/record! (step "r1" :infer))
+  (let [r (api-runs/steps-tail "r1" 0 200)]
+    (is (= "r1" (:run_id r)))
+    (is (= ["start" "infer"] (mapv :node (:steps r)))
+        "node and cell are keywords in the ring and strings on the wire — a
+         JSON client cannot read a keyword back")
+    (is (= ["loop/assemble" "loop/assemble"] (mapv :cell (:steps r)))
+        "the cell is its printed name, with no leading colon — str on a
+         keyword keeps the colon, and a panel would draw \":loop/assemble\"")
+    (is (= 2 (:next r)))
+    (is (= 2 (:count r)))
+    (is (zero? (:dropped r))))
+  (testing "a run with no ring is an empty tail, not a 404 — a client may
+            legitimately poll a run that has not stepped yet"
+    (is (= {:run_id "nope" :steps [] :next 0 :count 0 :dropped 0}
+           (api-runs/steps-tail "nope" 0 200)))))
+
+(deftest the-bus-subscription-feeds-the-ring
+  ;; The seam that matters: publishing a step anywhere in the process must
+  ;; reach the ring, or the endpoint serves an empty trace on a live run.
+  (let [sub (steps/subscribe!)]
+    (try
+      (events/publish! (step "r1" :dispatch))
+      (steps/drain! sub)
+      (is (= [:dispatch] (mapv :node (:steps (steps/since "r1" 0 100)))))
+      (finally (steps/unsubscribe! sub)))))
+
+(defn- eventually
+  "Wait up to `ms` for `pred`, polling. A fixed sleep would either be flaky
+  on a loaded machine or slow on an idle one; this is neither."
+  [ms pred]
+  (let [deadline (+ (System/currentTimeMillis) ms)]
+    (loop []
+      (cond (pred) true
+            (> (System/currentTimeMillis) deadline) false
+            :else (do (Thread/sleep 10) (recur))))))
+
+(deftest the-pump-carries-a-published-step-to-the-ring-on-its-own
+  ;; What start! wires. Without it the ring is a buffer nothing fills, and
+  ;; the endpoint answers an empty trace on a run that is stepping.
+  (try
+    (steps/start-pump!)
+    (events/publish! (step "r1" :arbiter))
+    (is (eventually 3000 #(seq (:steps (steps/since "r1" 0 100))))
+        "the pump drains the bus without anyone asking it to")
+    (is (= [:arbiter] (mapv :node (:steps (steps/since "r1" 0 100)))))
+    (finally (steps/stop-pump!))))
+
+(deftest starting-the-pump-twice-runs-one-pump
+  ;; start! can be called after a restart! that failed halfway, and two pumps
+  ;; on one bus means each drains half the events into the same rings — a
+  ;; trace with gaps that only appears under a restart.
+  (try
+    (steps/start-pump!)
+    (steps/start-pump!)
+    (is (steps/pumping?))
+    (finally (steps/stop-pump!)))
+  (is (not (steps/pumping?)) "and stopping once stops it")
+  (testing "stopping a pump that is not running is a no-op, not a throw —
+            stop! runs best-effort over every resource"
+    (is (nil? (steps/stop-pump!)))))

--- a/test/samizdat/test_runner.clj
+++ b/test/samizdat/test_runner.clj
@@ -65,6 +65,7 @@
             [mycelium.validation-test]
             [mycelium.workflow-test]
             [samizdat.agent-test]
+            [samizdat.approval-test]
             [samizdat.base-test]
             [samizdat.boundary-test]
             [samizdat.compaction-test]
@@ -155,10 +156,15 @@
             [samizdat.mechanics-test]
             [samizdat.repair-test]
             [samizdat.split-test]
+            [samizdat.steps-test]
             [samizdat.storm-test]
             [samizdat.stubs-test]
             [samizdat.tournament-test]
             [samizdat.trajectory-test]
+            [samizdat.tui-layout-test]
+            [samizdat.tui-readmodel-test]
+            [samizdat.tui-state-test]
+            [samizdat.tui-widgets-test]
             [samizdat.store-test]
             [samizdat.gui-api-test]
             [samizdat.gui-ops-test]
@@ -218,13 +224,19 @@
     samizdat.mechanics-test
     samizdat.repair-test
     samizdat.split-test
+    samizdat.steps-test
     samizdat.storm-test
     samizdat.stubs-test
     samizdat.tournament-test
     samizdat.trajectory-test
+    samizdat.tui-layout-test
+    samizdat.tui-readmodel-test
+    samizdat.tui-state-test
+    samizdat.tui-widgets-test
     samizdat.store-test
     samizdat.llm-test
     samizdat.agent-test
+    samizdat.approval-test
     samizdat.base-test
     samizdat.boundary-test
     samizdat.compaction-test

--- a/test/samizdat/tui_layout_test.clj
+++ b/test/samizdat/tui_layout_test.clj
@@ -1,0 +1,112 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui-layout-test
+  "The layout seam: WHAT the widgets are is the core's business, HOW they are
+  arranged is the user's.
+
+  resources/tui.edn is hiccup with `:widget/*` tags standing in for the
+  widgets the core implements. Every other tag is ftxui's own vocabulary and
+  passes through untouched, so rearranging the UI is editing EDN — no
+  rebuild, and the agent can do it to itself at runtime through the same
+  userspace seam that carries gates.edn and the manifests.
+
+  The load-bearing property tested here is that a BAD EDIT CANNOT BLACK-SCREEN
+  THE UI. A layout the agent breaks at runtime has to degrade to something
+  that still shows the run and still says what is wrong, or the one tool the
+  operator would use to see the damage is the tool the damage took out."
+  (:require [clojure.test :refer [deftest testing is]]
+            [samizdat.tui.layout :as layout]
+            ;; Registers every :widget/* into layout/widgets as a side effect
+            ;; of loading — which is what the shipped-layout test below
+            ;; checks against, so requiring it here is the test.
+            [samizdat.tui.widgets]))
+
+(def ^:private registry
+  {:widget/log (fn [_state props] [:text (str "log:" (:title props))])
+   :widget/tasks (fn [state _props] [:text (str "tasks:" (count (:tasks state)))])})
+
+(deftest widget-tags-expand-and-everything-else-passes-through
+  (is (= [:vbox {:border :rounded}
+          [:text "log:ACTIVITY"]
+          [:separator]
+          [:text "tasks:2"]]
+         (layout/expand
+          [:vbox {:border :rounded}
+           [:widget/log {:title "ACTIVITY"}]
+           [:separator]
+           [:widget/tasks {}]]
+          {:tasks [1 2]}
+          registry))
+      "ftxui's own tags are the arrangement vocabulary; only :widget/* is ours"))
+
+(deftest a-widget-may-be-written-without-props
+  (is (= [:vbox [:text "tasks:0"]]
+         (layout/expand [:vbox [:widget/tasks]] {:tasks []} registry))))
+
+(deftest nesting-and-sequences-survive-expansion
+  ;; hiccup children may be seqs — ftxui splices them — so the walk must not
+  ;; flatten a (for ...) into the parent's props position.
+  (is (= [:hbox [:vbox [:text "log:A"]] [:vbox [:text "log:B"]]]
+         (layout/expand
+          [:hbox [:vbox [:widget/log {:title "A"}]] [:vbox [:widget/log {:title "B"}]]]
+          {} registry))))
+
+(deftest an-unknown-widget-renders-a-visible-complaint-rather-than-throwing
+  ;; The whole point of the file being userspace is that the agent edits it
+  ;; while running. A typo'd tag that threw would take down the UI that shows
+  ;; what the agent just did — so it renders in place, named, and the rest of
+  ;; the layout still draws.
+  (let [out (layout/expand [:vbox [:widget/nope {}] [:widget/tasks {}]] {:tasks []} registry)]
+    (is (= :vbox (first out)))
+    (is (= [:text "tasks:0"] (nth out 2)) "its neighbour is unaffected")
+    (let [bad (nth out 1)]
+      (is (vector? bad))
+      (is (re-find #"widget/nope" (pr-str bad))
+          "and the broken tag is named where the operator can see it"))))
+
+(deftest a-widget-that-throws-is-contained-to-its-own-box
+  ;; Same argument one level down: a widget fed a state shape it did not
+  ;; expect must not take the frame with it.
+  (let [boom {:widget/boom (fn [_ _] (throw (ex-info "kaboom" {})))}
+        out (layout/expand [:vbox [:widget/boom {}] [:separator]]
+                           {} (merge registry boom))]
+    (is (re-find #"kaboom" (pr-str (nth out 1))))
+    (is (= [:separator] (nth out 2)))))
+
+(deftest the-shipped-layout-is-valid-and-names-only-widgets-that-exist
+  ;; The template is what a project seeds from and what a broken edit falls
+  ;; back to, so it is the one layout that must never be wrong.
+  (let [spec (layout/template)]
+    (is (vector? (:layout spec)) "tui.edn carries a :layout")
+    (is (seq (layout/widget-tags (:layout spec))))
+    (is (empty? (remove (set (keys @layout/widgets)) (layout/widget-tags (:layout spec))))
+        "every :widget/* the shipped layout names is implemented")))
+
+(deftest a-layout-that-is-not-hiccup-falls-back-to-the-template
+  (testing "nil, a map, a bare string — none of them can draw"
+    (doseq [junk [nil {} "vbox" 42 []]]
+      (is (= (:layout (layout/template)) (:layout (layout/validate {:layout junk})))
+          (str "fell back for " (pr-str junk)))))
+  (testing "and it says why, so the operator is not left guessing"
+    (is (string? (:error (layout/validate {:layout nil}))))))
+
+(deftest a-valid-layout-is-returned-unchanged-and-flagged-clean
+  (let [spec {:layout [:vbox [:widget/tasks {}]]}]
+    (is (= (:layout spec) (:layout (layout/validate spec))))
+    (is (nil? (:error (layout/validate spec))))))

--- a/test/samizdat/tui_layout_test.clj
+++ b/test/samizdat/tui_layout_test.clj
@@ -110,3 +110,94 @@
   (let [spec {:layout [:vbox [:widget/tasks {}]]}]
     (is (= (:layout spec) (:layout (layout/validate spec))))
     (is (nil? (:error (layout/validate spec))))))
+
+;; --- where the layout actually comes from ------------------------------------
+;;
+;; The bug these pin: `current` read the layout through `userspace/edn-body`,
+;; which in the TUI's process can only ever return the SHIPPED template — the
+;; TUI binds no project, so there is no stored row to read — and the
+;; userspace read cache then pinned that value for the life of the process,
+;; because nothing in a front end ever writes and nothing therefore ever
+;; invalidates. So `root`'s re-read-every-frame was a no-op after the first
+;; frame, an agent's saved version was invisible, and a person editing the
+;; file needed a restart. Three sources with a stated precedence instead.
+
+(defn- with-clean-layout [f]
+  (layout/serve! nil)
+  (layout/forget-file!)
+  (try (f) (finally (layout/serve! nil) (layout/forget-file!))))
+
+(deftest with-no-file-and-no-server-the-shipped-layout-is-what-draws
+  (with-clean-layout
+    (fn []
+      (is (= (:layout (layout/template)) (:layout (layout/current)))
+          "offline, first frame, nothing configured — it still draws"))))
+
+(deftest what-the-harness-serves-beats-the-shipped-template
+  ;; This is the agent editing its own UI. The server IS bound to the project,
+  ;; so it can read the stored `tui` policy; the TUI cannot, and asks.
+  (with-clean-layout
+    (fn []
+      (layout/serve! (pr-str {:prose-turns 5 :layout [:vbox [:widget/status {}]]}))
+      (is (= [:vbox [:widget/status {}]] (:layout (layout/current))))
+      (is (= 5 (:prose-turns (layout/current)))))))
+
+(deftest an-unparseable-served-layout-falls-back-and-says-so
+  (with-clean-layout
+    (fn []
+      (layout/serve! "{:layout [:vbox")
+      (is (= (:layout (layout/template)) (:layout (layout/current))))
+      (is (string? (:error (layout/current)))))))
+
+(deftest a-local-file-beats-what-the-harness-serves
+  ;; A person editing EDN is the requirement this file exists for, and they
+  ;; must not have to go through the harness's store to do it.
+  (with-clean-layout
+    (fn []
+      (let [f (java.io.File/createTempFile "tui-layout" ".edn")]
+        (try
+          (spit f (pr-str {:layout [:vbox [:widget/activity {:title "MINE"}]]}))
+          (layout/serve! (pr-str {:layout [:vbox [:widget/status {}]]}))
+          (is (= [:vbox [:widget/activity {:title "MINE"}]]
+                 (:layout (layout/current (.getPath f)))))
+          (finally (.delete f)))))))
+
+(deftest an-edit-to-the-file-takes-on-the-next-frame
+  ;; The whole claim of `root`: the layout is re-read, so a runtime edit
+  ;; shows up without a restart. It was false, and this is what says so.
+  (with-clean-layout
+    (fn []
+      (let [f (java.io.File/createTempFile "tui-layout" ".edn")
+            path (.getPath f)]
+        (try
+          (spit f (pr-str {:prose-turns 1 :layout [:vbox [:widget/status {}]]}))
+          (is (= 1 (:prose-turns (layout/current path))))
+          (spit f (pr-str {:prose-turns 99 :layout [:vbox [:widget/activity {}]]}))
+          ;; Pushed forward deliberately: two writes a millisecond apart can
+          ;; land on the same mtime, and a test that happened to pass on the
+          ;; clock rather than on the code would be no test at all.
+          (.setLastModified f (+ 2000 (.lastModified f)))
+          (is (= 99 (:prose-turns (layout/current path)))
+              "the edit took, with no restart and no cache to invalidate")
+          (is (= [:vbox [:widget/activity {}]] (:layout (layout/current path))))
+          (finally (.delete f)))))))
+
+(deftest a-half-written-file-does-not-take-the-screen-and-is-retried
+  ;; What a file being saved looks like for the instant it is being saved.
+  ;; It must not black-screen, and it must not be CACHED as broken either —
+  ;; the next frame has to try again or a torn read would be permanent.
+  (with-clean-layout
+    (fn []
+      (let [f (java.io.File/createTempFile "tui-layout" ".edn")
+            path (.getPath f)]
+        (try
+          (spit f "{:layout [:vbox")
+          (is (= (:layout (layout/template)) (:layout (layout/current path))))
+          (is (string? (:error (layout/current path))))
+          ;; Same mtime as far as the cache is concerned; the retry is what
+          ;; makes the finished write visible.
+          (spit f (pr-str {:layout [:vbox [:widget/status {}]]}))
+          (.setLastModified f 1000)
+          (is (= [:vbox [:widget/status {}]] (:layout (layout/current path)))
+              "a failed read is not remembered as the answer")
+          (finally (.delete f)))))))

--- a/test/samizdat/tui_readmodel_test.clj
+++ b/test/samizdat/tui_readmodel_test.clj
@@ -1,0 +1,106 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui-readmodel-test
+  "What a front end needs that the run detail did not yet answer: the board,
+  and the files the run has touched.
+
+  Both are queries over tables the loop already appends to, which is what
+  makes them read model rather than new state — the same property that lets
+  every other panel work identically on a live run and a finished one."
+  (:require [clojure.test :refer [deftest testing is]]
+            [db.jdbc]
+            [samizdat.api.runs :as api-runs]
+            [samizdat.store.db :as db]
+            [samizdat.store.journal :as journal]
+            [samizdat.store.runs :as runs]
+            [samizdat.store.tasks :as tasks]))
+
+(defmacro with-db [[binding] & body]
+  `(let [~binding (db/open! ":memory:")]
+     (try ~@body (finally (db/close ~binding)))))
+
+(defn- write-turn!
+  [c rid branch turn tool path]
+  (journal/record-turn! c rid {:branch-id branch :turn turn :tool-name tool
+                               :args (cond-> {} path (assoc :path path))
+                               :result "ok" :category :success}))
+
+(deftest the-run-detail-carries-the-board
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (tasks/create! c {:run-id rid :title "wire the panel"})
+      (tasks/create! c {:run-id rid :title "and close it"})
+      (let [board (:tasks (api-runs/get-run c rid))]
+        (is (= 2 (count board)))
+        (is (= #{"wire the panel" "and close it"} (set (map :title board))))))))
+
+(deftest a-closed-task-leaves-the-board
+  ;; The panel shows what is being worked on. A board that accumulated every
+  ;; finished task would be a log, and there is already one of those.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})
+          t (tasks/create! c {:run-id rid :title "done soon"})]
+      (tasks/close! c t)
+      (is (empty? (:tasks (api-runs/get-run c rid)))))))
+
+(deftest modified-files-are-the-paths-the-run-wrote-newest-first
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (write-turn! c rid "B1" 1 "write_file" "src/a.clj")
+      (write-turn! c rid "B1" 2 "read" "src/never.clj")
+      (write-turn! c rid "B1" 3 "edit_file" "src/b.clj")
+      (let [m (:modified (api-runs/get-run c rid))]
+        (is (= ["src/b.clj" "src/a.clj"] (mapv :path m))
+            "writing tools only, most recently touched first")
+        (is (= 3 (:turn (first m))) "and the turn that touched it")))))
+
+(deftest a-file-written-twice-appears-once-at-its-latest-turn
+  ;; Per path, not per write: the panel answers "what has this run changed",
+  ;; and a file edited eight times is one changed file.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (write-turn! c rid "B1" 1 "write_file" "src/a.clj")
+      (write-turn! c rid "B1" 5 "edit_file" "src/a.clj")
+      (let [m (:modified (api-runs/get-run c rid))]
+        (is (= 1 (count m)))
+        (is (= 5 (:turn (first m))))))))
+
+(deftest every-branch-that-touched-a-file-is-named
+  ;; A beam has several branches in the same tree; which ones touched a file
+  ;; is the question a person watching a beam actually has.
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (doseq [b ["B1" "B2"]] (runs/open-branch! c rid {:branch-id b}))
+      (write-turn! c rid "B1" 1 "write_file" "src/shared.clj")
+      (write-turn! c rid "B2" 2 "edit_file" "src/shared.clj")
+      (let [m (first (:modified (api-runs/get-run c rid)))]
+        (is (= "src/shared.clj" (:path m)))
+        (is (= #{"B1" "B2"} (set (:branches m))))))))
+
+(deftest a-turn-with-no-path-argument-is-not-a-modified-file
+  ;; Args are the JSON the model sent, so a malformed or absent path has to
+  ;; be skipped rather than filed as a file named "null".
+  (with-db [c]
+    (let [rid (runs/start-run! c {:problem "p"})]
+      (runs/open-branch! c rid {:branch-id "B1"})
+      (write-turn! c rid "B1" 1 "write_file" nil)
+      (write-turn! c rid "B1" 2 "bash" nil)
+      (is (empty? (:modified (api-runs/get-run c rid)))))))

--- a/test/samizdat/tui_state_test.clj
+++ b/test/samizdat/tui_state_test.clj
@@ -1,0 +1,203 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui-state-test
+  "The view state: what the pollers fold into, and what the widgets read.
+
+  Pure, so the TUI's whole policy — cursors, what a disconnect does, what
+  changing run resets — is testable with no terminal and no server. The run
+  loop is then only wiring."
+  (:require [clojure.test :refer [deftest testing is]]
+            [samizdat.tui.state :as st]))
+
+(deftest the-initial-state-names-the-server-and-nothing-else
+  (let [s (st/initial "http://x:1")]
+    (is (= "http://x:1" (:base s)))
+    (is (nil? (:run-id s)))
+    (is (= [] (:trace s)))
+    (is (= #{} (:expanded s)))))
+
+(deftest steps-append-to-the-trace-and-carry-the-cursor
+  (let [s (-> (st/initial "b")
+              (st/apply-steps {:ok true :body {:steps [{:seq 1 :node "start"}
+                                                       {:seq 2 :node "infer"}]
+                                               :next 2 :dropped 0}}))]
+    (is (= ["start" "infer"] (mapv :node (:trace s))))
+    (is (= 2 (:steps-cursor s)))
+    (testing "a second batch appends rather than replacing"
+      (let [s2 (st/apply-steps s {:ok true :body {:steps [{:seq 3 :node "parse"}]
+                                                  :next 3 :dropped 0}})]
+        (is (= ["start" "infer" "parse"] (mapv :node (:trace s2))))
+        (is (= 3 (:steps-cursor s2)))))))
+
+(deftest the-trace-the-ui-holds-is-bounded
+  ;; The server's ring is bounded and so is this: a TUI left running for a
+  ;; day would otherwise hold every step of every run it watched.
+  (let [many (mapv (fn [i] {:seq (inc i) :node (str "n" i)}) (range (+ st/max-trace 50)))
+        s (st/apply-steps (st/initial "b")
+                          {:ok true :body {:steps many :next (count many) :dropped 0}})]
+    (is (= st/max-trace (count (:trace s))))
+    (is (= "n50" (:node (first (:trace s))))
+        "the oldest are what go — 550 recorded, the first 50 dropped")))
+
+(deftest a-dropped-count-is-remembered-not-just-the-latest
+  ;; The server reports what THIS client missed. Two polls that each missed
+  ;; some have missed the sum, and a panel that showed only the latest would
+  ;; understate the hole.
+  (let [s (-> (st/initial "b")
+              (st/apply-steps {:ok true :body {:steps [] :next 0 :dropped 3}})
+              (st/apply-steps {:ok true :body {:steps [] :next 0 :dropped 4}}))]
+    (is (= 7 (:trace-dropped s)))))
+
+(deftest a-failed-poll-marks-the-state-disconnected-and-keeps-the-cursor
+  (let [s (-> (st/initial "b")
+              (st/apply-steps {:ok true :body {:steps [{:seq 5 :node "x"}] :next 5}})
+              (st/apply-steps {:ok false :error "connection refused"}))]
+    (is (false? (:connected? s)))
+    (is (= "connection refused" (:error s)))
+    (is (= 5 (:steps-cursor s)) "so nothing is missed when the server returns")
+    (is (= 1 (count (:trace s))) "and what was already drawn stays drawn")))
+
+(deftest a-good-poll-clears-a-previous-error
+  (let [s (-> (st/initial "b")
+              (st/apply-steps {:ok false :error "boom"})
+              (st/apply-steps {:ok true :body {:steps [] :next 0}}))]
+    (is (true? (:connected? s)))
+    (is (nil? (:error s)))))
+
+(deftest selecting-a-run-resets-everything-that-belonged-to-the-last-one
+  ;; The bug this exists to prevent: cursors and traces carried across a run
+  ;; change, so the new run's panel opened showing the old run's steps and
+  ;; then skipped everything before the stale cursor.
+  (let [s (-> (st/initial "b")
+              (st/apply-steps {:ok true :body {:steps [{:seq 9 :node "old"}] :next 9
+                                               :dropped 2}})
+              (assoc :branch-id "B1" :branch {:turns [{:turn 1}]}
+                     :detail {:run {:id "r1"}})
+              (st/select-run "r2"))]
+    (is (= "r2" (:run-id s)))
+    (is (= [] (:trace s)))
+    (is (zero? (:steps-cursor s)))
+    (is (zero? (:trace-dropped s)))
+    (is (nil? (:branch s)))
+    (is (nil? (:branch-id s)))
+    (is (nil? (:detail s)))))
+
+(deftest selecting-a-branch-drops-the-turns-of-the-last-one
+  (let [s (-> (st/initial "b")
+              (assoc :branch-id "B1" :branch {:turns [{:turn 1}]})
+              (st/select-branch "B2"))]
+    (is (= "B2" (:branch-id s)))
+    (is (nil? (:branch s)))))
+
+(deftest a-branch-is-picked-automatically-when-the-detail-lands
+  ;; Opening a run and being shown nothing until you click a branch is a
+  ;; worse first frame than opening it on the branch that is running.
+  (let [s (st/apply-detail (st/initial "b")
+                           {:ok true :body {:branches [{:id "B1" :status "culled"}
+                                                       {:id "B2" :status "active"}]}})]
+    (is (= "B2" (:branch-id s)) "the active one, not the first"))
+  (testing "a choice already made is not overridden on every poll"
+    (let [s (-> (st/initial "b")
+                (assoc :branch-id "B1")
+                (st/apply-detail {:ok true :body {:branches [{:id "B1"} {:id "B2" :status "active"}]}}))]
+      (is (= "B1" (:branch-id s))))))
+
+(deftest turn-text-lands-under-its-turn-number
+  ;; The prose arrives one turn at a time, because the branch listing drops
+  ;; it — so the state keeps a map the conversation reads through.
+  (let [s (st/apply-turn-text (st/initial "b") 3
+                              {:ok true :body {:turn 3 :assistant_text "said this"
+                                               :reasoning_text "thought that"}})]
+    (is (= "said this" (get-in s [:turn-text 3 :assistant_text])))
+    (is (= "thought that" (get-in s [:turn-text 3 :reasoning_text])))))
+
+(deftest a-failed-turn-text-fetch-does-not-blank-what-is-already-there
+  (let [s (-> (st/initial "b")
+              (st/apply-turn-text 3 {:ok true :body {:assistant_text "said this"}})
+              (st/apply-turn-text 3 {:ok false :error "gone"}))]
+    (is (= "said this" (get-in s [:turn-text 3 :assistant_text])))))
+
+(deftest changing-run-drops-the-prose-of-the-last-one
+  ;; Turn numbers restart per branch, so text kept across a switch would
+  ;; caption the new run's turn 3 with the old run's words.
+  (let [s (-> (st/initial "b")
+              (st/apply-turn-text 3 {:ok true :body {:assistant_text "old run"}})
+              (st/select-run "r2"))]
+    (is (empty? (:turn-text s))))
+  (let [s (-> (st/initial "b")
+              (st/apply-turn-text 3 {:ok true :body {:assistant_text "old branch"}})
+              (st/select-branch "B2"))]
+    (is (empty? (:turn-text s)))))
+
+(deftest the-turns-whose-prose-is-wanted-are-the-newest-on-screen
+  ;; Bounded: a run of four hundred turns must not fetch four hundred bodies
+  ;; every poll. The newest are what a reader is following.
+  (let [turns (mapv (fn [n] {:turn n}) (range 1 21))
+        s (assoc (st/initial "b") :branch {:turns turns})]
+    (is (= [18 19 20] (st/prose-wanted s 3)))
+    (testing "and text already held is not re-fetched"
+      (let [s (assoc-in s [:turn-text 20] {:assistant_text "have it"})]
+        (is (= [17 18 19] (st/prose-wanted s 3))))))
+  (testing "a branch with no turns wants nothing"
+    (is (= [] (st/prose-wanted (st/initial "b") 3)))))
+
+(deftest a-half-answered-questionnaire-survives-the-poll-that-lands-mid-answer
+  ;; Polls arrive every second or so and a person takes longer than that to
+  ;; read two questions. Resetting the cursor on every poll would make the
+  ;; second question unreachable — you would be sent back to the first,
+  ;; forever, while the branch sat parked.
+  (let [q {:id "q1" :questions [{:question "a"} {:question "b"}]}
+        s (-> (st/initial "b")
+              (st/apply-approvals {:ok true :body {:approvals [q]}})
+              (assoc :question-cursor 1 :question-answers ["first"])
+              (st/apply-approvals {:ok true :body {:approvals [q]}}))]
+    (is (= 1 (:question-cursor s)))
+    (is (= ["first"] (:question-answers s))))
+  (testing "but a different question starts clean"
+    (let [s (-> (st/initial "b")
+                (st/apply-approvals {:ok true :body {:approvals [{:id "q1"}]}})
+                (assoc :question-cursor 1 :question-answers ["first"])
+                (st/apply-approvals {:ok true :body {:approvals [{:id "q2"}]}}))]
+      (is (zero? (:question-cursor s)))
+      (is (= [] (:question-answers s))))))
+
+(deftest answering-advances-until-the-last-question-is-done
+  (let [s (assoc (st/initial "b")
+                 :approvals [{:id "q1" :questions [{:question "a"} {:question "b"}]}])
+        [s1 done1] (st/answer-question s ["yes"])]
+    (is (false? done1) "one of two answered is not a set to submit")
+    (is (= 1 (:question-cursor s1)))
+    (let [[_ done2] (st/answer-question s1 ["yes" "no"])]
+      (is (true? done2)))))
+
+(deftest folds-toggle-open-and-shut
+  (let [s (-> (st/initial "b") (st/toggle-fold "3/result"))]
+    (is (contains? (:expanded s) "3/result"))
+    (is (not (contains? (:expanded (st/toggle-fold s "3/result")) "3/result")))))
+
+(deftest the-run-list-lands-and-picks-the-newest-when-nothing-is-selected
+  (let [s (st/apply-runs (st/initial "b")
+                         {:ok true :body {:runs [{:id "r2"} {:id "r1"}]}})]
+    (is (= 2 (count (:runs s))))
+    (is (= "r2" (:run-id s)) "the first the server listed, which lists newest first"))
+  (testing "and does not steal a selection the user made"
+    (let [s (-> (st/initial "b")
+                (assoc :run-id "r1")
+                (st/apply-runs {:ok true :body {:runs [{:id "r2"} {:id "r1"}]}}))]
+      (is (= "r1" (:run-id s))))))

--- a/test/samizdat/tui_state_test.clj
+++ b/test/samizdat/tui_state_test.clj
@@ -153,9 +153,28 @@
     (is (= [18 19 20] (st/prose-wanted s 3)))
     (testing "and text already held is not re-fetched"
       (let [s (assoc-in s [:turn-text 20] {:assistant_text "have it"})]
-        (is (= [17 18 19] (st/prose-wanted s 3))))))
+        ;; 18 and 19 — the rest of the WINDOW, not the next three turns
+        ;; down. The window is chosen first and the held ones are dropped
+        ;; out of it; picking the newest n that are missing instead walked
+        ;; the whole branch n turns at a time.
+        (is (= [18 19] (st/prose-wanted s 3))))))
   (testing "a branch with no turns wants nothing"
     (is (= [] (st/prose-wanted (st/initial "b") 3)))))
+
+(deftest the-prose-window-does-not-walk-backwards-through-the-branch
+  ;; The bug this pins: `remove held` before `take-last n` made every poll
+  ;; ask for n turns FURTHER BACK, so a 400-turn branch fetched all 400
+  ;; bodies over 33 polls and held the whole 5.5MB the per-turn endpoint
+  ;; exists to avoid. Once the window is full it must ask for nothing.
+  (let [turns (mapv (fn [n] {:turn n}) (range 1 401))
+        s (assoc (st/initial "b") :branch {:turns turns})
+        want (st/prose-wanted s 12)
+        held (reduce (fn [acc n] (assoc-in acc [:turn-text n] {:assistant_text "x"}))
+                     s want)]
+    (is (= 12 (count want)))
+    (is (= [389 400] [(first want) (last want)]) "the newest twelve")
+    (is (= [] (st/prose-wanted held 12))
+        "and with those held it wants nothing more — not the twelve below them")))
 
 (deftest a-half-answered-questionnaire-survives-the-poll-that-lands-mid-answer
   ;; Polls arrive every second or so and a person takes longer than that to
@@ -185,6 +204,23 @@
     (is (= 1 (:question-cursor s1)))
     (let [[_ done2] (st/answer-question s1 ["yes" "no"])]
       (is (true? done2)))))
+
+(deftest y-and-n-answer-the-permission-dialog-that-is-on-screen
+  ;; The buttons are labelled "allow (y)" and "deny (n)", which was a promise
+  ;; the key handler did not keep. Pure, so the key policy is covered here
+  ;; rather than in the toolkit-bound suite.
+  (let [s (assoc (st/initial "b") :approvals [{:id "a1" :kind "shell"}])]
+    (is (= ["a1" :allow] (st/pending-decision s "y")))
+    (is (= ["a1" :deny] (st/pending-decision s "n")))
+    (is (nil? (st/pending-decision s "q")) "anything else belongs to whoever has focus"))
+  (testing "and they do nothing when no dialog is up"
+    (is (nil? (st/pending-decision (st/initial "b") "y"))))
+  (testing "nor over a questionnaire, where a letter is something being typed"
+    ;; The free-text box takes characters; y must reach it, not decide a
+    ;; question it was never offered as an answer to.
+    (let [s (assoc (st/initial "b")
+                   :approvals [{:id "q1" :questions [{:question "name?"}]}])]
+      (is (nil? (st/pending-decision s "y"))))))
 
 (deftest folds-toggle-open-and-shut
   (let [s (-> (st/initial "b") (st/toggle-fold "3/result"))]

--- a/test/samizdat/tui_widgets_test.clj
+++ b/test/samizdat/tui_widgets_test.clj
@@ -1,0 +1,338 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui-widgets-test
+  "The widgets, as data.
+
+  Each is (fn [state props] -> hiccup), so the whole set is covered here
+  without a terminal, without ftxui, and without a running server — the
+  reason the TUI is written this way rather than as paint calls.
+
+  What these tests hold: that a widget draws from the state it is given and
+  nothing else, that every one of them survives an EMPTY state (the first
+  frame, before any poll has answered, is the state every user sees), and
+  that the folds are wired to the toggle handler with ids stable across
+  frames — a fold whose id moved would close itself every time the run
+  advanced."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest testing is]]
+            [clojure.walk :as walk]
+            [samizdat.tui.layout :as layout]
+            [samizdat.tui.widgets :as w]))
+
+(defn- render [tag state props]
+  ((get @layout/widgets tag) state props))
+
+(defn- texts
+  "Every string anywhere in a rendered tree, concatenated — what the panel
+  says, independent of how it is boxed."
+  [form]
+  (let [acc (atom [])]
+    (walk/postwalk (fn [x] (when (string? x) (swap! acc conj x)) x) form)
+    (str/join " " @acc)))
+
+(defn- nodes-of
+  "Every element in `form` whose tag is `tag`."
+  [tag form]
+  (let [acc (atom [])]
+    (walk/postwalk (fn [x]
+                     (when (and (vector? x) (= tag (first x))) (swap! acc conj x))
+                     x)
+                   form)
+    @acc))
+
+(defn- props-of [el] (when (map? (second el)) (second el)))
+
+;; --- the activity log --------------------------------------------------------
+
+(def ^:private trace
+  [{:seq 1 :node "start" :cell "loop/assemble" :transition "ok" :turn 1 :ms 2}
+   {:seq 2 :node "infer" :cell "llm/infer" :transition "ok" :turn 1 :ms 900}
+   {:seq 3 :node "parse" :cell "llm/parse" :transition "tool" :turn 1 :ms 1
+    :failed true}])
+
+(deftest the-activity-log-is-the-manifest-states-not-a-tool-ticker
+  ;; The one deliberate departure from what was ported. dirge's ACTIVITY
+  ;; panel is a list of tool calls; here it is the state graph being walked,
+  ;; because that is the thing samizdat has and a tool ticker is already the
+  ;; conversation's job.
+  (let [out (render :widget/activity {:trace trace} {:title "ACTIVITY LOG"})
+        said (texts out)]
+    (is (str/includes? said "ACTIVITY LOG"))
+    (doseq [n ["start" "infer" "parse"]]
+      (is (str/includes? said n) (str "names the manifest state " n)))
+    (is (str/includes? said "llm/infer")
+        "and the cell behind the state, which is what an operator edits")))
+
+(deftest a-failed-step-is-marked
+  (let [said (texts (render :widget/activity {:trace trace} {}))]
+    (is (re-find #"(?i)fail|✗|!" said))))
+
+(deftest the-activity-log-says-when-it-fell-behind
+  ;; The ring drops the oldest under load and reports how many. A panel that
+  ;; swallowed that would draw a continuous trace with an invisible hole.
+  (let [said (texts (render :widget/activity {:trace trace :trace-dropped 7} {}))]
+    (is (str/includes? said "7"))))
+
+(deftest the-newest-step-is-the-one-nearest-the-input
+  ;; Reading order: a log you watch grows downward, like the conversation
+  ;; above the compose box.
+  (let [out (render :widget/activity {:trace trace} {})
+        said (texts out)]
+    (is (< (str/index-of said "start") (str/index-of said "parse")))))
+
+;; --- the conversation --------------------------------------------------------
+
+(def ^:private turns
+  [{:turn 1 :tool_name "read_file" :args "{\"path\":\"src/a.clj\"}"
+    :result "(ns a)" :category "neutral"}
+   {:turn 2 :tool_name "write_file" :args "{\"path\":\"src/a.clj\"}"
+    :result "+ (defn go [])\n- (defn old [])" :category "success"}])
+
+(def ^:private turn-text
+  ;; Prose arrives per turn on its own feed — the branch listing drops it.
+  {1 {:assistant_text "Looking at the namespace first."
+      :reasoning_text "I should read before I write."}
+   2 {:assistant_text "Replacing the entry point."}})
+
+(deftest the-conversation-shows-what-was-said-and-what-was-called
+  (let [said (texts (render :widget/conversation
+                            {:branch {:turns turns} :turn-text turn-text} {}))]
+    (is (str/includes? said "Looking at the namespace first."))
+    (is (str/includes? said "read_file"))
+    (is (str/includes? said "write_file"))))
+
+(deftest a-turn-whose-prose-has-not-arrived-still-draws-its-call
+  ;; The prose is a second fetch, so there are always frames where a turn is
+  ;; listed and its words are not back yet. That has to read as a turn with
+  ;; no prose, not as a blank entry or a crash.
+  (let [said (texts (render :widget/conversation {:branch {:turns turns}} {}))]
+    (is (str/includes? said "read_file"))
+    (is (not (str/includes? said "Looking at the namespace first.")))))
+
+(deftest thinking-arguments-and-results-fold-and-are-closed-by-default
+  ;; A conversation that opened every tool result would be unreadable after
+  ;; three turns. The header is always there; the body is a click away.
+  (let [out (render :widget/conversation
+                    {:branch {:turns turns} :turn-text turn-text} {})
+        folds (nodes-of :collapsible out)]
+    (is (seq folds) "folds are ftxui collapsibles, so the mouse works on them")
+    (is (every? #(false? (:show (props-of %))) folds)
+        "closed until the operator opens one")
+    (let [labels (str/join " " (keep #(:label (props-of %)) folds))]
+      (is (str/includes? labels "thinking"))
+      (is (str/includes? labels "result")))))
+
+(deftest an-expanded-fold-is-open-and-its-body-is-drawn
+  (let [id (w/fold-id 1 :result)
+        out (render :widget/conversation {:branch {:turns turns} :turn-text turn-text :expanded #{id}} {})
+        open (filter #(true? (:show (props-of %))) (nodes-of :collapsible out))]
+    (is (= 1 (count open)) "exactly the one that was expanded")
+    (is (str/includes? (texts open) "(ns a)") "and its body is rendered")))
+
+(deftest a-fold-id-is-stable-across-frames-and-unique-per-section
+  ;; The set of open folds is keyed by these. An id derived from a position
+  ;; in the list would move as the run advanced and every open fold would
+  ;; shut itself on the next turn.
+  (is (= (w/fold-id 3 :thinking) (w/fold-id 3 :thinking)))
+  (is (not= (w/fold-id 3 :thinking) (w/fold-id 3 :result)))
+  (is (not= (w/fold-id 3 :result) (w/fold-id 4 :result))))
+
+(deftest clicking-a-fold-toggles-it-through-the-handler
+  ;; Widgets are pure functions of state, so the handler arrives IN the
+  ;; state. That is what keeps them testable without a running loop.
+  (let [toggled (atom nil)
+        state {:branch {:turns turns} :turn-text turn-text :on {:toggle #(reset! toggled %)}}
+        fold (first (nodes-of :collapsible (render :widget/conversation state {})))]
+    ((:on-change (props-of fold)) true)
+    (is (some? @toggled) "the toggle handler was called with the fold's id")))
+
+(deftest a-write-result-is-drawn-as-a-diff
+  ;; +/- lines are the one result shape worth colouring: it is how a reader
+  ;; tells an edit that landed from one that replaced the wrong thing.
+  (let [id (w/fold-id 2 :result)
+        out (render :widget/conversation {:branch {:turns turns} :turn-text turn-text :expanded #{id}} {})
+        coloured (filter #(:color (props-of %)) (nodes-of :text out))
+        by-colour (group-by #(:color (props-of %)) coloured)]
+    (is (seq (get by-colour :green)) "additions")
+    (is (seq (get by-colour :red)) "removals")))
+
+(deftest a-failed-turn-reads-as-failed
+  (let [said (texts (render :widget/conversation
+                            {:branch {:turns [{:turn 1 :tool_name "bash"
+                                               :category "failure" :result "boom"}]}}
+                            {}))]
+    (is (re-find #"(?i)fail|✗" said))))
+
+;; --- the side panels ---------------------------------------------------------
+
+(deftest the-task-panel-shows-the-board-with-its-statuses
+  (let [said (texts (render :widget/tasks
+                            {:detail {:tasks [{:id "t1" :title "wire it" :status "in_progress"}
+                                              {:id "t2" :title "then test" :status "open"}]}}
+                            {:title "TASKS"}))]
+    (is (str/includes? said "wire it"))
+    (is (str/includes? said "then test"))
+    (is (re-find #"(?i)progress" said) "the one being worked on is marked")))
+
+(deftest the-files-panel-lists-what-the-run-changed
+  (let [said (texts (render :widget/files
+                            {:detail {:modified [{:path "src/a.clj" :turn 3 :branches ["B1"]}
+                                                 {:path "src/b.clj" :turn 1 :branches ["B1" "B2"]}]}}
+                            {:title "MODIFIED"}))]
+    (is (str/includes? said "src/a.clj"))
+    (is (str/includes? said "B2") "and who touched it, which is the beam's question")))
+
+(deftest the-context-panel-shows-fill-against-the-window
+  ;; The usage map comes off the wire with the KEBAB keys run-usage builds —
+  ;; :total-tokens, not :total_tokens, because the JSON writer emits the
+  ;; keyword it was given. Reading the snake spelling drew a run that had
+  ;; spent 8000 tokens as having spent none, which is the one number an
+  ;; operator watching a metered provider is actually there for.
+  (let [out (render :widget/context
+                    {:detail {:run {:usage {:total-tokens 4000 :turns 4}
+                                    :token_budget 10000
+                                    :max_turns 20}}}
+                    {:title "CONTEXT"})]
+    (is (seq (nodes-of :gauge out)) "a gauge, because a ratio is not a number to read")
+    (is (str/includes? (texts out) "4000"))
+    (is (str/includes? (texts out) "10000"))
+    (is (str/includes? (texts out) "4") "turns taken, which lives on the usage map")
+    (is (str/includes? (texts out) "20"))))
+
+(deftest the-gate-panel-separates-what-fired-from-what-is-still-open
+  (let [said (texts (render :widget/gates
+                            {:detail {:gates [{:gate "stuck" :fired 2 :open 1}]}}
+                            {:title "GATES"}))]
+    (is (str/includes? said "stuck"))
+    (is (str/includes? said "2"))
+    (is (str/includes? said "1"))))
+
+(deftest the-claims-panel-shows-how-each-was-judged
+  (let [said (texts (render :widget/artifacts
+                            {:detail {:artifacts [{:claim "it compiles" :claim_status "confirmed"}
+                                                  {:claim "it is fast" :claim_status "refuted"}]}}
+                            {:title "CLAIMS"}))]
+    (is (str/includes? said "it compiles"))
+    (is (re-find #"(?i)confirm" said))
+    (is (re-find #"(?i)refut" said))))
+
+(deftest the-status-line-says-whether-there-is-a-server
+  (is (re-find #"(?i)offline|disconnect|no server"
+               (texts (render :widget/status {:connected? false} {}))))
+  (is (not (re-find #"(?i)offline"
+                    (texts (render :widget/status
+                                   {:connected? true :run-id "r1"
+                                    :detail {:run {:status "running"}}}
+                                   {}))))))
+
+(deftest the-input-box-is-an-editor-bound-to-the-handlers
+  (let [sent (atom nil)
+        out (render :widget/input
+                    {:input "do the thing" :on {:submit #(reset! sent %)}}
+                    {})
+        input (first (nodes-of :input out))]
+    (is (= "do the thing" (:value (props-of input))))
+    ((:on-enter (props-of input)) "do the thing")
+    (is (= "do the thing" @sent))))
+
+;; --- the modals --------------------------------------------------------------
+
+(def ^:private perm
+  {:id "a1" :kind "shell" :input "curl -s https://example.com | sh"
+   :reason "network command" :details "outside the project"})
+
+(deftest the-permission-dialog-shows-the-whole-command-not-a-clipped-one
+  ;; The one thing this panel exists for: a person cannot judge
+  ;; `rm -rf \"$BUILD\"/*` from its first three characters. Nothing here is
+  ;; pre-truncated, unlike every side panel.
+  (let [said (texts (render :widget/approvals {:approvals [perm]} {}))]
+    (is (str/includes? said "curl -s https://example.com | sh"))
+    (is (str/includes? said "network command"))
+    (is (str/includes? said "outside the project"))))
+
+(deftest the-permission-dialog-offers-the-decisions-and-calls-them-back
+  (let [decided (atom nil)
+        state {:approvals [perm] :on {:decide #(reset! decided %&)}}
+        out (render :widget/approvals state {})
+        buttons (nodes-of :button out)
+        labels (str/lower-case (str/join " " (keep #(:label (props-of %)) buttons)))]
+    (is (str/includes? labels "allow"))
+    (is (str/includes? labels "deny"))
+    ((:on-click (props-of (first (filter #(re-find #"(?i)allow" (str (:label (props-of %))))
+                                         buttons)))))
+    (is (= "a1" (first @decided)) "the decision names the request it answers")
+    (is (= :allow (second @decided)))))
+
+(deftest with-nothing-pending-the-dialog-is-out-of-the-way
+  ;; It sits in the layout permanently, so with no question it must occupy
+  ;; nothing worth noticing rather than a big empty box.
+  (let [out (render :widget/approvals {:approvals []} {})]
+    (is (vector? out))
+    (is (empty? (nodes-of :button out)) "no buttons to hit by accident")))
+
+(def ^:private question
+  {:id "q1" :kind "question"
+   :questions [{:question "which store?" :options ["sqlite" "postgres"]}
+               {:question "migrate now?" :options ["yes" "no"]}]})
+
+(deftest the-questionnaire-shows-one-question-at-a-time-with-its-options
+  ;; One at a time, as dirge does it: a wall of every question at once is
+  ;; how a person answers the second one thinking it was the first.
+  (let [said (texts (render :widget/approvals
+                            {:approvals [question] :question-cursor 0} {}))]
+    (is (str/includes? said "which store?"))
+    (is (str/includes? said "sqlite"))
+    (is (not (str/includes? said "migrate now?"))
+        "the next question waits its turn")))
+
+(deftest the-questionnaire-advances-and-answers
+  (let [answered (atom nil)
+        state {:approvals [question] :question-cursor 1
+               :question-answers ["sqlite"]
+               :on {:answer #(reset! answered %&)}}
+        out (render :widget/approvals state {})]
+    (is (str/includes? (texts out) "migrate now?") "it is on the second question")
+    (let [menu (first (nodes-of :menu out))]
+      ((:on-enter (props-of menu)) 0)
+      (is (= "q1" (first @answered)))
+      (is (= ["sqlite" "yes"] (nth @answered 2))
+          "the earlier answer is carried, not lost on the way to the last"))))
+
+;; --- the property that matters most -----------------------------------------
+
+(deftest every-widget-draws-something-from-an-empty-state
+  ;; The first frame, before any poll has answered, is the state every user
+  ;; sees. A widget that assumed a run was selected would make starting the
+  ;; TUI a crash — and these are drawn from a file the agent can edit, so
+  ;; "just don't put that one in the layout" is not a defence.
+  (doseq [[tag f] @layout/widgets]
+    (testing (str tag)
+      (let [out (f {} {})]
+        (is (vector? out) "renders an element")
+        (is (keyword? (first out)) "with a tag")))))
+
+(deftest every-widget-tolerates-a-state-full-of-nils
+  ;; The shape between "nothing yet" and "loaded": a run selected, its detail
+  ;; not back. Half the panels were reading through keys that are legitimately
+  ;; nil for a frame or two.
+  (let [half {:run-id "r1" :detail nil :branch nil :trace nil
+              :runs nil :expanded nil :input nil :on nil}]
+    (doseq [[tag f] @layout/widgets]
+      (testing (str tag)
+        (is (vector? (f half {})))))))

--- a/test/samizdat/tui_widgets_test.clj
+++ b/test/samizdat/tui_widgets_test.clj
@@ -29,10 +29,12 @@
   that the folds are wired to the toggle handler with ids stable across
   frames — a fold whose id moved would close itself every time the run
   advanced."
-  (:require [clojure.string :as str]
+  (:require [clojure.set]
+            [clojure.string :as str]
             [clojure.test :refer [deftest testing is]]
             [clojure.walk :as walk]
             [samizdat.tui.layout :as layout]
+            [samizdat.tui.state :as st]
             [samizdat.tui.widgets :as w]))
 
 (defn- render [tag state props]
@@ -138,6 +140,41 @@
       (is (str/includes? labels "thinking"))
       (is (str/includes? labels "result")))))
 
+(deftest a-closed-fold-does-not-carry-its-body
+  ;; Cost, not appearance. `fold` handed the body to :collapsible whether or
+  ;; not it was open, so every frame split every tool result on the branch
+  ;; into one element per line — 175ms a frame at 200 turns, with every fold
+  ;; SHUT, and ftxui redraws on every keystroke. A shut fold's body is not
+  ;; on screen and must not be built.
+  (let [out (render :widget/conversation
+                    {:branch {:turns turns} :turn-text turn-text} {})]
+    (is (not (str/includes? (texts out) "(ns a)"))
+        "the body of a closed fold is not in the tree at all")
+    (is (str/includes? (texts out) "result")
+        "but its header is, which is what a reader scans"))
+  (testing "and the body is back the moment it is opened"
+    (let [out (render :widget/conversation
+                      {:branch {:turns turns} :turn-text turn-text
+                       :expanded #{(w/fold-id 1 :result)}} {})]
+      (is (str/includes? (texts out) "(ns a)")))))
+
+(deftest the-conversation-draws-a-bounded-tail-of-a-long-branch
+  ;; Every other panel is bounded — the trace at 500, the file list at
+  ;; :modified-files-shown. The biggest one was not, so a 400-turn branch
+  ;; built 400 entries per frame. How many is userspace, like :prose-turns:
+  ;; how far back a reader scrolls is their business.
+  (let [turns (mapv (fn [n] {:turn n :tool_name "read_file" :result "x"})
+                    (range 1 401))
+        out (render :widget/conversation {:branch {:turns turns}} {:turns 40})
+        drawn (keep #(:key (props-of %)) (nodes-of :vbox out))]
+    (is (= 40 (count drawn)) "the tail the layout asked for")
+    (is (= "400" (last drawn)) "and it is the NEWEST forty, which is what is being read")
+    (is (= "361" (first drawn))))
+  (testing "a branch shorter than the bound is drawn whole"
+    (let [turns (mapv (fn [n] {:turn n :tool_name "read_file"}) (range 1 4))
+          out (render :widget/conversation {:branch {:turns turns}} {:turns 40})]
+      (is (= 3 (count (keep #(:key (props-of %)) (nodes-of :vbox out))))))))
+
 (deftest an-expanded-fold-is-open-and-its-body-is-drawn
   (let [id (w/fold-id 1 :result)
         out (render :widget/conversation {:branch {:turns turns} :turn-text turn-text :expanded #{id}} {})
@@ -232,6 +269,38 @@
     (is (re-find #"(?i)confirm" said))
     (is (re-find #"(?i)refut" said))))
 
+(deftest the-branch-picker-lists-the-beam-and-switches-to-one
+  ;; samizdat runs a BEAM. Without this widget the auto-picked branch was the
+  ;; only one a reader could ever see: :select-branch was in the handler map
+  ;; with nothing on screen calling it.
+  (let [picked (atom nil)
+        state {:detail {:branches [{:id "B1" :status "active" :thesis {:claim "parser first"}}
+                                   {:id "B2" :status "culled" :thesis {:claim "lexer first"}}]}
+               :branch-id "B1"
+               :on {:select-branch #(reset! picked %)}}
+        out (render :widget/branches state {})]
+    (is (str/includes? (texts out) "B1"))
+    (is (str/includes? (texts out) "culled") "and what became of each")
+    (let [menu (first (nodes-of :menu out))]
+      (is (zero? (:selected (props-of menu))) "open on the one being read")
+      ((:on-enter (props-of menu)) 1)
+      (is (= "B2" @picked)))))
+
+(deftest the-compose-box-can-also-abort-and-resume
+  ;; Both were in the handler map and documented in tui.edn's widget table,
+  ;; and neither had anything on screen that called it.
+  (let [hit (atom [])
+        state {:on {:abort #(swap! hit conj :abort)
+                    :resume #(swap! hit conj :resume)}}
+        out (render :widget/input state {})
+        by-label (into {} (map (juxt #(:label (props-of %)) #(:on-click (props-of %))))
+                       (nodes-of :button out))]
+    (is (contains? by-label "abort"))
+    (is (contains? by-label "resume"))
+    ((get by-label "abort"))
+    ((get by-label "resume"))
+    (is (= [:abort :resume] @hit))))
+
 (deftest the-status-line-says-whether-there-is-a-server
   (is (re-find #"(?i)offline|disconnect|no server"
                (texts (render :widget/status {:connected? false} {}))))
@@ -301,6 +370,30 @@
     (is (not (str/includes? said "migrate now?"))
         "the next question waits its turn")))
 
+(deftest a-question-with-no-options-is-answered-in-words
+  ;; ask_human's `normalize` accepts a bare string and gives it no options —
+  ;; and an open-ended question is the ordinary use of a tool by that name.
+  ;; Rendered as a menu that has nothing in it, that question could not be
+  ;; answered at all: the branch sat parked for the whole :wait-ms and came
+  ;; back "unanswered".
+  (let [answered (atom nil)
+        free {:id "q9" :kind "question"
+              :questions [{:question "what should I name the module?" :options []}]}
+        out (render :widget/approvals
+                    {:approvals [free] :on {:answer #(reset! answered %&)}} {})]
+    (is (str/includes? (texts out) "what should I name the module?"))
+    (is (empty? (nodes-of :menu out)) "no menu, because there is nothing to pick from")
+    (let [box (first (nodes-of :input out))]
+      (is (some? box) "an editor instead")
+      ((:on-enter (props-of box)) "mycelium")
+      (is (= ["q9" 0 ["mycelium"]] (vec @answered))
+          "and what was typed is the answer"))))
+
+(deftest a-question-with-options-still-gets-a-menu-not-a-text-box
+  (let [out (render :widget/approvals {:approvals [question]} {})]
+    (is (seq (nodes-of :menu out)))
+    (is (empty? (nodes-of :input out)))))
+
 (deftest the-questionnaire-advances-and-answers
   (let [answered (atom nil)
         state {:approvals [question] :question-cursor 1
@@ -315,6 +408,22 @@
           "the earlier answer is carried, not lost on the way to the last"))))
 
 ;; --- the property that matters most -----------------------------------------
+
+(deftest every-handler-the-loop-offers-has-a-caller
+  ;; The ratchet for the defect that made this review worth doing. :abort,
+  ;; :resume and :select-branch sat in the handler map, were documented in
+  ;; tui.edn's widget table, and had nothing on screen that called them —
+  ;; and no test could see it, because both halves were correct alone. Read
+  ;; off the source because that is where the seam is: a widget reaches the
+  ;; loop only by naming a key, and a key nothing names is dead.
+  (let [src (slurp "tui/samizdat/tui/widgets.clj")
+        called (set (map (comp keyword second)
+                         (re-seq #"\[:on :([a-z-]+)\]" src)))]
+    (is (= st/handler-keys called)
+        (str "handlers with no widget calling them: "
+             (pr-str (clojure.set/difference st/handler-keys called))
+             "; widgets calling handlers the loop does not offer: "
+             (pr-str (clojure.set/difference called st/handler-keys))))))
 
 (deftest every-widget-draws-something-from-an-empty-state
   ;; The first frame, before any poll has answered, is the state every user

--- a/tui/samizdat/tui/core.clj
+++ b/tui/samizdat/tui/core.clj
@@ -29,10 +29,13 @@
   shows arrives through `samizdat.api.client` and everything it does goes
   back through a POST.
 
-  THE LAYOUT IS RE-READ EVERY FRAME. `resources/tui.edn` is userspace, so the
-  agent can rearrange its own UI while it runs and the next frame shows it —
-  that is the point of the file, and a layout cached at startup would make it
-  a lie. Reading it is a cached userspace lookup, not a file read."
+  THE LAYOUT IS RE-READ EVERY FRAME, and it comes from three places in
+  order: a local file a person edits, the version the harness serves (the
+  agent's, saved into the project), and the shipped template. That is the
+  point of the file — a layout fixed at startup would make every claim about
+  editing the UI while it runs a lie — and `samizdat.tui.layout` keeps it
+  cheap: the file is re-read only when its mtime moves, and the served body
+  is parsed once, when it arrives."
   (:require [clojure.string :as str]
             [ftxui.core :as ui]
             [samizdat.api.client :as client]
@@ -101,11 +104,17 @@
     (future (poll-once!))))
 
 (defn- answer!
-  "Record an answer to a questionnaire, and submit once the last one is in."
+  "Record an answer to a questionnaire, and submit once the last one is in.
+
+  `swap!` rather than reading and `reset!`ting: the poller writes into this
+  same atom every interval, and a reset would discard whichever poll landed
+  between the read and the write."
   [id _i answers]
-  (let [[next-state done?] (st/answer-question @state answers)]
-    (reset! state next-state)
-    (when done?
+  (let [done? (volatile! false)]
+    (swap! state (fn [s] (let [[next d] (st/answer-question s answers)]
+                           (vreset! done? d)
+                           next)))
+    (when @done?
       (let [r (client/decide! (:base @state) id {:decision :answer :answers answers})]
         (swap! state st/note-error (when-not (:ok r) (:error r)))
         (future (poll-once!))))))
@@ -133,6 +142,11 @@
   is the one that must not wait."
   []
   (let [base (:base @state)]
+    ;; The layout the harness holds, so a version the agent saved for itself
+    ;; reaches the screen. Only on success: an outage must not blank the
+    ;; arrangement that is already drawn.
+    (let [r (client/layout base)]
+      (when (:ok r) (layout/serve! (get-in r [:body :layout]))))
     (swap! state st/apply-runs (client/list-runs base))
     (when-let [rid (:run-id @state)]
       ;; The cursor is read here, after apply-runs may have selected a run —
@@ -202,12 +216,24 @@
 
 (defn- on-event
   "Global keys. Everything else — clicks, arrows, text — belongs to whichever
-  widget has the focus, so this consumes as little as it can."
+  widget has the focus, so this consumes as little as it can.
+
+  `y`/`n` are the exception, and only while a permission dialog is up: the
+  buttons are labelled `allow (y)` and `deny (n)`, and a label that names a
+  key has to mean it. `state/pending-decision` decides whether there is such
+  a dialog — over a questionnaire's answer box a `y` is a letter being
+  typed, and it goes through untouched."
   [{:keys [type key char control]}]
   (cond
     (and (= :key type) (= :ctrl-c key)) (do (ui/exit!) true)
     (and (= :character type) control (= "q" char)) (do (ui/exit!) true)
     (and (= :key type) (= :f5 key)) (do (future (poll-once!)) true)
+
+    (and (= :character type) (not control))
+    (if-let [[id d] (st/pending-decision @state char)]
+      (do (decide! id d) true)
+      false)
+
     :else false))
 
 (defn -main [& args]

--- a/tui/samizdat/tui/core.clj
+++ b/tui/samizdat/tui/core.clj
@@ -1,0 +1,222 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.core
+  "The terminal UI: the loop, the pollers, and the handlers.
+
+  This is the only namespace under `tui/` that knows ftxui exists. Everything
+  else — the state fold, the widgets, the layout — is data and pure
+  functions, which is why the suite covers them with no terminal. What is
+  left here is wiring, and it is small on purpose.
+
+  Strictly an HTTP client of the server, like the GUI: this process holds no
+  engines, no database handle and no run state of its own. Everything it
+  shows arrives through `samizdat.api.client` and everything it does goes
+  back through a POST.
+
+  THE LAYOUT IS RE-READ EVERY FRAME. `resources/tui.edn` is userspace, so the
+  agent can rearrange its own UI while it runs and the next frame shows it —
+  that is the point of the file, and a layout cached at startup would make it
+  a lie. Reading it is a cached userspace lookup, not a file read."
+  (:require [clojure.string :as str]
+            [ftxui.core :as ui]
+            [samizdat.api.client :as client]
+            [samizdat.tui.layout :as layout]
+            [samizdat.tui.state :as st]
+            ;; Registers every :widget/* as a side effect of loading. Without
+            ;; this require the layout resolves nothing and every panel draws
+            ;; a "no widget" complaint.
+            [samizdat.tui.widgets]))
+
+(defn default-base-url
+  "Where the server is. Defaults to the same port `jolt serve` does, so the
+  TUI finds a default server with no configuration; `SAMIZDAT_URL` points it
+  elsewhere, and `HARNESS_PORT` alone is enough when only the port moved."
+  []
+  (or (System/getenv "SAMIZDAT_URL")
+      (str "http://127.0.0.1:" (or (System/getenv "HARNESS_PORT") "3985"))))
+
+;; An ftxui atom, so a write from a poller thread redraws by itself. Plain
+;; swap! from anywhere is safe: refresh! is thread-safe and every event ends
+;; in a draw.
+(defonce state (ui/atom (st/initial (default-base-url))))
+
+;; The handlers below force a poll after acting, and the poller is defined
+;; further down where it belongs beside the loop.
+(declare poll-once!)
+
+;; --- what the user can do ----------------------------------------------------
+
+(defn- steer!
+  "Send the compose box as an intervention. Not a chat message: samizdat runs
+  autonomously and a person steers at a turn boundary, so this is the same
+  seam the supervisor uses."
+  [text]
+  (let [{:keys [base run-id branch-id]} @state]
+    (when-let [payload (st/steer-payload text)]
+      (if-not run-id
+        (swap! state st/note-error "no run selected")
+        (let [r (client/intervene! base run-id {:branch-id branch-id
+                                                :kind "message"
+                                                :payload payload})]
+          (swap! state #(-> % (st/note-error (when-not (:ok r) (:error r)))
+                            (cond-> (:ok r) st/clear-input))))))))
+
+(defn- abort! []
+  (let [{:keys [base run-id]} @state]
+    (when run-id
+      (let [r (client/abort! base run-id)]
+        (swap! state st/note-error (when-not (:ok r) (:error r)))))))
+
+(defn- resume! []
+  (let [{:keys [base run-id]} @state]
+    (when run-id
+      (let [r (client/resume! base run-id)]
+        (swap! state st/note-error (when-not (:ok r) (:error r)))))))
+
+(defn- decide!
+  "Answer a permission question. The branch is parked on this, so a failure
+  has to be visible rather than swallowed — the run would otherwise sit
+  there until the deadline with nobody knowing the click did nothing."
+  [id decision]
+  (let [r (client/decide! (:base @state) id {:decision decision})]
+    (swap! state st/note-error (when-not (:ok r) (:error r)))
+    ;; Poll straight away rather than waiting out the interval: the whole
+    ;; point of this dialog is that somebody is watching it.
+    (future (poll-once!))))
+
+(defn- answer!
+  "Record an answer to a questionnaire, and submit once the last one is in."
+  [id _i answers]
+  (let [[next-state done?] (st/answer-question @state answers)]
+    (reset! state next-state)
+    (when done?
+      (let [r (client/decide! (:base @state) id {:decision :answer :answers answers})]
+        (swap! state st/note-error (when-not (:ok r) (:error r)))
+        (future (poll-once!))))))
+
+(def ^:private handlers
+  "What the widgets can do, handed to them in the state. Widgets stay pure
+  functions and a test drives a click by passing recording functions here."
+  {:decide        decide!
+   :answer        answer!
+   :toggle        #(swap! state st/toggle-fold %)
+   :select-run    #(swap! state st/select-run %)
+   :select-branch #(swap! state st/select-branch %)
+   :input         #(swap! state st/set-input %)
+   :submit        steer!
+   :abort         abort!
+   :resume        resume!})
+
+;; --- the pollers -------------------------------------------------------------
+
+(defn- poll-once!
+  "One pass over every feed, folded into the state.
+
+  Ordered cheapest-first and each fold is independent, so a slow branch
+  detail does not hold up the step trace — the panel that moves most often
+  is the one that must not wait."
+  []
+  (let [base (:base @state)]
+    (swap! state st/apply-runs (client/list-runs base))
+    (when-let [rid (:run-id @state)]
+      ;; The cursor is read here, after apply-runs may have selected a run —
+      ;; reading it before would use the previous run's number on the first
+      ;; pass after a switch.
+      (swap! state st/apply-steps (client/steps-since base rid (:steps-cursor @state)))
+      ;; Before the detail: a branch parked on a question is a branch doing
+      ;; nothing, so the dialog is the panel that must not wait behind a
+      ;; slow response.
+      (swap! state st/apply-approvals (client/approvals base rid))
+      (swap! state st/apply-detail (client/run-detail base rid))
+      (when-let [bid (:branch-id @state)]
+        (swap! state st/apply-branch (client/branch-detail base rid bid))
+        ;; The prose, a turn at a time, for the newest turns only — the
+        ;; branch listing drops it because it is the bulk. How many is a
+        ;; userspace number, since how far back a reader wants to scroll is
+        ;; their business and not the harness's.
+        (doseq [n (st/prose-wanted @state (:prose-turns (layout/current) 12))]
+          (swap! state st/apply-turn-text n (client/turn-detail base rid bid n)))))))
+
+(defonce ^:private poller (atom nil))
+
+(defn start-polling!
+  "Tail the server on a background thread until `stop-polling!`.
+
+  The interval backs off on failure through the same policy the GUI's poll
+  loop uses, so a TUI left open against a stopped server is not hammering
+  it. Never throws out of the loop: a poller that died would leave a UI that
+  looks live and is frozen, which is the failure this project keeps finding."
+  []
+  (when-not @poller
+    (let [running (atom true)
+          t (Thread.
+             (fn []
+               (while @running
+                 (try (poll-once!)
+                      (catch Throwable e
+                        (swap! state st/note-error (ex-message e))))
+                 (Thread/sleep (if (:connected? @state)
+                                 client/base-interval-ms
+                                 client/max-backoff-ms))))
+             "samizdat-tui-poller")]
+      (.setDaemon t true)
+      (reset! poller {:running running :thread t})
+      (.start t)))
+  nil)
+
+(defn stop-polling! []
+  (when-let [{:keys [running]} @poller]
+    (reset! running false)
+    (reset! poller nil))
+  nil)
+
+;; --- the frame ---------------------------------------------------------------
+
+(defn root
+  "One frame: read the layout, expand its widgets against the state, draw.
+
+  Re-read every frame so a runtime edit to tui.edn takes effect on the next
+  one. `layout/current` never throws and never returns something undrawable —
+  a broken edit falls back to the shipped layout and reports itself in the
+  status line rather than taking the screen."
+  []
+  (let [{:keys [layout error]} (layout/current)
+        s (assoc @state :on handlers :layout-error error)]
+    (layout/expand layout s)))
+
+(defn- on-event
+  "Global keys. Everything else — clicks, arrows, text — belongs to whichever
+  widget has the focus, so this consumes as little as it can."
+  [{:keys [type key char control]}]
+  (cond
+    (and (= :key type) (= :ctrl-c key)) (do (ui/exit!) true)
+    (and (= :character type) control (= "q" char)) (do (ui/exit!) true)
+    (and (= :key type) (= :f5 key)) (do (future (poll-once!)) true)
+    :else false))
+
+(defn -main [& args]
+  (let [base (or (first (remove str/blank? args)) (default-base-url))]
+    (swap! state assoc :base base)
+    (println "samizdat tui →" base)
+    (start-polling!)
+    (try
+      ;; Mouse on: the folds in the conversation are ftxui collapsibles and
+      ;; clicking one is how they open.
+      (ui/run root :mode :fullscreen :mouse true :on-event on-event)
+      (finally (stop-polling!)))))

--- a/tui/samizdat/tui/layout.clj
+++ b/tui/samizdat/tui/layout.clj
@@ -21,9 +21,9 @@
 
   The core owns the first: a conversation log knows how to fold a diff, the
   activity log knows the trace is manifest states. `resources/tui.edn` owns
-  the second, and it is userspace — read through the same seam as gates.edn
-  and the manifests, versioned in the project, and editable by the agent
-  while it runs.
+  the second, and it is userspace — versioned in the project alongside
+  gates.edn and the manifests, editable by a person as a file and by the
+  agent as a stored version, both of them while it runs.
 
   The file is hiccup. Every tag is ftxui's own except `:widget/*`, each of
   which stands in for one widget the core implements; `expand` replaces those
@@ -43,11 +43,29 @@
   The alternative is a UI that black-screens on the edit whose damage it is
   the only tool for seeing.
 
+  WHERE THE LAYOUT COMES FROM. Three sources, most local first:
+
+  1. a FILE, `SAMIZDAT_TUI_LAYOUT` or `.samizdat/tui.edn` beside the run —
+     what a person edits, re-read whenever its mtime moves, so an edit shows
+     up on the next frame with no restart;
+  2. what the HARNESS SERVES, `GET /v1/harness/layout`, folded in by the
+     poller — the project's stored `tui` policy, which is how the agent
+     rearranges its own UI: the server is bound to the project and can read
+     that row, and this process is a strict HTTP client that cannot;
+  3. the SHIPPED template off the classpath, which is what draws offline and
+     on the first frame.
+
+  This used to be one source, `userspace/edn-body`, and it could not work:
+  a front end binds no project, so that read fell through to the classpath
+  template every time, and userspace's read cache — invalidated only by a
+  write, which a front end never makes — then pinned it for the life of the
+  process. Every claim about editing the UI while it runs was false, in both
+  directions.
+
   Toolkit-free on purpose: hiccup is data, so everything here is covered by
   the suite with no terminal and no ftxui."
   (:require [clojure.edn :as edn]
-            [clojure.java.io :as io]
-            [samizdat.userspace :as userspace]))
+            [clojure.java.io :as io]))
 
 ;; --- the registry ------------------------------------------------------------
 ;;
@@ -135,10 +153,10 @@
 (defn template
   "The shipped layout, straight off the classpath.
 
-  Read here rather than through the userspace seam because this is the
-  fallback: a project whose stored layout is broken needs the file, and
-  going back through the seam that just served the broken one to get it
-  would be circular."
+  The last of the three sources and the fallback for the other two: a
+  project whose stored layout is broken needs the file, and asking the
+  source that just served the broken one to supply the replacement would be
+  circular."
   []
   (some-> (io/resource "tui.edn") slurp edn/read-string))
 
@@ -165,16 +183,80 @@
                          (if (nil? l) "absent" (pr-str (type l)))
                          "); showing the shipped layout")))))
 
-(defn current
-  "The project's layout, validated, falling back to the shipped one.
+;; --- the three sources -------------------------------------------------------
 
-  Through `userspace/edn-body`, so a project seeds its own copy on first read
-  and the agent's edits to it take effect on the next load. Unparseable EDN
-  is caught here rather than left to throw: a half-written file is exactly
-  what a runtime edit looks like for the instant it is being saved."
+(defn- parse
+  "An EDN layout body as a spec, or a spec carrying only the complaint.
+
+  Never throws. A half-written file is exactly what a runtime edit looks like
+  for the instant it is being saved, and the tool for seeing the damage must
+  not be the thing the damage takes out."
+  [body what]
+  (try
+    (let [v (edn/read-string (str body))]
+      (if (map? v) v {:error (str what " is not a map of layout settings")}))
+    (catch Throwable e
+      {:error (str what " did not parse: " (ex-message e))})))
+
+;; The body the harness last served, already parsed. Written by the poller
+;; through `serve!`; nil until the first successful fetch, and left alone by
+;; a failed one — an outage must not cost the layout that is on screen.
+(defonce ^:private served (atom nil))
+
+(defn serve!
+  "Take the layout body `GET /v1/harness/layout` returned. nil clears it."
+  [body]
+  (reset! served (when (not-empty (str body)) (parse body "the harness's tui.edn")))
+  nil)
+
+(defn file-path
+  "Where a person's own layout lives, if they have one.
+
+  `SAMIZDAT_TUI_LAYOUT` names it outright; otherwise `.samizdat/tui.edn`
+  beside the project, which is where the harness already keeps the files a
+  person and the agent both edit in place."
   []
-  (validate
-   (or (try (userspace/edn-body :policy "tui")
-            (catch Throwable e
-              {:error (str "tui.edn did not parse: " (ex-message e))}))
-       {})))
+  (or (not-empty (str (System/getenv "SAMIZDAT_TUI_LAYOUT")))
+      ".samizdat/tui.edn"))
+
+;; {:path :stamp :spec} — so the common case is a stat and not a parse. The
+;; stamp is mtime AND length: `lastModified` is milliseconds, and an edit
+;; saved inside one of them would otherwise not be seen.
+(defonce ^:private file-cache (atom nil))
+
+(defn forget-file!
+  "Drop the file cache, so the next read goes to disk. For tests."
+  []
+  (reset! file-cache nil)
+  nil)
+
+(defn- from-file
+  "The layout in `path`, re-read whenever its mtime moves. nil when there is
+  no such file.
+
+  A spec that FAILED to parse is not cached: a torn read of a file being
+  written would otherwise be remembered as the answer, and the finished
+  write — which need not change the mtime again — would never be seen."
+  [path]
+  (let [f (io/file (str path))]
+    (when (.isFile f)
+      (let [stamp [(.lastModified f) (.length f)]
+            c @file-cache]
+        (if (and (= (str path) (:path c)) (= stamp (:stamp c)))
+          (:spec c)
+          (let [spec (try (parse (slurp f) (str path))
+                          (catch Throwable e {:error (str path ": " (ex-message e))}))]
+            (when-not (:error spec)
+              (reset! file-cache {:path (str path) :stamp stamp :spec spec}))
+            spec))))))
+
+(defn current
+  "The layout to draw: the local file, else what the harness serves, else the
+  shipped template — validated, so a broken one costs its own panel and a
+  line in the status bar rather than the screen.
+
+  Cheap enough to call every frame, which is the point: the file is re-read
+  only when its mtime moves, and the served body was parsed when it arrived."
+  ([] (current (file-path)))
+  ([path]
+   (validate (or (from-file path) @served (template) {}))))

--- a/tui/samizdat/tui/layout.clj
+++ b/tui/samizdat/tui/layout.clj
@@ -1,0 +1,180 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.layout
+  "The seam between what the widgets ARE and how they are ARRANGED.
+
+  The core owns the first: a conversation log knows how to fold a diff, the
+  activity log knows the trace is manifest states. `resources/tui.edn` owns
+  the second, and it is userspace — read through the same seam as gates.edn
+  and the manifests, versioned in the project, and editable by the agent
+  while it runs.
+
+  The file is hiccup. Every tag is ftxui's own except `:widget/*`, each of
+  which stands in for one widget the core implements; `expand` replaces those
+  and leaves the rest alone. That is the whole mechanism, and it is why a
+  user can put two conversation panes side by side without anyone having
+  added a feature for it.
+
+  DEGRADE, NEVER THROW. This file's whole reason for being userspace is that
+  it gets edited at runtime, so every failure mode here is a rendering:
+
+  - a `:widget/*` tag nothing implements draws a named complaint in its own
+    box and its neighbours are untouched;
+  - a widget that throws is contained to its own box, with the message;
+  - a layout that is not hiccup at all falls back to the shipped template and
+    reports why.
+
+  The alternative is a UI that black-screens on the edit whose damage it is
+  the only tool for seeing.
+
+  Toolkit-free on purpose: hiccup is data, so everything here is covered by
+  the suite with no terminal and no ftxui."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [samizdat.userspace :as userspace]))
+
+;; --- the registry ------------------------------------------------------------
+;;
+;; Populated by samizdat.tui.widgets, which requires this namespace — the
+;; dependency runs that way so a widget can be added without editing the
+;; loader, and so this namespace stays loadable on its own for the layout
+;; tests. Each entry is (fn [state props] -> hiccup).
+
+(defonce widgets (atom {}))
+
+(defn register!
+  "Add a widget under its `:widget/*` tag."
+  [tag f]
+  (swap! widgets assoc tag f)
+  nil)
+
+(defn widget-tag?
+  "Whether `x` is a tag this namespace resolves rather than passes through."
+  [x]
+  (and (keyword? x) (= "widget" (namespace x))))
+
+;; --- expansion ---------------------------------------------------------------
+
+(defn- complaint
+  "A widget-shaped box saying what went wrong, drawn where the widget was.
+
+  Bordered and titled rather than a bare line: it stands where a panel
+  stood, and an operator scanning a broken layout should be able to see
+  which panel is missing without reading the text."
+  [title detail]
+  [:vbox {:border :rounded :color :red}
+   [:text {:bold true} title]
+   [:text detail]])
+
+(defn- call-widget
+  [tag props state registry]
+  (if-let [f (get registry tag)]
+    (try
+      (f state (or props {}))
+      (catch Throwable e
+        (complaint (str tag " failed")
+                   (or (ex-message e) (str (class e))))))
+    (complaint (str "no widget " tag)
+               "not implemented in this build")))
+
+(defn expand
+  "`form` with every `:widget/*` tag replaced by what its widget renders.
+
+  `state` is the whole view state — a widget takes what it needs from it, so
+  the layout never has to name data, only widgets. `registry` defaults to the
+  registered widgets."
+  ([form state] (expand form state @widgets))
+  ([form state registry]
+   (cond
+     ;; A hiccup element whose tag is ours: props are the second element when
+     ;; it is a map, exactly as hiccup reads them everywhere else.
+     (and (vector? form) (widget-tag? (first form)))
+     (let [props (when (map? (second form)) (second form))]
+       (call-widget (first form) props state registry))
+
+     (vector? form)
+     (mapv #(expand % state registry) form)
+
+     ;; Seqs are spliced by ftxui, so a (for ...) in a layout has to survive
+     ;; the walk as a seq rather than becoming a vector in props position.
+     (seq? form)
+     (map #(expand % state registry) form)
+
+     :else form)))
+
+(defn widget-tags
+  "Every `:widget/*` tag named anywhere in `form`, as a set."
+  [form]
+  (cond
+    (and (vector? form) (widget-tag? (first form)))
+    (into #{(first form)} (mapcat widget-tags (rest form)))
+
+    (or (vector? form) (seq? form))
+    (into #{} (mapcat widget-tags form))
+
+    :else #{}))
+
+;; --- loading -----------------------------------------------------------------
+
+(defn template
+  "The shipped layout, straight off the classpath.
+
+  Read here rather than through the userspace seam because this is the
+  fallback: a project whose stored layout is broken needs the file, and
+  going back through the seam that just served the broken one to get it
+  would be circular."
+  []
+  (some-> (io/resource "tui.edn") slurp edn/read-string))
+
+(defn- drawable?
+  "Whether `x` could be an ftxui element. A vector with a keyword tag is the
+  only shape the renderer can start from."
+  [x]
+  (and (vector? x) (seq x) (keyword? (first x))))
+
+(defn validate
+  "`spec` if its `:layout` can be drawn; otherwise the template's, with
+  `:error` saying what was wrong.
+
+  Returns the spec either way. The caller draws what comes back and shows
+  `:error` if there is one — an operator whose edit did not take needs to be
+  told, and told without losing the UI."
+  [spec]
+  (let [l (:layout spec)]
+    (if (drawable? l)
+      (dissoc spec :error)
+      (assoc spec
+             :layout (:layout (template))
+             :error (str "tui.edn :layout is not a hiccup element ("
+                         (if (nil? l) "absent" (pr-str (type l)))
+                         "); showing the shipped layout")))))
+
+(defn current
+  "The project's layout, validated, falling back to the shipped one.
+
+  Through `userspace/edn-body`, so a project seeds its own copy on first read
+  and the agent's edits to it take effect on the next load. Unparseable EDN
+  is caught here rather than left to throw: a half-written file is exactly
+  what a runtime edit looks like for the instant it is being saved."
+  []
+  (validate
+   (or (try (userspace/edn-body :policy "tui")
+            (catch Throwable e
+              {:error (str "tui.edn did not parse: " (ex-message e))}))
+       {})))

--- a/tui/samizdat/tui/state.clj
+++ b/tui/samizdat/tui/state.clj
@@ -1,0 +1,225 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.state
+  "The view state: what the pollers fold into and what the widgets read.
+
+  Every function here is pure, which is what leaves the run loop as wiring
+  and puts the TUI's actual policy — cursors, what a disconnect does, what
+  changing run resets — under test with no terminal and no server.
+
+  The state is one flat map on purpose. A widget takes what it needs from it
+  and the layout never has to name data, only widgets; that is what lets a
+  user put a panel anywhere without anything being rewired."
+  (:require [clojure.string :as str]))
+
+(def max-trace
+  "How many steps the UI holds. The server's ring is bounded and so is this:
+  a TUI left running for a day would otherwise keep every step of every run
+  it watched."
+  500)
+
+(defn initial [base]
+  {:base base
+   :connected? false
+   :error nil
+   :layout-error nil
+   :runs []
+   :run-id nil
+   :detail nil
+   :branch-id nil
+   :branch nil
+   :trace []
+   :steps-cursor 0
+   :trace-dropped 0
+   :journal-cursor 0
+   :turn-text {}
+   :approvals []
+   :approval-id nil
+   :question-cursor 0
+   :question-answers []
+   :expanded #{}
+   :input ""})
+
+;; --- folding what the pollers fetch -----------------------------------------
+
+(defn- connected [s]
+  (assoc s :connected? true :error nil))
+
+(defn- disconnected [s {:keys [error]}]
+  ;; Cursors and everything already drawn survive: the point of a cursor is
+  ;; that an outage costs nothing, and a panel that blanked on a dropped
+  ;; connection would lose the history that says what happened before it.
+  (assoc s :connected? false :error (or error "no server")))
+
+(defn apply-steps
+  "Fold a steps tail into the trace.
+
+  `dropped` ACCUMULATES. The server reports what this client missed on that
+  response; two polls that each missed some have missed the sum, and a panel
+  shown only the latest would understate the hole in the trace."
+  [s {:keys [ok body] :as r}]
+  (if-not ok
+    (disconnected s r)
+    (let [steps (vec (:steps body))]
+      (-> s
+          connected
+          (update :trace (fn [t] (let [t (into (vec t) steps)]
+                                   (if (> (count t) max-trace)
+                                     (subvec t (- (count t) max-trace))
+                                     t))))
+          (assoc :steps-cursor (or (:next body) (:steps-cursor s) 0))
+          (update :trace-dropped + (or (:dropped body) 0))))))
+
+(defn- active-branch
+  "The branch to open a run on: the one that is running, else the first.
+
+  Opening a run and being shown nothing until you click is a worse first
+  frame than opening it on the branch that is working."
+  [branches]
+  (or (:id (first (filter #(= "active" (str (:status %))) branches)))
+      (:id (first branches))))
+
+(defn apply-detail
+  "Fold the run detail — the row, branches, artifacts, gates, board, files."
+  [s {:keys [ok body] :as r}]
+  (if-not ok
+    (disconnected s r)
+    (-> s
+        connected
+        (assoc :detail body)
+        ;; Only when nothing is chosen. Re-picking on every poll would drag
+        ;; the user off whichever branch they were reading the moment another
+        ;; one became active.
+        (update :branch-id #(or % (active-branch (:branches body)))))))
+
+(defn apply-branch
+  [s {:keys [ok body] :as r}]
+  (if-not ok
+    (disconnected s r)
+    (-> s connected (assoc :branch body))))
+
+(defn apply-approvals
+  "Fold the questions waiting on a person.
+
+  The cursor and the answers collected so far are reset when the question at
+  the head CHANGES — a questionnaire half answered must survive the poll that
+  arrives in the middle of answering it, and a new question must not inherit
+  the previous one's position."
+  [s {:keys [ok body] :as r}]
+  (if-not ok
+    (disconnected s r)
+    (let [as (vec (:approvals body))
+          head (:id (first as))]
+      (cond-> (assoc (connected s) :approvals as)
+        (not= head (:approval-id s))
+        (assoc :approval-id head :question-cursor 0 :question-answers [])))))
+
+(defn answer-question
+  "Record an answer and move to the next question, or say the set is done.
+
+  Returns `[state done?]` — the caller sends the answers only when done?, so
+  a half-answered questionnaire is never submitted."
+  [s answers]
+  (let [total (count (:questions (first (:approvals s))))
+        next-i (count answers)]
+    [(assoc s :question-answers (vec answers) :question-cursor (min next-i (dec total)))
+     (>= next-i total)]))
+
+(defn apply-turn-text
+  "Fold one turn's full row — the prose the branch listing leaves out.
+
+  A failure leaves what is already held alone. The text does not change
+  after the turn is recorded, so a fetch that fails is a fetch to retry, not
+  a reason to blank the words a reader is in the middle of."
+  [s turn {:keys [ok body]}]
+  (if ok
+    (assoc-in s [:turn-text turn] body)
+    s))
+
+(defn prose-wanted
+  "Which turns to fetch prose for: the newest `n` on the branch that are not
+  already held.
+
+  Bounded, and newest-first, because that is what a reader is following — a
+  run of four hundred turns must not fetch four hundred bodies every poll,
+  and the ones being read are at the bottom."
+  [s n]
+  (let [held (set (keys (:turn-text s)))]
+    (->> (get-in s [:branch :turns])
+         (map :turn)
+         (remove held)
+         (sort)
+         (take-last n)
+         vec)))
+
+(defn apply-runs
+  [s {:keys [ok body] :as r}]
+  (if-not ok
+    (disconnected s r)
+    (-> s
+        connected
+        (assoc :runs (vec (:runs body)))
+        ;; The server lists newest first, so the first is the one someone
+        ;; opening the TUI almost always wants — but never over a choice
+        ;; they already made.
+        (update :run-id #(or % (:id (first (:runs body))))))))
+
+;; --- what the user does ------------------------------------------------------
+
+(defn select-run
+  "Switch runs, dropping everything that belonged to the last one.
+
+  Cursors especially. Carrying a cursor across a run change opened the new
+  run's panels showing the old run's steps and then skipped everything
+  before the stale number."
+  [s run-id]
+  (assoc s
+         :run-id run-id
+         :detail nil
+         :branch-id nil
+         :branch nil
+         :trace []
+         :steps-cursor 0
+         :trace-dropped 0
+         :journal-cursor 0
+         ;; Turn numbers restart per branch, so prose kept across a switch
+         ;; would caption the new run's turn 3 with the old run's words.
+         :turn-text {}))
+
+(defn select-branch [s branch-id]
+  (assoc s :branch-id branch-id :branch nil :turn-text {}))
+
+(defn toggle-fold [s id]
+  (update s :expanded (fn [e] (let [e (set e)]
+                                (if (contains? e id) (disj e id) (conj e id))))))
+
+(defn set-input [s text]
+  (assoc s :input (or text "")))
+
+(defn clear-input [s]
+  (assoc s :input ""))
+
+(defn note-error [s msg]
+  (assoc s :error (when (not-empty (str msg)) (str msg))))
+
+(defn steer-payload
+  "What the compose box sends. Blank is not a directive."
+  [text]
+  (let [t (str/trim (str text))]
+    (when (seq t) t)))

--- a/tui/samizdat/tui/state.clj
+++ b/tui/samizdat/tui/state.clj
@@ -28,6 +28,18 @@
   user put a panel anywhere without anything being rewired."
   (:require [clojure.string :as str]))
 
+(def handler-keys
+  "Every action a widget may ask the loop to take.
+
+  Named here, in the toolkit-free half, so the suite can hold both ends of
+  the seam: that `samizdat.tui.core` offers exactly these, and that some
+  widget calls each one. Three of them — :abort, :resume and :select-branch
+  — were offered and documented for a whole release with nothing on screen
+  that called them, which no test could see because each half was correct on
+  its own."
+  #{:decide :answer :toggle :select-run :select-branch :input :submit
+    :abort :resume})
+
 (def max-trace
   "How many steps the UI holds. The server's ring is bounded and so is this:
   a TUI left running for a day would otherwise keep every step of every run
@@ -153,19 +165,23 @@
     s))
 
 (defn prose-wanted
-  "Which turns to fetch prose for: the newest `n` on the branch that are not
-  already held.
+  "Which turns to fetch prose for: the ones in the newest-`n` WINDOW that are
+  not already held.
 
-  Bounded, and newest-first, because that is what a reader is following — a
-  run of four hundred turns must not fetch four hundred bodies every poll,
-  and the ones being read are at the bottom."
+  The window is chosen first and the held turns are dropped out of it. The
+  other order — the newest n turns that are missing — reads the same and is
+  not: with the window full it asks for the n turns BELOW it, and the poll
+  after that for the n below those, so a four-hundred-turn branch fetched
+  all four hundred bodies over thirty-three polls and held the whole 5.5MB
+  the per-turn endpoint exists to avoid. Bounded means the set stops being
+  asked for, not that each poll asks for a bounded number."
   [s n]
   (let [held (set (keys (:turn-text s)))]
     (->> (get-in s [:branch :turns])
          (map :turn)
-         (remove held)
          (sort)
          (take-last n)
+         (remove held)
          vec)))
 
 (defn apply-runs
@@ -204,6 +220,20 @@
 
 (defn select-branch [s branch-id]
   (assoc s :branch-id branch-id :branch nil :turn-text {}))
+
+(defn pending-decision
+  "What a bare `y`/`n` means right now: `[approval-id decision]`, or nil.
+
+  Only over a yes/no PERMISSION question. A questionnaire's answer box takes
+  characters, and a `y` typed into it is a word being written, not a verdict
+  on a question nobody offered as yes-or-no."
+  [s ch]
+  (let [a (first (:approvals s))]
+    (when (and a (empty? (:questions a)))
+      (case (str ch)
+        "y" [(:id a) :allow]
+        "n" [(:id a) :deny]
+        nil))))
 
 (defn toggle-fold [s id]
   (update s :expanded (fn [e] (let [e (set e)]

--- a/tui/samizdat/tui/widgets.clj
+++ b/tui/samizdat/tui/widgets.clj
@@ -1,0 +1,426 @@
+;; samizdat - a self-hosting agentic harness
+;; Copyright (C) 2026 Dmitri Sotnikov
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+;;
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+(ns samizdat.tui.widgets
+  "The widgets the layout arranges.
+
+  Each is `(fn [state props] -> hiccup)` and registers itself under a
+  `:widget/*` tag. Two rules hold the whole namespace together:
+
+  PURE FUNCTIONS OF STATE. A widget reads the view state and returns hiccup.
+  It never polls, never writes, and never reaches for a connection. What it
+  can DO arrives in the state as `:on` handlers, so a test drives a click by
+  passing a recording function and the suite covers every interaction with
+  no terminal and no server.
+
+  DRAW SOMETHING FROM NOTHING. The first frame — before any poll has
+  answered — is the state every user sees, and the layout that decides which
+  widgets exist is a file the agent edits at runtime. So every widget renders
+  an element for an empty state and for the half-loaded one between them.
+  There is a test that walks the registry and holds this for all of them.
+
+  Toolkit-free: hiccup is data. `ftxui` appears nowhere in this file."
+  (:require [clojure.string :as str]
+            [samizdat.tui.layout :as layout]))
+
+;; --- shared shapes -----------------------------------------------------------
+
+(defn- clip
+  "`s` on one line, no longer than `n`. Panels are narrow and a tool result
+  carries newlines."
+  [s n]
+  (let [one (str/join " " (str/split (str s) #"\s+"))]
+    (if (> (count one) n) (str (subs one 0 (max 0 (dec n))) "…") one)))
+
+(defn- panel
+  "A titled box. Every side panel is one, so a layout that puts two of them
+  in a column gets borders that line up without saying so."
+  [props & children]
+  (into [:vbox (cond-> {:border :rounded}
+                 (:flex props) (assoc :flex true)
+                 (:width props) (assoc :width (:width props)))]
+        (cond-> []
+          (:title props) (conj [:text {:bold true} (str " " (:title props) " ")]
+                               [:separator])
+          :always (into (remove nil? children)))))
+
+(defn- empty-note
+  "What a panel says when it has nothing. Dim rather than blank: a panel that
+  drew nothing is indistinguishable from one that failed to draw."
+  [s]
+  [:text {:dim true} (str "  " s)])
+
+(defn fold-id
+  "The identity of one foldable section, stable across frames.
+
+  Keyed by the turn and the section, never by a position in a list — the
+  conversation grows, and an id that moved would shut every open fold on the
+  turn after it was opened."
+  [turn section]
+  (str turn "/" (name section)))
+
+(defn- toggle-fn
+  "The click handler for a fold. Absent handlers are tolerated: a widget
+  rendered by a test, or in a frame before the loop wired itself, still
+  draws."
+  [state id]
+  (fn [_open?] (when-let [f (get-in state [:on :toggle])] (f id))))
+
+(defn- fold
+  "A collapsible section: header always visible, body a click away.
+
+  ftxui's own `:collapsible`, so the mouse works on it for free — this is
+  the widget FTXUI already opens and closes on a click, and wiring our own
+  hit-testing over a `:text` would be re-implementing it worse."
+  [state id label body]
+  [:collapsible {:label label
+                 :show (contains? (set (:expanded state)) id)
+                 :on-change (toggle-fn state id)}
+   body])
+
+;; --- the activity log --------------------------------------------------------
+
+(defn- step-line [{:keys [node cell transition ms failed]}]
+  [:hbox
+   [:text {:color (if failed :red :cyan)} (if failed " ✗ " " · ")]
+   [:text {:bold true} (clip node 12)]
+   [:text {:dim true} (str " " (clip (or cell "") 16)
+                           (when transition (str " →" (clip transition 8)))
+                           (when ms (str " " ms "ms")))]])
+
+(defn activity
+  "The ACTIVITY LOG: the manifest states the agent is walking.
+
+  This is the one deliberate departure from the UI it was ported from.
+  dirge's activity panel is a ticker of tool calls; samizdat's workflow is a
+  state machine written in a file the agent can edit, so what an operator
+  wants to watch is the graph being walked — :start, :measure, :infer,
+  :parse, :dispatch, :journal, :settle, :arbiter, :route — with the cell
+  behind each state, because the cell is the thing they would edit.
+
+  Newest LAST, so it grows downward toward the compose box the way the
+  conversation does."
+  [state props]
+  (let [trace (vec (:trace state))
+        dropped (:trace-dropped state)]
+    (panel props
+           (when (and dropped (pos? dropped))
+             [:text {:color :yellow} (str "  ⚠ " dropped " step(s) dropped")])
+           (if (seq trace)
+             (into [:vbox {:flex true}] (map step-line trace))
+             (empty-note "no steps yet")))))
+
+;; --- the conversation --------------------------------------------------------
+
+(defn- diff-line
+  "One line of a write result, coloured when it reads as a diff. How a reader
+  tells an edit that landed from one that replaced the wrong thing."
+  [line]
+  (cond
+    (str/starts-with? line "+") [:text {:color :green} line]
+    (str/starts-with? line "-") [:text {:color :red} line]
+    :else [:text line]))
+
+(defn- body-block
+  "A result or an argument blob, as lines. Diff-coloured when `diff?`."
+  [s diff?]
+  (let [lines (str/split-lines (str s))]
+    (into [:vbox] (map (if diff? diff-line (fn [l] [:text l])) lines))))
+
+(defn- failed? [turn]
+  (contains? #{"failure" "mechanics"} (str (:category turn))))
+
+(defn- turn-entry
+  [state {:keys [turn tool_name args result] :as t}]
+  (let [writing? (contains? #{"write_file" "edit_file" "patch"} (str tool_name))
+        ;; The prose arrives per turn, because the branch listing drops it —
+        ;; it is the bulk of a long run (5.5MB against 62KB of results) and
+        ;; fetching it wholesale timed the branch panel out entirely. So the
+        ;; words come from :turn-text, filled in for the turns on screen.
+        text (get-in state [:turn-text turn])
+        assistant_text (:assistant_text text)
+        reasoning_text (:reasoning_text text)]
+    [:vbox {:key (str turn)}
+     ;; What the model said, in full. Prose is the one thing never folded:
+     ;; it is short, and it is the part a reader is actually following.
+     (when (not-empty (str assistant_text))
+       [:paragraph (str assistant_text)])
+
+     (when (not-empty (str reasoning_text))
+       (fold state (fold-id turn :thinking)
+             (str "thinking (" (count (str reasoning_text)) " chars)")
+             [:paragraph {:dim true} (str reasoning_text)]))
+
+     (when tool_name
+       [:hbox
+        [:text {:color (if (failed? t) :red :green)}
+         (if (failed? t) " ✗ " " → ")]
+        [:text {:bold true} (str tool_name)]
+        [:text {:dim true} (str "  turn " turn)]])
+
+     (when (not-empty (str args))
+       (fold state (fold-id turn :args) "arguments" (body-block args false)))
+
+     (when (not-empty (str result))
+       (fold state (fold-id turn :result)
+             (str "result (" (count (str/split-lines (str result))) " lines)")
+             (body-block result writing?)))
+
+     [:separator {:dim true}]]))
+
+(defn conversation
+  "The agent's turns: what it said, what it called, and what came back.
+
+  Thinking, arguments and results fold, closed by default — a log that
+  opened every tool result is unreadable after three turns, and the header
+  alone is what a reader scans."
+  [state props]
+  (let [turns (vec (get-in state [:branch :turns]))]
+    (panel (assoc props :title (or (:title props)
+                                   (some->> (:branch-id state) (str "BRANCH "))))
+           (if (seq turns)
+             (into [:vbox {:flex true :frame :y :scroll-indicator :v}]
+                   (map #(turn-entry state %) turns))
+             (empty-note "no turns yet — pick a run")))))
+
+;; --- the side panels ---------------------------------------------------------
+
+(def ^:private task-glyph
+  {"in_progress" "▶" "open" "○" "blocked" "⊘" "done" "✓"})
+
+(defn tasks
+  "The board: what is open, what is being worked on, what is blocked."
+  [state props]
+  (let [board (vec (get-in state [:detail :tasks]))]
+    (panel props
+           (if (seq board)
+             (into [:vbox {:flex true :frame :y}]
+                   (for [{:keys [title status]} board]
+                     [:hbox
+                      [:text {:color (if (= "in_progress" status) :yellow :default)}
+                       (str " " (get task-glyph (str status) "·") " ")]
+                      [:text (clip title 26)]
+                      [:text {:dim true} (str " " status)]]))
+             (empty-note "board is empty")))))
+
+(defn files
+  "What this run has changed, most recently first, naming every branch that
+  touched a path — which is the question a beam raises."
+  [state props]
+  (let [mods (vec (get-in state [:detail :modified]))]
+    (panel props
+           (if (seq mods)
+             (into [:vbox {:flex true :frame :y}]
+                   (for [{:keys [path turn branches]} mods]
+                     [:hbox
+                      [:text " "]
+                      [:text (clip path 24)]
+                      [:text {:dim true} (str " t" turn
+                                              (when (seq branches)
+                                                (str " " (str/join "," branches))))]]))
+             (empty-note "nothing written yet")))))
+
+(defn- ratio [used total]
+  (if (and (number? used) (number? total) (pos? total))
+    (double (min 1.0 (/ used total)))
+    0.0))
+
+(defn context
+  "What the run is spending: tokens against its budget, turns against its
+  ceiling. Gauges rather than numbers alone — a ratio is not a number to
+  read."
+  [state props]
+  (let [run (get-in state [:detail :run])
+        ;; KEBAB keys: run-usage builds a Clojure map and the JSON writer
+        ;; emits the keywords it was handed, so the wire carries
+        ;; :total-tokens. The snake spelling read every run as having spent
+        ;; nothing.
+        used (get-in run [:usage :total-tokens])
+        budget (:token_budget run)
+        turns (get-in run [:usage :turns])
+        max-turns (:max_turns run)]
+    (panel props
+           [:vbox
+            [:text {:dim true} (str "  tokens " (or used 0)
+                                    (when budget (str " / " budget)))]
+            [:gauge {:value (ratio used budget)
+                     :color (if (> (ratio used budget) 0.85) :red :cyan)}]
+            [:text {:dim true} (str "  turns  " (or turns 0)
+                                    (when max-turns (str " / " max-turns)))]
+            [:gauge {:value (ratio turns max-turns)}]])))
+
+(defn gates
+  "Which gates have fired, and how many of their predictions are still open —
+  the run's own account of advice it was given and has not yet answered."
+  [state props]
+  (let [gs (vec (get-in state [:detail :gates]))]
+    (panel props
+           (if (seq gs)
+             (into [:vbox {:frame :y}]
+                   (for [{:keys [gate fired open]} gs]
+                     [:hbox
+                      [:text " "]
+                      [:text (clip gate 18)]
+                      [:text {:dim true} (str "  fired " fired)]
+                      [:text {:color (if (pos? (or open 0)) :yellow :default)}
+                       (str "  open " (or open 0))]]))
+             (empty-note "no gates fired")))))
+
+(def ^:private claim-color
+  {"confirmed" :green "refuted" :red "ambiguous" :yellow "existential" :cyan})
+
+(defn artifacts
+  "The claims the run has made and how each was judged. The harness is
+  claim-first, so this is its actual output — the panel that says whether
+  any of the work is standing up."
+  [state props]
+  (let [as (vec (get-in state [:detail :artifacts]))]
+    (panel props
+           (if (seq as)
+             (into [:vbox {:frame :y}]
+                   (for [{:keys [claim claim_status]} as]
+                     [:hbox
+                      [:text {:color (get claim-color (str claim_status) :default)}
+                       (str " " (clip (str claim_status) 11) " ")]
+                      [:text (clip claim 20)]]))
+             (empty-note "no claims yet")))))
+
+(defn runs
+  "The run picker."
+  [state props]
+  (let [rs (vec (:runs state))]
+    (panel props
+           (if (seq rs)
+             [:menu {:entries (mapv #(clip (str (:id %) "  " (:problem %)) 40) rs)
+                     :selected (max 0 (.indexOf (mapv :id rs) (:run-id state)))
+                     :on-enter (fn [i]
+                                 (when-let [f (get-in state [:on :select-run])]
+                                   (f (:id (nth rs i nil)))))}]
+             (empty-note "no runs")))))
+
+;; --- the modals --------------------------------------------------------------
+
+(defn- lines-of
+  "A blob as its own lines, uncut. Used only by the approval dialog, which is
+  the one place in this UI where clipping is the wrong answer."
+  [s]
+  (into [:vbox] (map (fn [l] [:text l]) (str/split-lines (str s)))))
+
+(defn- permission-dialog
+  [state {:keys [id kind input reason details]}]
+  (let [decide (fn [d] (fn [] (when-let [f (get-in state [:on :decide])] (f id d))))]
+    [:vbox {:border :heavy :color :yellow}
+     [:text {:bold true :color :yellow} " ⚠ PERMISSION REQUIRED "]
+     [:separator]
+     [:text {:dim true} (str " tool: " kind)]
+     ;; NOT clipped, unlike every other panel. A person cannot judge
+     ;; `rm -rf "$BUILD"/*` from its first three characters, and a dialog
+     ;; that hid the rest would be asking them to approve something they
+     ;; were not shown.
+     (lines-of input)
+     (when (not-empty (str reason)) [:text {:dim true} (str " why: " reason)])
+     (when (not-empty (str details)) [:text {:dim true} (str " " details)])
+     [:separator]
+     [:hbox
+      [:button {:label "allow (y)" :on-click (decide :allow)}]
+      [:button {:label "deny (n)" :on-click (decide :deny)}]]]))
+
+(defn- questionnaire
+  [state {:keys [id questions]}]
+  (let [qs (vec questions)
+        i (min (or (:question-cursor state) 0) (max 0 (dec (count qs))))
+        q (nth qs i nil)
+        so-far (vec (:question-answers state))]
+    [:vbox {:border :heavy :color :cyan}
+     [:text {:bold true :color :cyan}
+      (str " ? QUESTION " (inc i) " of " (count qs) " ")]
+     [:separator]
+     [:paragraph (str (:question q))]
+     [:menu {:entries (mapv str (:options q))
+             :on-enter (fn [n]
+                         (when-let [f (get-in state [:on :answer])]
+                           ;; Carry what has already been answered. Handing
+                           ;; back only the latest would lose every earlier
+                           ;; answer on the way to the last question.
+                           (f id i (conj so-far (str (nth (:options q) n nil))))))}]]))
+
+(defn approvals
+  "Questions waiting on a person: the permission gate and ask_human.
+
+  One at a time. A wall of every pending question at once is how somebody
+  answers the second one thinking it was the first — and with the branch
+  parked on an answer, a mis-click is not a cosmetic mistake.
+
+  Draws nothing when there is nothing pending: it sits in the layout
+  permanently, so an idle run must not carry an empty box, and there must be
+  no button to hit by accident."
+  [state props]
+  (let [pending (vec (:approvals state))
+        a (first pending)]
+    (cond
+      (nil? a) [:empty]
+      (seq (:questions a)) (questionnaire state a)
+      :else (permission-dialog state a))))
+
+;; --- the bottom strip --------------------------------------------------------
+
+(defn input
+  "The compose box. What it sends is an INTERVENTION, not a chat message —
+  samizdat runs are autonomous and a person steers them at a turn boundary,
+  so this is the same seam the supervisor uses."
+  [state props]
+  (panel (assoc props :title (or (:title props) "STEER"))
+         [:input {:value (or (:input state) "")
+                  :placeholder "a directive for the run — Enter sends"
+                  :on-change (fn [s] (when-let [f (get-in state [:on :input])] (f s)))
+                  :on-enter (fn [s] (when-let [f (get-in state [:on :submit])] (f s)))}]))
+
+(defn status
+  "The status line: whether there is a server, which run, and what it is
+  doing. The first thing to look at when nothing else is moving."
+  [state props]
+  (let [run (get-in state [:detail :run])]
+    [:hbox {:bg :gray-dark}
+     (if (:connected? state)
+       [:text {:color :green} " ● connected "]
+       [:text {:color :red} " ○ offline "])
+     [:text {:dim true} (str " " (or (:run-id state) "no run") " ")]
+     (when run [:text (str " " (:status run) " ")])
+     (when-let [e (:error state)] [:text {:color :red} (str " " (clip e 40) " ")])
+     (when-let [e (:layout-error state)] [:text {:color :yellow} (str " " (clip e 60) " ")])
+     [:filler]
+     [:text {:dim true} (str (or (:base state) "") " ")]]))
+
+;; --- registration ------------------------------------------------------------
+;;
+;; Last, so every widget above is defined. The layout names these tags and
+;; nothing else resolves them; a tag with no entry here draws a complaint in
+;; its own box rather than taking the frame down (samizdat.tui.layout).
+
+(doseq [[tag f] {:widget/activity     activity
+                 :widget/approvals    approvals
+                 :widget/conversation conversation
+                 :widget/tasks        tasks
+                 :widget/files        files
+                 :widget/context      context
+                 :widget/gates        gates
+                 :widget/artifacts    artifacts
+                 :widget/runs         runs
+                 :widget/input        input
+                 :widget/status       status}]
+  (layout/register! tag f))

--- a/tui/samizdat/tui/widgets.clj
+++ b/tui/samizdat/tui/widgets.clj
@@ -49,11 +49,20 @@
 
 (defn- panel
   "A titled box. Every side panel is one, so a layout that puts two of them
-  in a column gets borders that line up without saying so."
+  in a column gets borders that line up without saying so.
+
+  `:height` is forwarded like `:width` because a column of panels is a
+  competition for rows: without a ceiling on the ones that do not need many,
+  the flexed panel below them is the one that gets squeezed off the screen."
   [props & children]
   (into [:vbox (cond-> {:border :rounded}
-                 (:flex props) (assoc :flex true)
-                 (:width props) (assoc :width (:width props)))]
+                 ;; The VALUE, not a coerced true: ftxui's flex kinds are
+                 ;; `:grow` (may take spare room, may not be squeezed) as
+                 ;; well as plain `true` (both), and flattening them cost a
+                 ;; layout the distinction that keeps a panel on screen.
+                 (:flex props) (assoc :flex (:flex props))
+                 (:width props) (assoc :width (:width props))
+                 (:height props) (assoc :height (:height props)))]
         (cond-> []
           (:title props) (conj [:text {:bold true} (str " " (:title props) " ")]
                                [:separator])
@@ -86,12 +95,19 @@
 
   ftxui's own `:collapsible`, so the mouse works on it for free — this is
   the widget FTXUI already opens and closes on a click, and wiring our own
-  hit-testing over a `:text` would be re-implementing it worse."
-  [state id label body]
-  [:collapsible {:label label
-                 :show (contains? (set (:expanded state)) id)
-                 :on-change (toggle-fn state id)}
-   body])
+  hit-testing over a `:text` would be re-implementing it worse.
+
+  `body-fn` is a THUNK, and it is called only when the fold is open. Passing
+  the body itself built every tool result on the branch into one element per
+  line on every frame whether or not anyone could see it: 175ms a frame at
+  two hundred turns with every fold shut, and ftxui redraws on a keystroke.
+  A shut fold is not on screen and its body does not get built."
+  [state id label body-fn]
+  (let [open? (contains? (set (:expanded state)) id)]
+    [:collapsible {:label label
+                   :show open?
+                   :on-change (toggle-fn state id)}
+     (if open? (body-fn) [:empty])]))
 
 ;; --- the activity log --------------------------------------------------------
 
@@ -142,6 +158,14 @@
   (let [lines (str/split-lines (str s))]
     (into [:vbox] (map (if diff? diff-line (fn [l] [:text l])) lines))))
 
+(defn- line-count
+  "How many lines `s` has, without cutting it into them. This is only ever a
+  number in a fold's LABEL, which is drawn on every frame for every turn on
+  screen — splitting a thousand-line result to count it is the body-building
+  the fold itself now avoids, moved into the header."
+  [s]
+  (inc (count (re-seq #"\n" (str s)))))
+
 (defn- failed? [turn]
   (contains? #{"failure" "mechanics"} (str (:category turn))))
 
@@ -164,7 +188,7 @@
      (when (not-empty (str reasoning_text))
        (fold state (fold-id turn :thinking)
              (str "thinking (" (count (str reasoning_text)) " chars)")
-             [:paragraph {:dim true} (str reasoning_text)]))
+             #(vector :paragraph {:dim true} (str reasoning_text))))
 
      (when tool_name
        [:hbox
@@ -174,23 +198,39 @@
         [:text {:dim true} (str "  turn " turn)]])
 
      (when (not-empty (str args))
-       (fold state (fold-id turn :args) "arguments" (body-block args false)))
+       (fold state (fold-id turn :args) "arguments" #(body-block args false)))
 
      (when (not-empty (str result))
        (fold state (fold-id turn :result)
-             (str "result (" (count (str/split-lines (str result))) " lines)")
-             (body-block result writing?)))
+             (str "result (" (line-count result) " lines)")
+             #(body-block result writing?)))
 
      [:separator {:dim true}]]))
+
+(def default-turns-shown
+  "How many turns the conversation draws when the layout does not say.
+
+  A default, not a policy: `:turns` in the layout is the number that counts,
+  and this is what a layout written before the prop existed gets."
+  60)
 
 (defn conversation
   "The agent's turns: what it said, what it called, and what came back.
 
   Thinking, arguments and results fold, closed by default — a log that
   opened every tool result is unreadable after three turns, and the header
-  alone is what a reader scans."
+  alone is what a reader scans.
+
+  BOUNDED, like every other panel. `:turns` in the layout says how many, and
+  it is the newest that many — a conversation is read from the bottom, and
+  the four hundred entries above the fold were being rebuilt on every
+  keystroke to be scrolled past. How far back is userspace for the same
+  reason `:prose-turns` is: how much history a reader wants is their
+  business, and every turn added costs a frame."
   [state props]
-  (let [turns (vec (get-in state [:branch :turns]))]
+  (let [all (vec (get-in state [:branch :turns]))
+        n (or (:turns props) default-turns-shown)
+        turns (if (> (count all) n) (subvec all (- (count all) n)) all)]
     (panel (assoc props :title (or (:title props)
                                    (some->> (:branch-id state) (str "BRANCH "))))
            (if (seq turns)
@@ -313,6 +353,26 @@
                                    (f (:id (nth rs i nil)))))}]
              (empty-note "no runs")))))
 
+(defn branches
+  "The beam: every branch on this run and what became of it.
+
+  A run here is a BEAM, so the branch being read is one of several and which
+  one is a choice. Without this the auto-picked branch was the only one
+  reachable — the state fold could switch and nothing on screen asked it to."
+  [state props]
+  (let [bs (vec (get-in state [:detail :branches]))]
+    (panel props
+           (if (seq bs)
+             [:menu {:entries (mapv #(clip (str (:id %) " " (:status %) "  "
+                                                (get-in % [:thesis :claim]))
+                                           32)
+                                    bs)
+                     :selected (max 0 (.indexOf (mapv :id bs) (:branch-id state)))
+                     :on-enter (fn [i]
+                                 (when-let [f (get-in state [:on :select-branch])]
+                                   (f (:id (nth bs i nil)))))}]
+             (empty-note "no branches")))))
+
 ;; --- the modals --------------------------------------------------------------
 
 (defn- lines-of
@@ -345,19 +405,27 @@
   (let [qs (vec questions)
         i (min (or (:question-cursor state) 0) (max 0 (dec (count qs))))
         q (nth qs i nil)
-        so-far (vec (:question-answers state))]
+        so-far (vec (:question-answers state))
+        opts (vec (:options q))
+        ;; Carry what has already been answered. Handing back only the
+        ;; latest would lose every earlier answer on the way to the last
+        ;; question.
+        answer (fn [a] (when-let [f (get-in state [:on :answer])]
+                         (f id i (conj so-far (str a)))))]
     [:vbox {:border :heavy :color :cyan}
      [:text {:bold true :color :cyan}
       (str " ? QUESTION " (inc i) " of " (count qs) " ")]
      [:separator]
      [:paragraph (str (:question q))]
-     [:menu {:entries (mapv str (:options q))
-             :on-enter (fn [n]
-                         (when-let [f (get-in state [:on :answer])]
-                           ;; Carry what has already been answered. Handing
-                           ;; back only the latest would lose every earlier
-                           ;; answer on the way to the last question.
-                           (f id i (conj so-far (str (nth (:options q) n nil))))))}]]))
+     (if (seq opts)
+       [:menu {:entries (mapv str opts)
+               :on-enter (fn [n] (answer (nth opts n nil)))}]
+       ;; No options is not a malformed question — `ask_human` takes a bare
+       ;; string and an open-ended question is the ordinary use of a tool by
+       ;; that name. Drawn as an empty menu it could not be answered AT ALL,
+       ;; and the branch parked until the deadline for want of a text box.
+       [:input {:placeholder "type an answer — Enter sends"
+                :on-enter answer}])]))
 
 (defn approvals
   "Questions waiting on a person: the permission gate and ask_human.
@@ -380,15 +448,29 @@
 ;; --- the bottom strip --------------------------------------------------------
 
 (defn input
-  "The compose box. What it sends is an INTERVENTION, not a chat message —
-  samizdat runs are autonomous and a person steers them at a turn boundary,
-  so this is the same seam the supervisor uses."
+  "The compose box, and the two things done to a run rather than said to it.
+
+  What the box sends is an INTERVENTION, not a chat message — samizdat runs
+  are autonomous and a person steers them at a turn boundary, so this is the
+  same seam the supervisor uses. Abort and resume sit beside it because they
+  are the other two, and because they were documented here long before
+  anything on screen called them."
   [state props]
   (panel (assoc props :title (or (:title props) "STEER"))
-         [:input {:value (or (:input state) "")
-                  :placeholder "a directive for the run — Enter sends"
-                  :on-change (fn [s] (when-let [f (get-in state [:on :input])] (f s)))
-                  :on-enter (fn [s] (when-let [f (get-in state [:on :submit])] (f s)))}]))
+         [:hbox
+          [:input {:flex true
+                   :value (or (:input state) "")
+                   :placeholder "a directive for the run — Enter sends"
+                   :on-change (fn [s] (when-let [f (get-in state [:on :input])] (f s)))
+                   :on-enter (fn [s] (when-let [f (get-in state [:on :submit])] (f s)))}]
+          ;; Spelled out rather than built by a helper taking the key as an
+          ;; argument: `every-handler-the-loop-offers-has-a-caller` reads
+          ;; these literally, and a key assembled at runtime is a key that
+          ;; ratchet cannot see.
+          [:button {:label "abort"
+                    :on-click (fn [] (when-let [f (get-in state [:on :abort])] (f)))}]
+          [:button {:label "resume"
+                    :on-click (fn [] (when-let [f (get-in state [:on :resume])] (f)))}]]))
 
 (defn status
   "The status line: whether there is a server, which run, and what it is
@@ -421,6 +503,7 @@
                  :widget/gates        gates
                  :widget/artifacts    artifacts
                  :widget/runs         runs
+                 :widget/branches     branches
                  :widget/input        input
                  :widget/status       status}]
   (layout/register! tag f))


### PR DESCRIPTION
Epics karamazov-whbw (the port) and karamazov-6nv4 (a review of it).

tui/ is a second front end on the same terms as gui/: its own source root, its own alias, and a strict HTTP client of the server. Everything except the run loop is written toolkit-free — the widgets return hiccup, and hiccup is data — so the main suite covers them with no terminal and no cmake. `jolt tui-test` drives real FTXUI headlessly for the parts that cannot be checked as data: that a click reaches a fold, and that a typed answer reaches the branch parked on it.

The layout is EDN, and it comes from three places, most local first: a file at $SAMIZDAT_TUI_LAYOUT or .samizdat/tui.edn, re-read whenever its mtime and length move, so a person's edit lands on the next frame; GET /v1/harness/layout, which is the server reading the project's stored `tui` policy on behalf of a client that holds no database handle, which is how the agent rearranges its own UI; then resources/tui.edn off the classpath, for offline and the first frame. It is hiccup with :widget/* tags resolved against a registry, and every other tag is ftxui's own and passes through untouched. A bad edit costs a panel rather than the screen: an unknown tag draws a named complaint in its own box, a widget that throws is contained to its box, and a layout that is not hiccup at all falls back to the shipped one and says so in the status line. The file's whole point is being edited while running, and a black screen would take out the tool for seeing the damage.

ACTIVITY LOG shows the manifest states the implementer is walking rather than a tool-call ticker. Those steps were published on the in-process bus and held by nobody, so a front end — which has no bus to subscribe to — could not draw the one thing it most wanted. samizdat.steps keeps a bounded ring per run, fed by a pump, and /v1/runs/:id/steps serves it with journal-tail's cursor contract so a client runs one poll loop over both feeds. Deliberately not durable: what a turn DID is the turns table, and writing fourteen rows a turn to record the shape of a graph the manifest already states is paying storage for a redraw.

The model's prose needed an endpoint of its own. branch-turns drops assistant_text and reasoning_text because they are the bulk — 5.5MB against 62KB of results on one real run, enough that the branch panel exceeded its socket timeout and never drew — so a turn can now be fetched whole and the TUI asks only for the newest few. The run detail also carries the board and the paths the run has changed, both queries over tables the loop already appends to.

samizdat.api.client is now the one client both front ends use, and samizdat.gui.api is that namespace under its old names. How to reach the server is mechanism, and the GUI and the TUI had no business answering it twice.

samizdat.approval adds a gate that can wait for a person, and gates.edn :approval defaults to :mode :refuse, which is exactly what the harness did before. Blocking is opt-in because runs here are unattended by design and a release that started parking them would hang a campaign overnight. Every wait is bounded by :wait-ms and resolves to a stated :on-timeout, and a run that ends releases its waiters, so the gate always terminates. An expired wait tells the model it was never judged, only unseen, so it cannot learn a policy from an empty room. ask_human puts a questionnaire through the same queue.

The second commit is a review pass over the first, and everything in it was measured rather than argued. prose-wanted dropped the turns it already held before taking the newest n, so every poll asked for n turns further back and a 400-turn branch fetched all 400 bodies over thirty-three polls — the whole 5.5MB the per-turn endpoint exists to avoid; its test asserted the walk-backward answer, so it was pinning the bug. A question with no options could not be answered at all: ask_human takes a bare string, the questionnaire drew that as an empty menu, and through real FTXUI clicking every row of the dialog fired the answer handler zero times while the branch sat parked for the full wait. The conversation drew every turn and built every fold's body whether or not it was open, which is 175ms a frame at two hundred turns with every fold shut and ftxui redraws on a keystroke; bounded and made lazy, the same frame costs 14.6ms. :abort, :resume and :select-branch were in the handler map, documented in tui.edn's widget table, and called by nothing, so a beam run showed the auto-picked branch and could never leave it. And the layout the TUI drew was never the one it claimed to read — a front end binds no project, so the userspace read fell through to the classpath template every time and the read cache pinned that for the life of the process, which is what the three sources above replace.

Two ratchets came out of it. every-handler-the-loop-offers-has-a-caller compares state/handler-keys against the keys widgets.clj actually names, because each half of that seam was correct on its own and that is why no test could see the gap. And the prose window has a test over four hundred turns that holds it asks for nothing once the window is full.

Full suite 2156 tests / 9502 assertions green, jolt tui-test 5 / 15 green. The layout chain was also checked live end to end against a running harness: a version saved through its nREPL came back from the endpoint, through samizdat.api.client, and drew.

Not in this PR: pinning a :git/sha for ftxui-jolt, which is :local/root until it tags a release that ships the compiled shim. The shipped arrangement also still degrades on a short terminal — at 190x55 with a permission dialog open every panel draws, at 150x44 the bottom ones lose their content rows. That is inherent to a fixed column of panels, and the file is right there to adjust.
