### PR TITLE
Make the TUI usable: start a run, name the project, show the tree

### DIFF
--- a/.github/workflows/linux-sandbox.yml
+++ b/.github/workflows/linux-sandbox.yml
@@ -16,6 +16,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Pinned, like tests.yml, and for the reason that workflow learned: the
+# installer takes the LATEST release when given nothing, so a jolt release
+# breaks CI here with no change in this repo. This battery does not build a
+# binary and so never hit the 0.8.5 boot-image abort, but it runs on every
+# push and had no reason to be the one workflow that tracks whatever shipped
+# this morning. Keep in step with tests.yml, which has the latest-release
+# canary that says when the pin can move.
+env:
+  JOLT_VERSION: "0.8.6"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -62,7 +72,7 @@ jobs:
           test -s /tmp/jolt-install || { echo "could not fetch the jolt installer" >&2; exit 1; }
           head -1 /tmp/jolt-install | grep -q '^#!' \
             || { echo "fetched file is not a script:" >&2; head -3 /tmp/jolt-install >&2; exit 1; }
-          bash /tmp/jolt-install --dir "$HOME/.local/bin"
+          bash /tmp/jolt-install --dir "$HOME/.local/bin" --version "$JOLT_VERSION"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Cache jolt gitlibs

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -94,8 +94,9 @@ right gutter, a wide short row, and the bottom strip.
 | `:widget/gates` | gates that fired, and predictions still unsettled |
 | `:widget/artifacts` | claims made, and how each was judged |
 | `:widget/approvals` | the one question a person is being asked, if any. Draws nothing when there is none |
+| `:widget/git` | the working tree: branch, `+staged ~unstaged ?untracked`, and the last commit's subject |
 | `:widget/input` | the compose box, plus start, abort and resume. Bare by default — pass `{:title "STEER"}` for a caption |
-| `:widget/status` | connected or offline, which run, its status, the last error |
+| `:widget/status` | the footer — see below |
 
 Two details worth knowing because they look like bugs otherwise:
 
@@ -106,6 +107,56 @@ Two details worth knowing because they look like bugs otherwise:
 - **The conversation is bounded** — the newest `:turns` of them, 60 by
   default. Every entry is rebuilt on every frame, so this is a frame-rate
   number as much as a history one.
+
+### The footer
+
+Ported from dirge's status line, which reads
+`project:branch | model | used/ctx (pct%) | Nmsgs | state`:
+
+```
+ ● connected  samizdat:tui-start-a-run │ glm-5.3 │ 9k / 128k (7%) │ 1 / 1 turns │ aborted │ 61aba012   127.0.0.1:3986
+```
+
+Left to right: the connection, the project and its git branch, the model
+actually answering, tokens against the model's context window, turns against
+the run's ceiling, what the run is doing, the run id, and which harness this
+is pointed at. Every segment is optional — the first frame has none of them.
+
+The connection dot is samizdat's own addition rather than dirge's. dirge's UI
+*is* the process doing the work; this one is a client that can be pointed
+anywhere, so it has to be able to say it has lost the thing it is watching.
+
+Two details carried over deliberately:
+
+- **The denominator is the window, not the fold-trigger budget.** So the
+  percentage reads 0–100 instead of running past 100 once a fold became due,
+  and an imminent fold is flagged with a `fold` / `fold!` marker at 75% and
+  90% instead.
+- **`project:branch` collapses to just the project** on a detached HEAD or
+  outside a git tree — never a dangling separator.
+
+### Where the project data comes from
+
+`GET /v1/harness/project`, which the poller folds in beside the layout. The
+footer and the GIT panel both read it:
+
+```json
+{"project": "samizdat", "root": "/Users/yogthos/src/samizdat",
+ "branch": "tui-start-a-run", "staged": 0, "unstaged": 16, "untracked": 0,
+ "last_commit": "Let the TUI start a run, and drop the caption over its input",
+ "provider": "glm", "model": "glm-5.3", "context_window": 128000}
+```
+
+Served rather than read locally for the same reason the layout is: only the
+harness process is bound to the project. A TUI that shelled out to git itself
+would caption whichever directory it happened to be started from — silently,
+and wrongly, whenever it is pointed at a harness on another machine.
+
+The server caches the git side for `:git-snapshot-ttl-ms` (gates.edn, 3s by
+default), because the snapshot is three `git` calls and the poller asks every
+1.5s per connected front end. dirge learned the same thing the harder way: it
+read `.git/HEAD` once per painted frame and froze its UI on large repos until
+it cached the lookup.
 
 ## Rearranging it, while it runs
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -37,8 +37,8 @@ needing cmake and a C++17 compiler). This is also why the TUI is not part of
 | `F5` | poll now, without waiting out the interval |
 | `Ctrl-C`, `Ctrl-Q` | quit |
 | arrows + `Enter` | pick a run in RUNS, a branch in BEAM, an option in a questionnaire |
-| type + `Enter` | send what is in the compose box |
-| `abort` / `resume` | the two things done *to* a run rather than said to it |
+| type + `Enter` | **with no run selected**, start a run on what you typed; **with one**, send it as a directive |
+| `start` / `abort` / `resume` | the three things done *to* a run rather than said to it |
 
 The mouse is on, and folds are ftxui's own collapsibles — clicking one is how
 it opens, with no hit-testing of our own.
@@ -49,9 +49,32 @@ untouched (`samizdat.tui.state/pending-decision` decides which). Everything
 else — arrows, text, clicks — belongs to whichever widget has the focus; the
 global handler consumes as little as it can.
 
-What the compose box sends is an **intervention**, not a chat message.
-Samizdat runs autonomously and a person steers it at a turn boundary, so this
-is the same seam the supervisor uses.
+### The compose box does two things
+
+One box, and whether there is a run selected decides what Enter means.
+
+**With no run selected** the words are a **problem statement**, and Enter
+starts a run on them. Nothing else on screen can give a fresh harness its
+first problem — before this the box answered "no run selected" and dropped
+what you had typed.
+
+**With a run selected** the words are an **intervention** for it, not a chat
+message. Samizdat runs autonomously and a person steers it at a turn
+boundary, so that is the same seam the supervisor uses.
+
+The `start` button does it either way, which is how you start a second run
+while reading the first. Only the problem statement is sent — the turn budget,
+the beam width and the model are left to the server's own config, which is
+what an omitted key means; the GUI has a form for those because it has room
+for one. The request runs off the UI thread, because `POST /v1/runs` does not
+answer until the beam has opened every branch, which can take tens of seconds.
+The status line says `starting…` while it does, in cyan: that is a notice, not
+an error, and it travels in its own field so the strip never claims both at
+once.
+
+`abort` and `resume` with no run selected say "no run selected" rather than
+doing nothing silently — a button that quietly no-ops is indistinguishable
+from one that is not wired up, which is exactly how it got reported.
 
 ## What is on screen
 
@@ -71,7 +94,7 @@ right gutter, a wide short row, and the bottom strip.
 | `:widget/gates` | gates that fired, and predictions still unsettled |
 | `:widget/artifacts` | claims made, and how each was judged |
 | `:widget/approvals` | the one question a person is being asked, if any. Draws nothing when there is none |
-| `:widget/input` | the compose box, plus abort and resume |
+| `:widget/input` | the compose box, plus start, abort and resume. Bare by default — pass `{:title "STEER"}` for a caption |
 | `:widget/status` | connected or offline, which run, its status, the last error |
 
 Two details worth knowing because they look like bugs otherwise:

--- a/resources/gates.edn
+++ b/resources/gates.edn
@@ -238,6 +238,22 @@
         Two minutes covers a slow selection call under load without letting a
         client hang forever on a provider that never answers."}
 
+ :git-snapshot-ttl-ms
+ {:value 3000 :kind :threshold :capability-tunable? true
+  :provenance ["karamazov-uk77" "dirge-vuzz"]
+  :doc "How long GET /v1/harness/project may serve a cached git snapshot.
+
+        The endpoint shells out to git three times — symbolic-ref, log -1,
+        status --porcelain — and the TUI's poller asks every 1.5 s per
+        connected front end. The tree does not change that fast, and dirge
+        learned the same thing the harder way: it read .git/HEAD once per
+        PAINTED FRAME and froze its UI on large repos until it cached the
+        lookup (dirge-vuzz). Three seconds keeps the branch fresh enough to
+        notice a checkout while taking git off the poll path.
+
+        Raise it on a slow filesystem or a very large repo; 0 disables the
+        cache and reads on every request."}
+
  :image-connect-ms
  {:value 20000 :kind :threshold :capability-tunable? true
   :provenance ["karamazov-zrq"]

--- a/resources/tui.edn
+++ b/resources/tui.edn
@@ -63,7 +63,10 @@
  ;;                         with one it is a directive for that run, with none
  ;;                         the words are the problem statement for a new run.
  ;;                         Bare by default; {:title "STEER"} draws a caption.
- ;;   :widget/status        the status line.
+ ;;   :widget/git           the working tree: branch, +staged ~unstaged
+ ;;                         ?untracked, and the last commit's subject.
+ ;;   :widget/status        the footer: project:branch, model, context fill,
+ ;;                         turns, run status, run id.
 
  ;; THREE PANELS TO A COLUMN, not five. A bare :height is an EQUALITY
  ;; constraint in ftxui, so a stack of pinned boxes cannot shrink to fit and
@@ -102,9 +105,17 @@
   ;; The run's own account of itself: what it has established, and what it
   ;; was advised and has not answered. Wide and short — both are short lists
   ;; of long lines, which is the opposite of what a gutter is for.
+  ;; GIT rides in this row rather than in a gutter, and the reason is the
+  ;; warning at the top of this file. A fourth box in the right column put
+  ;; BEAM 6 + TASKS 8 + GIT 6 = 20 pinned rows against a :grow MODIFIED that
+  ;; may not be squeezed, so on a 28-row terminal GIT drew as a titled box
+  ;; with no content in it — the same squeeze, one panel further along. Here
+  ;; the row is pinned at 7, GIT needs 3 content rows inside its chrome, and
+  ;; it fits at any height the rest of the layout does.
   [:hbox {:height 7}
    [:widget/artifacts {:title "CLAIMS" :flex true}]
-   [:widget/gates {:title "GATES" :flex true}]]
+   [:widget/gates {:title "GATES" :flex true}]
+   [:widget/git {:title "GIT" :width 34}]]
 
   ;; Above the compose box, because the branch is parked on it and it is the
   ;; only thing on screen that is waiting on you. Invisible when idle.

--- a/resources/tui.edn
+++ b/resources/tui.edn
@@ -58,7 +58,11 @@
  ;;   :widget/approvals     the question a person is being asked, if any: the
  ;;                         permission dialog, or ask_human's questionnaire.
  ;;                         Draws nothing when there is nothing pending.
- ;;   :widget/input         the compose box: interventions, abort, resume.
+ ;;   :widget/input         the compose box, and start / abort / resume. What
+ ;;                         Enter means depends on whether a run is selected:
+ ;;                         with one it is a directive for that run, with none
+ ;;                         the words are the problem statement for a new run.
+ ;;                         Bare by default; {:title "STEER"} draws a caption.
  ;;   :widget/status        the status line.
 
  ;; THREE PANELS TO A COLUMN, not five. A bare :height is an EQUALITY

--- a/src/samizdat/agent/gitdiff.clj
+++ b/src/samizdat/agent/gitdiff.clj
@@ -38,6 +38,47 @@
     (or (some-> (git root "stash" "create") str/trim not-empty)
         "HEAD")))
 
+(defn- porcelain-counts
+  "Split `git status --porcelain` into git's own three kinds.
+
+  Two status columns per line, X and Y: X is the index against HEAD, Y the
+  working tree against the index, and `??` is a path git has never seen. A
+  path can count on BOTH sides — staged once and edited again since — so
+  these are three counts and not a partition, which is also why one \"dirty\"
+  number would be the wrong thing to show."
+  [out]
+  (let [lines (remove str/blank? (str/split-lines (str out)))]
+    (reduce (fn [acc line]
+              (let [x (get line 0) y (get line 1)]
+                (if (and (= \? x) (= \? y))
+                  (update acc :untracked inc)
+                  (cond-> acc
+                    (not (contains? #{\space \?} x)) (update :staged inc)
+                    (not (contains? #{\space \?} y)) (update :unstaged inc)))))
+            {:staged 0 :unstaged 0 :untracked 0}
+            lines)))
+
+(defn snapshot
+  "The working tree at a glance: `{:branch :staged :unstaged :untracked
+  :last-commit}`. nil when `root` is not a git working tree.
+
+  For a front end to show, not for the model — the TUI holds no filesystem
+  knowledge of the project it is watching, so the server reads this and
+  serves it. Ported from dirge, whose status line carries `project:branch`
+  and whose left panel carries the counts.
+
+  `:branch` is nil on a DETACHED HEAD (rebase, bisect, a CI checkout), where
+  there is no branch to name and the counts still matter; `:last-commit` is
+  nil in a repo with no commits yet. Fails soft like everything else here."
+  [root]
+  (when (and root (proc/available? "git")
+             (git root "rev-parse" "--is-inside-work-tree"))
+    (merge {:branch (some-> (git root "symbolic-ref" "--quiet" "--short" "HEAD")
+                            str/trim not-empty)
+            :last-commit (some-> (git root "log" "-1" "--format=%s")
+                                 str/trim not-empty)}
+           (porcelain-counts (git root "status" "--porcelain")))))
+
 (defn changed-files
   "The paths the run changed since `baseline`: tracked edits (git diff
   --name-only) UNION new files (git ls-files --others). The union matters —

--- a/src/samizdat/api/client.clj
+++ b/src/samizdat/api/client.clj
@@ -108,6 +108,16 @@
   [base]
   (GET base "/v1/harness/layout"))
 
+(defn project
+  "Which project the harness is working on, which branch, how dirty, and
+  which model — GET /v1/harness/project.
+
+  Asked of the server rather than read locally because the front end holds no
+  filesystem knowledge of the project: a TUI pointed at a harness elsewhere
+  would otherwise caption whatever repo it was started from."
+  [base]
+  (GET base "/v1/harness/project"))
+
 (defn approvals
   "Questions this run is waiting on a person to answer — the permission gate
   and ask_human, which share one queue."

--- a/src/samizdat/config.clj
+++ b/src/samizdat/config.clj
@@ -295,17 +295,21 @@
                p))
       :local))
 
+(defn- named-provider
+  "The provider a config layer NAMES, as a keyword, or nil when it names none.
+
+  Accepts a string as well as a keyword: `:provider \"glm\"` is what somebody
+  writes after reading /health, where it has been through JSON, and refusing
+  a legible file on that is a crash rather than a correction."
+  [m]
+  (some-> (get-in m [:llm :provider]) name str/lower-case not-empty keyword))
+
 (defn load-config
   "Build the config map. `overrides` is merged last so tests and REPL sessions
   can point at a fake provider or an in-memory database without touching env."
   ([] (load-config nil))
   ([overrides]
-   (let [provider (detect-provider)
-         defaults (or (providers provider)
-                      (throw (ex-info (str "Unknown HARNESS_PROVIDER: " provider)
-                                      {:provider provider
-                                       :known (keys providers)})))
-         ;; The project layer layers between defaults and overrides. Root: the
+   (let [;; The project layer layers between defaults and overrides. Root: the
          ;; caller's :run :root if given, then HARNESS_ROOT, else the process
          ;; working dir. The env rung exists because a SERVED harness has no
          ;; other way to name the project it works on: every other run knob has
@@ -320,8 +324,24 @@
          ;; moving env above the files would silently change every checkout
          ;; that pins a value in .samizdat/config.edn.
          files (file-config root)
+         ;; READ BEFORE THE PRESET IS EXPANDED, and that ordering is the whole
+         ;; point: a layer that names a provider picks that provider's
+         ;; base-url, key-env, model, context window and temperature. It used
+         ;; to name only the :provider KEY — the preset had already been
+         ;; expanded from whatever `detect-provider` found — so a file saying
+         ;; `{:llm {:provider :glm}}` ran against DeepSeek's endpoint with
+         ;; DeepSeek's key and deepseek-v4-flash while dispatching the GLM
+         ;; adapter, and said nothing. Overrides outrank files here for the
+         ;; same reason they do everywhere else.
+         provider (or (named-provider overrides)
+                      (named-provider files)
+                      (detect-provider))
+         defaults (or (providers provider)
+                      (throw (ex-info (str "Unknown provider: " provider)
+                                      {:provider provider
+                                       :known (keys providers)})))
          db (db-location root (env "HARNESS_DB"))]
-     (deep-merge
+     (-> (deep-merge
       ;; 3985 rather than a common port: 3000 is the busiest address on a
       ;; developer machine, and a harness that silently fails to bind (or
       ;; binds where something else already lives) is worse than one on an
@@ -429,7 +449,13 @@
                   :stop-on-first-done? (not= "0" (or (env "HARNESS_STOP_ON_FIRST_DONE")
                                                      "1"))}}
       files
-      overrides))))
+      overrides)
+      ;; The RESOLVED provider, not whatever spelling a layer used. `provider`
+      ;; already normalised a string to its keyword to pick the preset, and
+      ;; every consumer downstream — registry/adapter-for above all — expects
+      ;; a keyword; leaving the file's `"glm"` to win the merge would dispatch
+      ;; on a string and find no adapter.
+      (assoc-in [:llm :provider] provider)))))
 
 (defn provider-llm
   "The :llm config for a SPECIFIC provider — its base URL, model, temperature,

--- a/src/samizdat/engine/proc.clj
+++ b/src/samizdat/engine/proc.clj
@@ -111,14 +111,31 @@
         finished? (try
                     (.waitFor p ms java.util.concurrent.TimeUnit/MILLISECONDS)
                     (catch Throwable _ false))]
-    (if-not finished?
-      (do (reap! proc) {:timeout true :ms ms})
-      ;; Exited, so this deref returns immediately and only collects the
-      ;; already-complete stdout/stderr.
-      (let [done @proc]
-        {:exit (:exit done)
-         :out (or (:out done) "")
-         :err (or (:err done) "")}))))
+    (try
+      (if-not finished?
+        (do (reap! proc) {:timeout true :ms ms})
+        ;; Exited, so this deref returns immediately and only collects the
+        ;; already-complete stdout/stderr.
+        (let [done @proc]
+          {:exit (:exit done)
+           :out (or (:out done) "")
+           :err (or (:err done) "")}))
+      ;; CLOSE THE PIPES. `:out :string` reads the child's output into a
+      ;; string and leaves the pipe fds open: measured 2 fds per call, never
+      ;; released, so 30 spawns cost 60 descriptors and 60 cost 120. That is
+      ;; the leak behind provenance A-3 — the suite "holds ~260 fds at peak"
+      ;; and needed `ulimit -n 1024` — and it is not only a test problem: the
+      ;; `shell` tool comes through here, so a long run that shells out a few
+      ;; hundred times exhausts its own descriptors and starts failing to open
+      ;; the database ("sqlite step failed: unable to open database file",
+      ;; which is exactly how it surfaced).
+      ;;
+      ;; In a `finally` so the timeout path closes too, and each close is
+      ;; independent: a stream already closed by the shim must not stop the
+      ;; other two from being closed.
+      (finally
+        (doseq [stream [(.getInputStream p) (.getErrorStream p) (.getOutputStream p)]]
+          (try (some-> stream .close) (catch Throwable _ nil)))))))
 
 (defn available?
   "Whether `bin` can be executed at all. Used by the smoke probes and to give

--- a/src/samizdat/server.clj
+++ b/src/samizdat/server.clj
@@ -32,6 +32,7 @@
             [clojure.string :as str]
             [clojure.tools.logging :as log]
             [samizdat.agent.gates :as gates]
+            [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.api.control :as control]
             [samizdat.api.openai :as openai]
             [samizdat.api.runs :as api-runs]
@@ -164,6 +165,56 @@
 (defn- layout-table [_req]
   (json-response (layout-body)))
 
+;; {:at ms :root path :snapshot m} — see gates.edn :git-snapshot-ttl-ms for why
+;; a cache exists at all.
+(defonce ^:private git-cache (atom nil))
+
+(defn cached-snapshot
+  "`gitdiff/snapshot` for `root`, at most once per :git-snapshot-ttl-ms.
+
+  Keyed on the root as well as the clock, so a harness whose project moved
+  does not serve the previous one's branch for the rest of the window."
+  [root]
+  (let [ttl (or (gates/threshold :git-snapshot-ttl-ms) 0)
+        now (System/currentTimeMillis)
+        c @git-cache]
+    (if (and c (= root (:root c)) (< (- now (:at c)) ttl))
+      (:snapshot c)
+      (let [s (gitdiff/snapshot root)]
+        (reset! git-cache {:at now :root root :snapshot s})
+        s))))
+
+(defn project-body
+  "What a front end needs to caption itself: which project, which branch, how
+  dirty, which model.
+
+  Served rather than read locally for the same reason the layout is: the TUI
+  holds no filesystem knowledge of the project and no database handle, so a
+  TUI pointed at a harness on another machine — or merely started from
+  another directory — would otherwise caption the wrong repo with perfect
+  confidence. Only this process knows what it is working on.
+
+  Every field is nullable and the endpoint never fails: a harness outside a
+  git tree still has a project name, and a front end that cannot draw a
+  branch should still draw the rest of its footer."
+  []
+  (let [cfg (system/config)
+        root (get-in cfg [:run :root])
+        snap (cached-snapshot root)]
+    {:project (some-> root (str/split #"/") last not-empty)
+     :root root
+     :branch (:branch snap)
+     :staged (:staged snap)
+     :unstaged (:unstaged snap)
+     :untracked (:untracked snap)
+     :last_commit (:last-commit snap)
+     :provider (some-> (get-in cfg [:llm :provider]) name)
+     :model (get-in cfg [:llm :model])
+     :context_window (get-in cfg [:llm :context-window])}))
+
+(defn- project-table [_req]
+  (json-response (project-body)))
+
 ;; --- routing ----------------------------------------------------------------
 ;;
 ;; A route is [method pattern handler]. A pattern segment starting with ':'
@@ -197,6 +248,9 @@
    ;; database handle can still see the version the agent saved.
    [:get "/v1/harness/layout" #'layout-table]
    [:get "/v1/harness/models" #'harness-models]
+   ;; Which project, which branch, how dirty, which model — the footer and the
+   ;; GIT panel. Served because only this process is bound to the project.
+   [:get "/v1/harness/project" #'project-table]
    [:get "/v1/runs" (fn [req] (json-response (api-runs/list-runs (system/conn)
                                                                  (long-param req "limit"))))]
    ;; `(or (:status r) 200)`, the same shape resume uses: a handler that refuses

--- a/test-tui/samizdat/tui/mouse_test.clj
+++ b/test-tui/samizdat/tui/mouse_test.clj
@@ -131,6 +131,112 @@
         (is (= ["q9" 0 ["mycelium"]] @answered)
             "what was typed reached the handler that unparks the branch")))))
 
+(defn- at-of
+  "The 0-based [row col] `needle` starts at in a rendered frame, or nil. The
+  buttons sit at the right end of a flexed row, so a click needs the column
+  as well as the line."
+  [text needle]
+  (first (keep-indexed (fn [i line]
+                         (when-let [c (str/index-of line needle)] [i c]))
+                       (str/split-lines text))))
+
+(defn- button-at
+  "Where to click a button labelled `label`, found on the row the buttons
+  share.
+
+  Anchored on \"abort\" rather than searching the frame for the label: the
+  compose box's own placeholder reads \"…Enter starts a run\", so a plain
+  search for \"start\" lands in the text field and focuses it instead —
+  which looks exactly like a dead button. No placeholder says \"abort\"."
+  [text label]
+  (let [lines (str/split-lines text)]
+    (first (keep-indexed (fn [i line]
+                           (when (str/includes? line "abort")
+                             (when-let [c (str/index-of line label)] [i c])))
+                         lines))))
+
+(defn- click!
+  [s [y x]]
+  (ui/send-mouse! s {:button :left :motion :pressed :x x :y y})
+  (ui/send-mouse! s {:button :left :motion :released :x x :y y}))
+
+(deftest the-compose-box-buttons-answer-a-click
+  ;; The data half checks that each button carries the right :on-click. What
+  ;; it cannot say is that a click REACHES one — three components share a row
+  ;; with a flexed input, and FTXUI routes a press by hit-testing the
+  ;; container it built. So every button on the strip is pressed for real.
+  (doseq [label ["start" "abort" "resume"]]
+    (testing label
+      (let [hit (atom [])
+            app (fn [] (w/input {:on {:start  (fn [& _] (swap! hit conj :start))
+                                      :abort  #(swap! hit conj :abort)
+                                      :resume #(swap! hit conj :resume)
+                                      :input  (fn [_])
+                                      :submit (fn [_])}}
+                                {}))]
+        (ui/with-screen [s app]
+          (let [frame (ui/render-text s 80 8)
+                at (button-at frame label)]
+            (is (some? at) (str label " is on screen: " (pr-str frame)))
+            (click! s at)
+            (is (= [(keyword label)] @hit)
+                (str "clicking " label " reached the handler"))))))))
+
+(deftest typing-a-problem-and-pressing-enter-starts-a-run
+  ;; End to end through the toolkit for the thing the TUI could not do: no
+  ;; run selected, type a statement, press Enter, and the loop is asked to
+  ;; start a run with exactly those words.
+  (let [started (atom nil)
+        text (atom "")
+        app (fn [] (w/input {:input @text
+                             :on {:input  #(reset! text %)
+                                  :submit (fn [_] (reset! started :STEERED))
+                                  :start  #(reset! started %)
+                                  :abort  (fn [])
+                                  :resume (fn [])}}
+                            {}))]
+    (ui/with-screen [s app]
+      (let [frame (ui/render-text s 80 8)]
+        ;; Focus the box by clicking its placeholder, then type.
+        (is (some? (at-of frame "problem")) (str "the box says what it takes: " frame))
+        (click! s (at-of frame "problem")))
+      (ui/send-char! s "build a parser")
+      (ui/send-key! s :return)
+      (is (= "build a parser" @started)
+          "Enter started a run on what was typed, rather than steering nothing"))))
+
+(deftest the-buttons-still-answer-a-click-inside-the-whole-layout
+  ;; The widget alone is not the configuration anybody runs. In the shipped
+  ;; layout the strip sits under a flexed row, two panel columns and a
+  ;; scrolling :frame, and FTXUI routes a press by hit-testing the containers
+  ;; it built out of all of that — so the claim "abort and resume respond to
+  ;; the mouse" is only worth making about the real tree.
+  (let [hit (atom [])
+        handlers {:start  (fn [& _] (swap! hit conj :start))
+                  :abort  #(swap! hit conj :abort)
+                  :resume #(swap! hit conj :resume)
+                  :input  (fn [_])
+                  :submit (fn [_])
+                  :toggle (fn [_])
+                  :decide (fn [& _])
+                  :answer (fn [& _])
+                  :select-run (fn [_])
+                  :select-branch (fn [_])}
+        current (requiring-resolve 'samizdat.tui.layout/current)
+        expand (requiring-resolve 'samizdat.tui.layout/expand)
+        app (fn [] (expand (:layout (current))
+                           (assoc (st/initial "http://x") :on handlers)))]
+    (ui/with-screen [s app]
+      (let [frame (ui/render-text s 110 30)]
+        (doseq [label ["abort" "resume" "start"]]
+          (testing label
+            (reset! hit [])
+            (let [at (button-at frame label)]
+              (is (some? at) (str label " is on the strip"))
+              (click! s at)
+              (is (= [(keyword label)] @hit)
+                  (str "a click at " (pr-str at) " reached " label)))))))))
+
 (deftest the-whole-shipped-layout-renders-through-the-real-toolkit
   ;; The layout is userspace hiccup expanded against the registry, and every
   ;; widget is only ever checked as data. This is the one test that says the
@@ -141,4 +247,7 @@
         frame (ui/render-text (expand (:layout (layout)) (st/initial "http://x")) 120 30)]
     (is (str/includes? frame "ACTIVITY LOG"))
     (is (str/includes? frame "TASKS"))
-    (is (str/includes? frame "offline") "the status line drew too")))
+    (is (str/includes? frame "offline") "the status line drew too")
+    (is (not (str/includes? frame "STEER"))
+        "and the compose box is the box, with no row spent captioning it")
+    (is (str/includes? frame "start") "with a way to start the first run")))

--- a/test-tui/samizdat/tui/mouse_test.clj
+++ b/test-tui/samizdat/tui/mouse_test.clj
@@ -244,10 +244,28 @@
   ;; rejects would otherwise surface as a black screen on first run.
   (let [layout (requiring-resolve 'samizdat.tui.layout/current)
         expand (requiring-resolve 'samizdat.tui.layout/expand)
-        frame (ui/render-text (expand (:layout (layout)) (st/initial "http://x")) 120 30)]
+        ;; A project folded in, because the GIT box's content is what the
+        ;; squeeze assertion below is about and an empty state draws its
+        ;; empty note instead. Everything else is still the first frame.
+        state (assoc (st/initial "http://x")
+                     :project {:project "samizdat" :branch "trunk"
+                               :staged 1 :unstaged 2 :untracked 0
+                               :last_commit "a commit"
+                               :model "glm-5.3" :context_window 128000})
+        frame (ui/render-text (expand (:layout (layout)) state) 120 30)]
     (is (str/includes? frame "ACTIVITY LOG"))
     (is (str/includes? frame "TASKS"))
     (is (str/includes? frame "offline") "the status line drew too")
     (is (not (str/includes? frame "STEER"))
         "and the compose box is the box, with no row spent captioning it")
-    (is (str/includes? frame "start") "with a way to start the first run")))
+    (is (str/includes? frame "start") "with a way to start the first run")
+    ;; The TITLE is not the assertion. A box whose content got squeezed to
+    ;; zero rows still prints its title, which is exactly how the first
+    ;; placement of this panel passed a weaker version of this test while
+    ;; drawing an empty box on a real terminal.
+    (is (str/includes? frame "GIT") "the GIT box is placed")
+    (is (str/includes? frame "trunk")
+        "and its CONTENT drew — a titled box with no rows in it is the squeeze
+         this layout's own warning is about")
+    (is (re-find #"\+1 ~2" frame) "including the dirty counts")
+    (is (str/includes? frame "samizdat:trunk") "and the footer's project label")))

--- a/test/samizdat/config_test.clj
+++ b/test/samizdat/config_test.clj
@@ -39,12 +39,15 @@
   (let [cfg (config/load-config {:llm {:provider :glm}})
         {:keys [base-url model temperature]} (:llm cfg)]
     (testing "the provider defaults resolve to dirge's working GLM config"
-      ;; provider defaults are read by key-env detection; assert the static
-      ;; provider table rather than a live-env-dependent selection.
-      (is (= "https://open.bigmodel.cn/api/coding/paas/v4"
-             (get-in config/providers-for-test [:glm :base-url])))
-      (is (= "glm-5.3" (get-in config/providers-for-test [:glm :model])))
-      (is (= 0.2 (get-in config/providers-for-test [:glm :temperature]))))))
+      ;; Asserted on the LOADED config, which is the claim worth making. It
+      ;; used to bind these three and then assert the static table instead,
+      ;; with a comment about key-env detection — because naming a provider
+      ;; did not in fact expand its preset, so the loaded values were
+      ;; whatever the environment had detected. Now it does, and the binding
+      ;; is the thing under test rather than dead.
+      (is (= "https://open.bigmodel.cn/api/coding/paas/v4" base-url))
+      (is (= "glm-5.3" model))
+      (is (= 0.2 temperature)))))
 
 (deftest provider-temperature-wins-over-family-default
   ;; A provider that pins a temperature (GLM's 0.2) beats the 0.7 family
@@ -144,6 +147,72 @@
     (when edn-content
       (spit (java.io.File. dir "config.edn") edn-content))
     home))
+
+(deftest a-config-file-that-names-a-provider-gets-that-provider
+  ;; The provider was chosen by `detect-provider` ALONE — HARNESS_PROVIDER, else
+  ;; the first provider whose key-env is in the environment — and the file
+  ;; layers were merged on top of the preset that choice had already expanded.
+  ;; So `{:llm {:provider :glm}}` in a config file set the :provider key and
+  ;; nothing else: the run kept DeepSeek's base-url, DeepSeek's api-key and
+  ;; deepseek-v4-flash, while naming itself glm and dispatching the GLM
+  ;; adapter. Wrong endpoint, wrong key, wrong model, no complaint.
+  ;;
+  ;; A layer that names a provider now selects that provider's preset, which is
+  ;; the only reading of "provider: glm" that means anything.
+  (let [home (temp-config-home "{:llm {:provider :glm}}")
+        root (temp-project-root nil)]
+    (try
+      (with-redefs [config/config-home (fn [] home)]
+        (let [{:keys [provider base-url model temperature]}
+              (:llm (config/load-config {:run {:root root}}))]
+          (is (= :glm provider))
+          (is (= "https://open.bigmodel.cn/api/coding/paas/v4" base-url)
+              "GLM's endpoint, not whichever provider the environment detected")
+          (is (= "glm-5.3" model))
+          (is (= 0.2 temperature) "and GLM's coding temperature")))
+      (finally (delete-recursively (java.io.File. home))
+               (delete-recursively (java.io.File. root)))))
+  (testing "a project file overrides the global one's provider"
+    (let [home (temp-config-home "{:llm {:provider :glm}}")
+          root (temp-project-root "{:llm {:provider :deepseek}}")]
+      (try
+        (with-redefs [config/config-home (fn [] home)]
+          (let [{:keys [provider base-url model]}
+                (:llm (config/load-config {:run {:root root}}))]
+            (is (= :deepseek provider))
+            (is (str/includes? base-url "deepseek"))
+            (is (= "deepseek-v4-flash" model))))
+        (finally (delete-recursively (java.io.File. home))
+                 (delete-recursively (java.io.File. root))))))
+  (testing "a file may name the provider and still pin one of its keys"
+    (let [home (temp-config-home "{:llm {:provider :glm :model \"glm-4.6\"}}")
+          root (temp-project-root nil)]
+      (try
+        (with-redefs [config/config-home (fn [] home)]
+          (let [{:keys [base-url model]} (:llm (config/load-config {:run {:root root}}))]
+            (is (= "glm-4.6" model) "the pin wins over the preset")
+            (is (str/includes? base-url "bigmodel") "the rest of the preset still applies")))
+        (finally (delete-recursively (java.io.File. home))
+                 (delete-recursively (java.io.File. root))))))
+  (testing "a provider spelled as a string is the provider it names"
+    ;; EDN written by a person, not by code: `:provider "glm"` is what someone
+    ;; who has seen the JSON in /health writes, and reading it as an unknown
+    ;; provider would have been a crash on a legible file.
+    (let [home (temp-config-home "{:llm {:provider \"glm\"}}")
+          root (temp-project-root nil)]
+      (try
+        (with-redefs [config/config-home (fn [] home)]
+          (is (= :glm (get-in (config/load-config {:run {:root root}}) [:llm :provider]))))
+        (finally (delete-recursively (java.io.File. home))
+                 (delete-recursively (java.io.File. root))))))
+  (testing "a provider no table knows is an error, not a silent fallback"
+    (let [home (temp-config-home "{:llm {:provider :nope}}")
+          root (temp-project-root nil)]
+      (try
+        (with-redefs [config/config-home (fn [] home)]
+          (is (thrown? Exception (config/load-config {:run {:root root}}))))
+        (finally (delete-recursively (java.io.File. home))
+                 (delete-recursively (java.io.File. root)))))))
 
 (deftest a-global-config-sits-beneath-the-project-config
   (let [home (temp-config-home "{:http {:port 4100} :llm {:model \"global-model\" :base-url \"http://global\"}}")

--- a/test/samizdat/gitdiff_test.clj
+++ b/test/samizdat/gitdiff_test.clj
@@ -46,3 +46,63 @@
             (is (contains? changed "src_new.clj") "the newly-created file is seen")
             (is (contains? changed "seed.txt") "and a tracked edit is still seen")))
         (finally (sh dir (str "rm -rf " dir)))))))
+
+(deftest snapshot-reads-the-tree-at-a-glance
+  ;; What the TUI's footer and GIT panel are built on: branch, dirty counts
+  ;; split the way git splits them, and the last commit's subject. Ported from
+  ;; dirge's status line (project:branch) and left-panel GIT box
+  ;; (⎇ branch / +staged ~unstaged ?untracked / last commit).
+  (when (proc/available? "git")
+    (let [dir (str (System/getProperty "java.io.tmpdir") "/gd-snap-"
+                   (System/currentTimeMillis))]
+      (try
+        (proc/run {:timeout-ms 15000} "sh" "-c" (str "mkdir -p " dir))
+        (sh dir "git init -q -b trunk && git config user.email t@t.co && git config user.name t")
+        (sh dir "echo seed > seed.txt && git add -A && git commit -qm 'the first commit'")
+        (testing "a clean tree"
+          (let [s (gd/snapshot dir)]
+            (is (= "trunk" (:branch s)))
+            (is (= 0 (:staged s)))
+            (is (= 0 (:unstaged s)))
+            (is (= 0 (:untracked s)))
+            (is (= "the first commit" (:last-commit s)))))
+        (testing "one of each kind of dirty, counted separately"
+          ;; git's own split: a staged add is X, an unstaged edit is Y, and a
+          ;; file git has never seen is ??. Collapsing them into one "dirty"
+          ;; number would lose the distinction the panel exists to show.
+          (sh dir "echo staged > staged.txt && git add staged.txt")
+          (sh dir "echo more >> seed.txt")
+          (sh dir "echo untracked > untracked.txt")
+          (let [s (gd/snapshot dir)]
+            (is (= 1 (:staged s)))
+            (is (= 1 (:unstaged s)))
+            (is (= 1 (:untracked s)))))
+        (testing "a file both staged and edited again counts on both sides"
+          (sh dir "echo edited >> staged.txt")
+          (let [s (gd/snapshot dir)]
+            (is (= 1 (:staged s)))
+            (is (= 2 (:unstaged s)) "seed.txt and the re-edited staged.txt")))
+        (finally (sh dir (str "rm -rf " dir)))))))
+
+(deftest snapshot-fails-soft
+  ;; Same posture as diff and changed-files: the footer degrades to the
+  ;; project name rather than the UI failing to draw.
+  (is (nil? (gd/snapshot nil)))
+  (is (nil? (gd/snapshot (str (System/getProperty "java.io.tmpdir") "/definitely-not-a-repo-xyz")))))
+
+(deftest a-detached-head-has-no-branch-but-still-has-counts
+  ;; Rebase, bisect, and a CI checkout all sit on a detached HEAD. dirge omits
+  ;; the branch segment there; the counts are still worth showing.
+  (when (proc/available? "git")
+    (let [dir (str (System/getProperty "java.io.tmpdir") "/gd-detached-"
+                   (System/currentTimeMillis))]
+      (try
+        (proc/run {:timeout-ms 15000} "sh" "-c" (str "mkdir -p " dir))
+        (sh dir "git init -q && git config user.email t@t.co && git config user.name t")
+        (sh dir "echo a > a.txt && git add -A && git commit -qm one")
+        (sh dir "git checkout -q --detach HEAD")
+        (let [s (gd/snapshot dir)]
+          (is (some? s) "still a repo")
+          (is (nil? (:branch s)) "no branch to name")
+          (is (= "one" (:last-commit s))))
+        (finally (sh dir (str "rm -rf " dir)))))))

--- a/test/samizdat/proc_test.clj
+++ b/test/samizdat/proc_test.clj
@@ -49,3 +49,43 @@
       (is (empty? (survivors))
           "a TERM-trapping child tree must not outlive the reap"))
     (finally (sweep!))))
+
+(defn- open-fds
+  "How many descriptors this process holds, via /dev/fd. nil where that is
+  not a directory, so the test can skip rather than fail on a platform that
+  does not publish it."
+  []
+  (let [d (java.io.File. "/dev/fd")]
+    (when (.isDirectory d) (count (.list d)))))
+
+(deftest run-does-not-leak-the-pipes-it-reads
+  ;; `:out :string` reads the child's output into a string and left the pipe
+  ;; descriptors open: measured 2 per call, never released — 30 spawns cost
+  ;; 60 fds, 60 cost 120. That is the leak behind provenance A-3, where the
+  ;; suite "holds ~260 fds at peak" and the `test` task raises ulimit -n to
+  ;; 1024 to paper over it; adding three git-spawning tests was enough to
+  ;; cross even the raised limit, and it surfaced as "sqlite step failed:
+  ;; unable to open database file" in namespaces that had nothing to do with
+  ;; subprocesses.
+  ;;
+  ;; Not a test-only concern: the `shell` tool runs through here, so a run
+  ;; that shells out a few hundred times exhausted its own descriptors and
+  ;; then could not open its database.
+  (when-let [before (open-fds)]
+    (dotimes [_ 40]
+      (proc/run {:timeout-ms 5000} "sh" "-c" "echo hello"))
+    (let [after (open-fds)]
+      (is (<= after (+ before 4))
+          (str "40 spawns should cost no descriptors; held " before
+               " before and " after " after. Two per call is the pipe leak.")))))
+
+(deftest a-timed-out-run-closes-its-pipes-too
+  ;; The timeout path returns before the deref that collects output, so it
+  ;; needs its own close — which is why the close sits in a finally rather
+  ;; than beside the successful return.
+  (when-let [before (open-fds)]
+    (dotimes [_ 5]
+      (is (:timeout (proc/run {:timeout-ms 50} "sh" "-c" "sleep 5"))))
+    (let [after (open-fds)]
+      (is (<= after (+ before 4))
+          (str "held " before " before and " after " after five timeouts")))))

--- a/test/samizdat/server_test.clj
+++ b/test/samizdat/server_test.clj
@@ -24,9 +24,11 @@
             [clojure.test :refer [deftest testing is]]
             [jolt.process :as p]
             [ring-chez.adapter :as adapter]
+            [samizdat.agent.gitdiff :as gitdiff]
             [samizdat.api.control :as control]
             [samizdat.server :as server]
             [samizdat.store.db :as db]
+            [samizdat.system :as system]
             [samizdat.userspace :as userspace]))
 
 (defn- request [body]
@@ -76,6 +78,54 @@
       (finally
         (userspace/bind! prev)
         (db/close conn)))))
+
+(deftest the-harness-serves-the-project-it-is-working-on
+  ;; Same seam as the layout above, for the footer and the GIT panel: only
+  ;; this process knows which directory it was pointed at, so a TUI reading
+  ;; git in its OWN process would caption whichever repo it happened to be
+  ;; started from — confidently, and wrongly, whenever it is pointed at a
+  ;; harness elsewhere.
+  (with-redefs [system/config (fn [] {:run {:root "/tmp/some/where/myproject"}
+                                      :llm {:provider :glm :model "glm-5.3"
+                                            :context-window 128000}})
+                server/cached-snapshot (fn [_] {:branch "trunk" :staged 1
+                                                :unstaged 2 :untracked 3
+                                                :last-commit "did a thing"})]
+    (let [b (server/project-body)]
+      (is (= "myproject" (:project b)) "the basename, which is what a footer has room for")
+      (is (= "trunk" (:branch b)))
+      (is (= [1 2 3] [(:staged b) (:unstaged b) (:untracked b)]))
+      (is (= "did a thing" (:last_commit b)))
+      (is (= "glm" (:provider b)) "a string on the wire, not a keyword")
+      (is (= "glm-5.3" (:model b)))
+      (is (= 128000 (:context_window b)))))
+  (testing "outside a git tree it still names the project"
+    (with-redefs [system/config (fn [] {:run {:root "/tmp/plain"}
+                                        :llm {:provider :local :model "m"}})
+                  server/cached-snapshot (fn [_] nil)]
+      (let [b (server/project-body)]
+        (is (= "plain" (:project b)))
+        (is (nil? (:branch b)))
+        (is (nil? (:staged b)) "absent, not zero — 'no repo' is not 'clean'")))))
+
+(deftest the-git-snapshot-is-cached-so-git-is-off-the-poll-path
+  ;; Three shell-outs per request and a poller asking every 1.5s per front
+  ;; end. dirge read .git/HEAD once per painted frame and froze its UI on
+  ;; large repos until it cached (dirge-vuzz); this is that lesson taken up
+  ;; front, with the window in gates.edn.
+  (let [calls (atom 0)]
+    (with-redefs [gitdiff/snapshot (fn [_] (swap! calls inc) {:branch "b"})]
+      (reset! @#'server/git-cache nil)
+      (is (= {:branch "b"} (server/cached-snapshot "/r")))
+      (is (= {:branch "b"} (server/cached-snapshot "/r")))
+      (is (= 1 @calls) "the second read came from the cache")
+      (testing "a different root is not the cached one"
+        (is (= {:branch "b"} (server/cached-snapshot "/other")))
+        (is (= 2 @calls)))
+      (testing "and an expired window reads again"
+        (swap! @#'server/git-cache assoc :at 0)
+        (server/cached-snapshot "/other")
+        (is (= 3 @calls))))))
 
 (deftest content-length-is-octets-not-characters
   ;; A 3-byte em-dash decodes to one char. Judging completeness by char count

--- a/test/samizdat/tui_state_test.clj
+++ b/test/samizdat/tui_state_test.clj
@@ -237,3 +237,55 @@
                 (assoc :run-id "r1")
                 (st/apply-runs {:ok true :body {:runs [{:id "r2"} {:id "r1"}]}}))]
       (is (= "r1" (:run-id s))))))
+
+;; --- starting a run from the compose box ------------------------------------
+
+(deftest enter-starts-a-run-when-there-is-none-and-steers-when-there-is
+  ;; The TUI could reach every run the server already had and could not make
+  ;; one. Typing into the compose box with nothing selected reported "no run
+  ;; selected" and dropped the text — so a freshly started harness with an
+  ;; empty database had no path to its first run at all.
+  (is (= :start (st/enter-action (st/initial "b")))
+      "nothing to steer, so the words are a problem statement")
+  (is (= :submit (st/enter-action (assoc (st/initial "b") :run-id "r1")))
+      "with a run on screen the words are a directive for it"))
+
+(deftest a-started-run-is-selected-and-the-box-is-emptied
+  (let [s (-> (st/initial "b")
+              (st/set-input "build a parser")
+              (st/apply-start {:ok true :body {:run_id "r7"}}))]
+    (is (= "r7" (:run-id s)) "the new run is what the panels now show")
+    (is (= "" (:input s)) "and the statement is not left to be sent twice")
+    (is (re-find #"r7" (str (:notice s))) "with the id said back")
+    (is (nil? (:error s)))))
+
+(deftest a-refused-start-keeps-the-statement
+  ;; The server refuses with 503 when the beam does not come up. Clearing the
+  ;; box would make the user retype several paragraphs to try again.
+  (let [s (-> (st/initial "b")
+              (st/set-input "build a parser")
+              (st/apply-start {:ok false :error "HTTP 503"}))]
+    (is (nil? (:run-id s)))
+    (is (= "build a parser" (:input s)))
+    (is (re-find #"503" (str (:error s)))))
+  (testing "and so does a 2xx that carried no id"
+    (let [s (st/apply-start (st/set-input (st/initial "b") "x")
+                            {:ok true :body {}})]
+      (is (nil? (:run-id s)))
+      (is (= "x" (:input s)))
+      (is (not-empty (str (:error s)))))))
+
+(deftest a-notice-is-not-an-error
+  ;; The status line paints :error red. "starting…" is not a failure and must
+  ;; not read as one, so it travels in its own field.
+  (let [s (st/note-notice (st/initial "b") "starting…")]
+    (is (= "starting…" (:notice s)))
+    (is (nil? (:error s))))
+  (testing "and an error clears a stale notice"
+    (let [s (-> (st/initial "b") (st/note-notice "starting…") (st/note-error "boom"))]
+      (is (= "boom" (:error s)))
+      (is (nil? (:notice s)) "or the strip would claim both at once"))))
+
+(deftest starting-is-refused-before-it-is-sent-when-there-is-nothing-to-start
+  (is (nil? (st/steer-payload "   ")))
+  (is (= "go" (st/steer-payload "  go  "))))

--- a/test/samizdat/tui_widgets_test.clj
+++ b/test/samizdat/tui_widgets_test.clj
@@ -301,6 +301,53 @@
     ((get by-label "resume"))
     (is (= [:abort :resume] @hit))))
 
+(deftest the-compose-box-can-start-a-run
+  ;; The gap this whole change is about: with no run selected the box's Enter
+  ;; went to :submit, which has nothing to steer, so a fresh harness could not
+  ;; be given its first problem from the UI at all. Enter now means :start
+  ;; while nothing is selected, and the button means it either way.
+  (let [hit (atom [])
+        state {:input "build a parser"
+               :on {:start #(swap! hit conj [:start %])
+                    :submit #(swap! hit conj [:submit %])}}
+        out (render :widget/input state {})
+        inp (first (nodes-of :input out))
+        by-label (into {} (map (juxt #(:label (props-of %)) #(:on-click (props-of %))))
+                       (nodes-of :button out))]
+    (is (contains? by-label "start") "and it is on screen, not only on a key")
+    ((get by-label "start"))
+    (is (= [[:start "build a parser"]] @hit)
+        "the button starts on what is in the box, not on an empty string")
+    (reset! hit [])
+    ((:on-enter (props-of inp)) "build a parser")
+    (is (= [[:start "build a parser"]] @hit)
+        "Enter with no run selected starts one")
+    (is (re-find #"(?i)problem|start" (str (:placeholder (props-of inp))))
+        "and the box says so rather than offering to steer nothing"))
+  (testing "with a run selected Enter steers it instead"
+    (let [hit (atom [])
+          state {:run-id "r1"
+                 :on {:start #(swap! hit conj [:start %])
+                      :submit #(swap! hit conj [:submit %])}}
+          out (render :widget/input state {})
+          inp (first (nodes-of :input out))]
+      ((:on-enter (props-of inp)) "try the other parser")
+      (is (= [[:submit "try the other parser"]] @hit))
+      (is (re-find #"(?i)directive|steer" (str (:placeholder (props-of inp))))))))
+
+(deftest the-compose-box-is-just-the-box-unless-a-layout-asks-for-a-title
+  ;; A titled, bordered panel around one input line spent two rows saying
+  ;; "STEER" above a box whose own placeholder already says what it is. The
+  ;; header is userspace like every other piece of the arrangement: absent by
+  ;; default, drawn when a layout names it.
+  (let [bare (render :widget/input {} {})]
+    (is (not (re-find #"(?i)steer" (texts bare)))
+        "no title, and nothing claiming one")
+    (is (nil? (:border (props-of bare))) "and no box of its own"))
+  (let [titled (render :widget/input {} {:title "STEER"})]
+    (is (str/includes? (texts titled) "STEER"))
+    (is (some? (:border (props-of titled))))))
+
 (deftest the-status-line-says-whether-there-is-a-server
   (is (re-find #"(?i)offline|disconnect|no server"
                (texts (render :widget/status {:connected? false} {}))))
@@ -311,9 +358,12 @@
                                    {}))))))
 
 (deftest the-input-box-is-an-editor-bound-to-the-handlers
+  ;; :run-id is what makes Enter mean :submit — with none selected there is
+  ;; nothing to steer and it means :start instead, which is what
+  ;; `the-compose-box-can-start-a-run` covers.
   (let [sent (atom nil)
         out (render :widget/input
-                    {:input "do the thing" :on {:submit #(reset! sent %)}}
+                    {:run-id "r1" :input "do the thing" :on {:submit #(reset! sent %)}}
                     {})
         input (first (nodes-of :input out))]
     (is (= "do the thing" (:value (props-of input))))

--- a/test/samizdat/tui_widgets_test.clj
+++ b/test/samizdat/tui_widgets_test.clj
@@ -357,6 +357,83 @@
                                     :detail {:run {:status "running"}}}
                                    {}))))))
 
+(def ^:private proj
+  {:project "samizdat" :branch "tui-start-a-run"
+   :staged 1 :unstaged 2 :untracked 3
+   :last_commit "Let the TUI start a run"
+   :provider "glm" :model "glm-5.3" :context_window 128000})
+
+(deftest the-footer-says-which-project-branch-and-model
+  ;; Ported from dirge's status line, which reads
+  ;; `project:branch | model | used/ctx (pct%) | Nmsgs | state`. Samizdat's
+  ;; had the run id and the base URL and nothing about WHAT was being worked
+  ;; on or by which model — the two things a person glancing at a long run
+  ;; actually wants, and the two that say whether the harness is pointed where
+  ;; they think it is.
+  (let [said (texts (render :widget/status
+                            {:connected? true :run-id "61aba012-b68a-4adc"
+                             :project proj
+                             :detail {:run {:status "running" :model "glm-5.3"
+                                            :max_turns 40
+                                            :usage {:total-tokens 9475 :turns 3}}}}
+                            {}))]
+    (is (str/includes? said "samizdat:tui-start-a-run")
+        "project and branch, the way dirge writes it")
+    (is (str/includes? said "glm-5.3") "the model actually answering")
+    (is (re-find #"9\.?5?k */ *128k" said) "tokens against the window, abbreviated")
+    (is (str/includes? said "7%") "and as a percentage of it")
+    (is (re-find #"3 */ *40" said) "turns against the ceiling")
+    (is (str/includes? said "running") "and what the run is doing")
+    (is (str/includes? said "61aba012") "the run, short")))
+
+(deftest the-footer-draws-before-anything-has-answered
+  ;; The first frame: no project, no run, offline. Every segment is optional
+  ;; and the strip still has to be a strip.
+  (let [said (texts (render :widget/status {:connected? false} {}))]
+    (is (re-find #"(?i)offline" said))
+    (is (re-find #"(?i)no run" said)))
+  (testing "and a harness outside a git tree has a project but no branch"
+    (let [said (texts (render :widget/status
+                              {:connected? true
+                               :project {:project "plain" :model "m"}}
+                              {}))]
+      (is (str/includes? said "plain"))
+      (is (not (str/includes? said "plain:")) "no dangling separator"))))
+
+(deftest the-footer-warns-before-a-fold-not-after
+  ;; dirge's own refinement: the denominator is the window, so the gauge reads
+  ;; 0-100 and a fold is flagged by a marker instead of the percentage running
+  ;; past 100 (dirge-l4rp, dirge-cx7t).
+  (let [at (fn [used] (texts (render :widget/status
+                                     {:connected? true :project proj
+                                      :detail {:run {:usage {:total-tokens used}}}}
+                                     {})))]
+    (is (not (re-find #"fold" (at 10000))) "quiet well below the window")
+    (is (re-find #"fold" (at 100000)) "flagged approaching it")
+    (is (re-find #"fold!" (at 120000)) "and urgently at the top")))
+
+(deftest the-git-panel-shows-the-branch-and-what-is-dirty
+  ;; dirge's left-panel GIT box: branch, the three counts git itself
+  ;; distinguishes, and the last commit's subject.
+  (let [said (texts (render :widget/git {:project proj} {}))]
+    (is (str/includes? said "tui-start-a-run"))
+    (is (re-find #"\+1" said) "staged")
+    (is (re-find #"~2" said) "unstaged")
+    (is (re-find #"\?3" said) "untracked")
+    (is (str/includes? said "Let the TUI start a run") "and the last commit"))
+  (testing "a clean tree says so rather than showing three zeroes"
+    (let [said (texts (render :widget/git
+                              {:project {:project "p" :branch "main" :staged 0
+                                         :unstaged 0 :untracked 0
+                                         :last_commit "x"}}
+                              {}))]
+      (is (re-find #"(?i)clean" said))))
+  (testing "outside a repo it says that, and does not invent a branch"
+    (let [said (texts (render :widget/git {:project {:project "p"}} {}))]
+      (is (re-find #"(?i)not a git|no repo|no branch" said))))
+  (testing "and it draws before the first poll answers"
+    (is (vector? (render :widget/git {} {})))))
+
 (deftest the-input-box-is-an-editor-bound-to-the-handlers
   ;; :run-id is what makes Enter mean :submit — with none selected there is
   ;; nothing to steer and it means :start instead, which is what

--- a/tui/samizdat/tui/core.clj
+++ b/tui/samizdat/tui/core.clj
@@ -80,15 +80,45 @@
           (swap! state #(-> % (st/note-error (when-not (:ok r) (:error r)))
                             (cond-> (:ok r) st/clear-input))))))))
 
+(defn- start!
+  "Start a run on the compose box, as its problem statement.
+
+  Only `:problem` goes up: everything else POST /v1/runs takes — the turn
+  budget, the beam width, the model — is left to the server's own config,
+  which is what an omitted key means. The GUI has a form for those because
+  it has room for one; this is one line, and the statement is the part that
+  cannot be defaulted.
+
+  OFF THE UI THREAD, and that is not optional: the endpoint does not answer
+  when the run row is written — beam/run! opens every branch first — so a
+  start legitimately takes tens of seconds, which is why the client allows
+  it 40. A UI that stopped redrawing for that long is the frozen-but-alive
+  failure this project keeps finding."
+  [text]
+  (let [{:keys [base]} @state]
+    (if-let [problem (st/steer-payload text)]
+      (do (swap! state st/note-notice "starting…")
+          (future
+            (swap! state st/apply-start
+                   (client/start-run! base {:problem problem}))
+            (poll-once!)))
+      (swap! state st/note-error "type a problem statement first"))))
+
+;; `if-not run-id` rather than `when run-id`: both of these used to do
+;; NOTHING AND SAY NOTHING with no run selected, which is indistinguishable
+;; from a button that is not wired to anything — and that is exactly how it
+;; was reported.
 (defn- abort! []
   (let [{:keys [base run-id]} @state]
-    (when run-id
+    (if-not run-id
+      (swap! state st/note-error "no run selected")
       (let [r (client/abort! base run-id)]
         (swap! state st/note-error (when-not (:ok r) (:error r)))))))
 
 (defn- resume! []
   (let [{:keys [base run-id]} @state]
-    (when run-id
+    (if-not run-id
+      (swap! state st/note-error "no run selected")
       (let [r (client/resume! base run-id)]
         (swap! state st/note-error (when-not (:ok r) (:error r)))))))
 
@@ -129,6 +159,7 @@
    :select-branch #(swap! state st/select-branch %)
    :input         #(swap! state st/set-input %)
    :submit        steer!
+   :start         start!
    :abort         abort!
    :resume        resume!})
 

--- a/tui/samizdat/tui/core.clj
+++ b/tui/samizdat/tui/core.clj
@@ -178,6 +178,11 @@
     ;; arrangement that is already drawn.
     (let [r (client/layout base)]
       (when (:ok r) (layout/serve! (get-in r [:body :layout]))))
+    ;; Beside the layout because it is the same KIND of thing — what the
+    ;; harness is, rather than what a run is doing — and because both survive
+    ;; a run being deselected. Cheap: the server caches the git side (gates.edn
+    ;; :git-snapshot-ttl-ms), so this is not three shell-outs per poll.
+    (swap! state st/apply-project (client/project base))
     (swap! state st/apply-runs (client/list-runs base))
     (when-let [rid (:run-id @state)]
       ;; The cursor is read here, after apply-runs may have selected a run —

--- a/tui/samizdat/tui/state.clj
+++ b/tui/samizdat/tui/state.clj
@@ -54,6 +54,10 @@
    ;; red, and "starting…" is not a failure.
    :notice nil
    :layout-error nil
+   ;; What the harness says it is working on: project, branch, dirty counts,
+   ;; model. Nil until the first poll answers, so the footer and the GIT panel
+   ;; both have to draw without it.
+   :project nil
    :runs []
    :run-id nil
    :detail nil
@@ -186,6 +190,16 @@
          (take-last n)
          (remove held)
          vec)))
+
+(defn apply-project
+  "Fold GET /v1/harness/project.
+
+  A failure leaves what is already held alone, like the turn text: the branch
+  and the project name do not change because one poll missed, and blanking
+  the footer on a dropped connection would take away the caption while
+  leaving the panels it labels."
+  [s {:keys [ok body]}]
+  (if ok (assoc s :project body) s))
 
 (defn apply-runs
   [s {:keys [ok body] :as r}]

--- a/tui/samizdat/tui/state.clj
+++ b/tui/samizdat/tui/state.clj
@@ -37,7 +37,7 @@
   — were offered and documented for a whole release with nothing on screen
   that called them, which no test could see because each half was correct on
   its own."
-  #{:decide :answer :toggle :select-run :select-branch :input :submit
+  #{:decide :answer :toggle :select-run :select-branch :input :submit :start
     :abort :resume})
 
 (def max-trace
@@ -50,6 +50,9 @@
   {:base base
    :connected? false
    :error nil
+   ;; Beside :error rather than sharing it: the status line paints an error
+   ;; red, and "starting…" is not a failure.
+   :notice nil
    :layout-error nil
    :runs []
    :run-id nil
@@ -245,11 +248,61 @@
 (defn clear-input [s]
   (assoc s :input ""))
 
-(defn note-error [s msg]
-  (assoc s :error (when (not-empty (str msg)) (str msg))))
+(defn note-error
+  "Say what went wrong, and drop any notice it supersedes — a strip claiming
+  \"starting…\" beside \"HTTP 503\" tells the reader nothing about which
+  happened."
+  [s msg]
+  (cond-> (assoc s :error (when (not-empty (str msg)) (str msg)))
+    (not-empty (str msg)) (assoc :notice nil)))
+
+(defn note-notice
+  "Say what is happening. Not an error, and not a place for one."
+  [s msg]
+  (assoc s :notice (when (not-empty (str msg)) (str msg))))
 
 (defn steer-payload
   "What the compose box sends. Blank is not a directive."
   [text]
   (let [t (str/trim (str text))]
     (when (seq t) t)))
+
+(defn enter-action
+  "Which handler Enter in the compose box means right now.
+
+  One box, two meanings, decided by whether there is a run to talk to. With
+  a run selected the words are a directive for it. With none they are a
+  PROBLEM STATEMENT, because a harness whose database is empty has nothing
+  to steer and the statement is the only thing it can be given — the TUI
+  could reach every run the server already had and could not make one, so
+  the first thing a new user typed was answered with \"no run selected\" and
+  dropped.
+
+  A pure function rather than a branch inside the widget so the rule is
+  testable, and named as a KEY so the widget still spells both handlers out
+  literally — `every-handler-the-loop-offers-has-a-caller` reads those off
+  the source."
+  [s]
+  (if (:run-id s) :submit :start))
+
+(defn apply-start
+  "Fold the answer to POST /v1/runs.
+
+  A started run becomes the selected one, so the panels attach to what was
+  just asked for rather than leaving the user to find it in the picker. A
+  REFUSAL keeps the statement in the box: the server answers 503 when the
+  beam does not come up inside its window, and clearing the box would make a
+  retry mean retyping the paragraphs that were refused."
+  [s {:keys [ok body error]}]
+  (let [id (:run_id body)]
+    (if (and ok (not-empty (str id)))
+      (-> s
+          (select-run (str id))
+          clear-input
+          ;; The error too: a start that worked supersedes whatever the last
+          ;; attempt complained about, and leaving it up reads as this run
+          ;; having failed.
+          (assoc :error nil)
+          (note-notice (str "started " (str id))))
+      (note-error s (or (not-empty (str error))
+                        "the server accepted the request and returned no run id")))))

--- a/tui/samizdat/tui/widgets.clj
+++ b/tui/samizdat/tui/widgets.clj
@@ -36,7 +36,8 @@
 
   Toolkit-free: hiccup is data. `ftxui` appears nowhere in this file."
   (:require [clojure.string :as str]
-            [samizdat.tui.layout :as layout]))
+            [samizdat.tui.layout :as layout]
+            [samizdat.tui.state :as st]))
 
 ;; --- shared shapes -----------------------------------------------------------
 
@@ -448,29 +449,53 @@
 ;; --- the bottom strip --------------------------------------------------------
 
 (defn input
-  "The compose box, and the two things done to a run rather than said to it.
+  "The compose box, and the three things done to a run rather than said to it.
 
-  What the box sends is an INTERVENTION, not a chat message — samizdat runs
-  are autonomous and a person steers them at a turn boundary, so this is the
-  same seam the supervisor uses. Abort and resume sit beside it because they
-  are the other two, and because they were documented here long before
-  anything on screen called them."
+  ONE BOX, TWO MEANINGS, and `state/enter-action` decides which. With a run
+  selected what it sends is an INTERVENTION, not a chat message — samizdat
+  runs are autonomous and a person steers them at a turn boundary, so that is
+  the same seam the supervisor uses. With no run selected there is nothing to
+  steer, so the words are the problem statement for a new run: the TUI could
+  reach every run the server already had and could not make one, which made
+  the first thing anybody typed into a fresh harness an error message.
+
+  `start` is a button as well as a key, because with a run already selected
+  Enter belongs to steering and starting another needs somewhere to click.
+  Abort and resume sit beside it because they are the rest of what is done
+  to a run rather than said to it.
+
+  NO TITLE unless a layout asks for one. A bordered panel spent two rows
+  captioning a single input line whose own placeholder already says what it
+  takes; the caption is userspace like the rest of the arrangement, so
+  `{:title \"STEER\"}` brings it back."
   [state props]
-  (panel (assoc props :title (or (:title props) "STEER"))
-         [:hbox
-          [:input {:flex true
-                   :value (or (:input state) "")
-                   :placeholder "a directive for the run — Enter sends"
-                   :on-change (fn [s] (when-let [f (get-in state [:on :input])] (f s)))
-                   :on-enter (fn [s] (when-let [f (get-in state [:on :submit])] (f s)))}]
-          ;; Spelled out rather than built by a helper taking the key as an
-          ;; argument: `every-handler-the-loop-offers-has-a-caller` reads
-          ;; these literally, and a key assembled at runtime is a key that
-          ;; ratchet cannot see.
-          [:button {:label "abort"
-                    :on-click (fn [] (when-let [f (get-in state [:on :abort])] (f)))}]
-          [:button {:label "resume"
-                    :on-click (fn [] (when-let [f (get-in state [:on :resume])] (f)))}]]))
+  (let [starting? (= :start (st/enter-action state))
+        ;; Spelled out rather than built by a helper taking the key as an
+        ;; argument: `every-handler-the-loop-offers-has-a-caller` reads these
+        ;; literally, and a key assembled at runtime is a key that ratchet
+        ;; cannot see. That is also why the branch is over two whole handlers
+        ;; rather than over one name.
+        on-enter (if starting?
+                   (fn [s] (when-let [f (get-in state [:on :start])] (f s)))
+                   (fn [s] (when-let [f (get-in state [:on :submit])] (f s))))
+        ;; The layout's own sizing still applies to the bare row — it is the
+        ;; element that stands where the panel used to.
+        row [:hbox (select-keys props [:flex :width :height])
+             [:input {:flex true
+                      :value (or (:input state) "")
+                      :placeholder (if starting?
+                                     "the problem to work on — Enter starts a run"
+                                     "a directive for the run — Enter sends")
+                      :on-change (fn [s] (when-let [f (get-in state [:on :input])] (f s)))
+                      :on-enter on-enter}]
+             [:button {:label "start"
+                       :on-click (fn [] (when-let [f (get-in state [:on :start])]
+                                          (f (or (:input state) ""))))}]
+             [:button {:label "abort"
+                       :on-click (fn [] (when-let [f (get-in state [:on :abort])] (f)))}]
+             [:button {:label "resume"
+                       :on-click (fn [] (when-let [f (get-in state [:on :resume])] (f)))}]]]
+    (if (:title props) (panel props row) row)))
 
 (defn status
   "The status line: whether there is a server, which run, and what it is
@@ -484,6 +509,11 @@
      [:text {:dim true} (str " " (or (:run-id state) "no run") " ")]
      (when run [:text (str " " (:status run) " ")])
      (when-let [e (:error state)] [:text {:color :red} (str " " (clip e 40) " ")])
+     ;; Cyan, not red, and only when there is no error to report instead: a
+     ;; notice says what is happening ("starting…"), and a strip carrying both
+     ;; at once does not tell the reader which of them is the news.
+     (when-let [n (and (not (:error state)) (:notice state))]
+       [:text {:color :cyan} (str " " (clip n 40) " ")])
      (when-let [e (:layout-error state)] [:text {:color :yellow} (str " " (clip e 60) " ")])
      [:filler]
      [:text {:dim true} (str (or (:base state) "") " ")]]))

--- a/tui/samizdat/tui/widgets.clj
+++ b/tui/samizdat/tui/widgets.clj
@@ -75,6 +75,27 @@
   [s]
   [:text {:dim true} (str "  " s)])
 
+(defn fmt-tokens
+  "A token count short enough for a footer: 9475 -> \"9k\", 1250000 -> \"1.2M\".
+  Ported from dirge's status line, which learned that the exact figure is
+  noise at a glance and the magnitude is the signal."
+  [n]
+  (let [n (or n 0)]
+    (cond
+      (>= n 1000000) (format "%.1fM" (double (/ n 1000000)))
+      (>= n 1000) (str (quot n 1000) "k")
+      :else (str n))))
+
+(defn project-label
+  "`project:branch`, or just the project when there is no branch to name — a
+  detached HEAD, or a harness outside a git tree. Never a dangling separator."
+  [{:keys [project branch]}]
+  (let [p (str (or project ""))]
+    (cond
+      (str/blank? p) nil
+      (not-empty (str branch)) (str p ":" branch)
+      :else p)))
+
 (defn fold-id
   "The identity of one foldable section, stable across frames.
 
@@ -446,6 +467,42 @@
       (seq (:questions a)) (questionnaire state a)
       :else (permission-dialog state a))))
 
+(defn git
+  "The working tree at a glance: branch, what is dirty, and the last commit.
+
+  Ported from dirge's left-panel GIT box. The three counts are kept separate
+  because git keeps them separate — a path can be staged AND edited again
+  since, so one \"dirty\" number would hide the case a reader most needs to
+  see before shipping.
+
+  Everything comes from GET /v1/harness/project: this process reads no git of
+  its own, so a TUI pointed at a harness on another machine shows THAT
+  machine's tree rather than confidently mislabelling its own."
+  [state props]
+  (let [{:keys [branch staged unstaged untracked last_commit] :as p} (:project state)
+        counts (mapv #(or % 0) [staged unstaged untracked])
+        dirty (reduce + counts)]
+    (panel props
+           (cond
+             (nil? p) (empty-note "no harness yet")
+             (nil? branch) (empty-note (if (some? staged)
+                                         "detached HEAD"
+                                         "not a git working tree"))
+             :else
+             [:vbox
+              [:text {:color :green} (str " \u2387 " (clip branch 24))]
+              (if (zero? dirty)
+                [:text {:dim true} "  clean"]
+                [:hbox
+                 [:text {:color (if (pos? (nth counts 0)) :green :default)}
+                  (str "  +" (nth counts 0))]
+                 [:text {:color (if (pos? (nth counts 1)) :yellow :default)}
+                  (str " ~" (nth counts 1))]
+                 [:text {:color (if (pos? (nth counts 2)) :yellow :default)}
+                  (str " ?" (nth counts 2))]])
+              (when (not-empty (str last_commit))
+                [:text {:dim true} (str "  " (clip last_commit 30))])]))))
+
 ;; --- the bottom strip --------------------------------------------------------
 
 (defn input
@@ -497,26 +554,95 @@
                        :on-click (fn [] (when-let [f (get-in state [:on :resume])] (f)))}]]]
     (if (:title props) (panel props row) row)))
 
+(def ^:private fold-warn-fraction
+  "Where the footer starts flagging a fold, as a fraction of the window.
+
+  dirge's numbers and its reasoning: the denominator is the WINDOW, so the
+  gauge reads 0-100 rather than running past 100 once usage passes the
+  fold-trigger budget — a fold is flagged by a marker instead (dirge-l4rp,
+  dirge-cx7t). samizdat's own ladder rungs are gates.edn :compaction; these
+  two are the front end's warning line, not the policy, which is why they are
+  not read from there."
+  0.75)
+
+(def ^:private fold-urgent-fraction 0.90)
+
+(defn- fill-segment
+  "`used / window (pct%)` with a fold marker as the window fills, or nil when
+  there is no window to measure against."
+  [used window]
+  (when (and window (pos? window))
+    (let [pct (quot (* 100 (or used 0)) window)
+          frac (/ (double (or used 0)) window)]
+      (str (fmt-tokens used) " / " (fmt-tokens window) " (" pct "%"
+           (cond (>= frac fold-urgent-fraction) " fold!"
+                 (>= frac fold-warn-fraction) " fold"
+                 :else "")
+           ")"))))
+
 (defn status
-  "The status line: whether there is a server, which run, and what it is
-  doing. The first thing to look at when nothing else is moving."
+  "The footer: where the harness is pointed, what is answering, what the run
+  has spent, and what it is doing.
+
+  Ported from dirge's status line, which reads
+  `project:branch | model | used/ctx (pct%) | Nmsgs | state`. Samizdat's said
+  only the run id and the base URL — nothing about WHICH project or WHICH
+  model, which are the two things that say whether the harness is pointed
+  where the reader thinks it is. A stale serve process answering on the
+  expected port is exactly the confusion these segments remove.
+
+  Every segment is optional and the strip draws with none of them: the first
+  frame has no project, no run and no connection. The connection dot stays
+  leftmost and is samizdat's own addition — dirge's UI is the process doing
+  the work, where this one is a client that can be pointed anywhere and has
+  to say when it has lost the thing it is watching."
   [state props]
-  (let [run (get-in state [:detail :run])]
-    [:hbox {:bg :gray-dark}
-     (if (:connected? state)
-       [:text {:color :green} " ● connected "]
-       [:text {:color :red} " ○ offline "])
-     [:text {:dim true} (str " " (or (:run-id state) "no run") " ")]
-     (when run [:text (str " " (:status run) " ")])
-     (when-let [e (:error state)] [:text {:color :red} (str " " (clip e 40) " ")])
-     ;; Cyan, not red, and only when there is no error to report instead: a
-     ;; notice says what is happening ("starting…"), and a strip carrying both
-     ;; at once does not tell the reader which of them is the news.
-     (when-let [n (and (not (:error state)) (:notice state))]
-       [:text {:color :cyan} (str " " (clip n 40) " ")])
-     (when-let [e (:layout-error state)] [:text {:color :yellow} (str " " (clip e 60) " ")])
-     [:filler]
-     [:text {:dim true} (str (or (:base state) "") " ")]]))
+  (let [run (get-in state [:detail :run])
+        p (:project state)
+        model (or (:model run) (:model p))
+        used (get-in run [:usage :total-tokens])
+        turns (get-in run [:usage :turns])
+        fill (fill-segment used (:context_window p))
+        sep [:text {:dim true} " \u2502 "]]
+    (into [:hbox {:bg :gray-dark}]
+          (remove nil?
+                  [(if (:connected? state)
+                     [:text {:color :green} " \u25cf connected "]
+                     [:text {:color :red} " \u25cb offline "])
+                   (when-let [l (project-label p)]
+                     [:text {:bold true} (str " " (clip l 34))])
+                   (when model sep)
+                   (when model [:text {:color :cyan} (clip (str model) 20)])
+                   (when fill sep)
+                   (when fill [:text {:dim true} fill])
+                   (when turns sep)
+                   (when turns [:text {:dim true}
+                                (str turns (when-let [m (:max_turns run)]
+                                             (str " / " m))
+                                     " turns")])
+                   (when run sep)
+                   (when run [:text (str (:status run))])
+                   sep
+                   [:text {:dim true} (if-let [r (:run-id state)]
+                                        (subs (str r) 0 (min 8 (count (str r))))
+                                        "no run")]
+                   (when-let [e (:error state)]
+                     [:text {:color :red} (str " " (clip e 40) " ")])
+                   ;; Cyan, not red, and only when there is no error to report
+                   ;; instead: a notice says what is happening ("starting…"),
+                   ;; and a strip carrying both at once does not tell the
+                   ;; reader which of them is the news.
+                   (when-let [n (and (not (:error state)) (:notice state))]
+                     [:text {:color :cyan} (str " " (clip n 40) " ")])
+                   (when-let [e (:layout-error state)]
+                     [:text {:color :yellow} (str " " (clip e 60) " ")])
+                   [:filler]
+                   ;; Scheme stripped: "http://" is seven columns that say
+                   ;; nothing, and with the project, model, fill and turn
+                   ;; segments now on this line the strip overran an
+                   ;; ordinary terminal and clipped the run id into the URL.
+                   [:text {:dim true}
+                    (str " " (str/replace (str (or (:base state) "")) #"^https?://" "") " ")]]))))
 
 ;; --- registration ------------------------------------------------------------
 ;;
@@ -525,6 +651,7 @@
 ;; its own box rather than taking the frame down (samizdat.tui.layout).
 
 (doseq [[tag f] {:widget/activity     activity
+                 :widget/git          git
                  :widget/approvals    approvals
                  :widget/conversation conversation
                  :widget/tasks        tasks


### PR DESCRIPTION
Five things, in the order they were found.

**The TUI could not start a run.** With nothing selected Enter went to
`:submit`, which answered "no run selected" and dropped what had been typed, so
a harness with an empty database had no path to its first run from the UI.
Enter now means `:start` while nothing is selected and `:submit` once
something is; `state/enter-action` holds the rule so it is testable rather than
a branch in a click handler. A `start` button does it either way. Only
`:problem` goes up — the rest of what `POST /v1/runs` takes is left to the
server's config — and it runs off the UI thread, since that endpoint waits for
the beam to open every branch.

Abort and resume did receive their clicks; they did nothing and said nothing
with no run selected, which from the outside is a button wired to nothing.
Both say so now. Two toolkit tests press them for real, one on the widget and
one inside the whole shipped layout, since the container FTXUI hit-tests is
built out of the layout rather than the widget.

The STEER panel spent two rows captioning a single input line whose own
placeholder says what it takes. The row is bare; `{:title "STEER"}` brings the
caption back.

**A config file that named a provider did not get that provider.** The
provider came from `detect-provider` alone and the file layers were merged on
top of the preset that choice had already expanded, so
`{:llm {:provider :glm}}` set the `:provider` key and nothing else: DeepSeek's
endpoint, DeepSeek's key and deepseek-v4-flash, dispatching the GLM adapter,
silently. Files are now read before the preset is expanded. A provider spelled
as a string is the provider it names; one no table knows is an error rather
than a fall back to whatever the environment had.

`glm-uses-the-coding-endpoint` had bound the loaded values, ignored them and
asserted the static table instead, with a comment about key-env detection. It
asserts the loaded config now.

**proc/run leaked two descriptors per subprocess.** `:out :string` reads the
child's output into a string and left the pipe fds open — 30 spawns cost 60,
60 cost 120, never released. This is the leak behind provenance A-3, where the
suite "holds ~260 fds at peak" and the test task raises `ulimit -n` to 1024.
Three new git-spawning tests crossed even the raised limit and it surfaced
nowhere near the cause: eleven errors in store-test's ledger tests reading
"sqlite step failed: unable to open database file", all of which passed in
isolation. Not test-only — the `shell` tool runs through here, so a run that
shells out a few hundred times exhausts its own descriptors and then cannot
open its database.

**The footer and a GIT box, ported from dirge.** The status line said the run
id and the base URL, nothing about which project, branch or model — the things
that say whether the harness is pointed where you think it is. It now reads
`project:branch │ model │ used/window (pct%) │ turns │ status │ run`. The
denominator is the context window rather than the fold-trigger budget, so the
percentage reads 0-100 and an imminent fold is a `fold`/`fold!` marker;
`project:branch` collapses to the project alone on a detached HEAD. The
connection dot stays leftmost and is ours: dirge's UI is the process doing the
work, this one is a client that can be pointed anywhere.

`:widget/git` is dirge's left-panel GIT box — branch, `+staged ~unstaged
?untracked`, last commit subject. Both read a new `GET /v1/harness/project`,
served because only the harness process is bound to the project: a TUI
shelling out to git itself would caption whichever directory it was started
from whenever it is pointed elsewhere. The server caches the git side for
`:git-snapshot-ttl-ms`, since the poller asks every 1.5s and dirge froze its
own UI reading `.git/HEAD` per frame before it cached.

GIT sits in the wide CLAIMS/GATES row rather than a gutter. A fourth box in
the right column put 20 pinned rows against a `:grow` MODIFIED that may not be
squeezed, so on a 28-row terminal it drew as a titled box with nothing in it —
the squeeze tui.edn's own warning is about, one panel further along. The
toolkit test asserts the box's content now, not its title, which is what let
the bad placement pass.

**Both workflows pin jolt.** linux-sandbox.yml took the latest release; it
builds no binary so it never hit the 0.8.5 boot-image abort, but it runs on
every push and had no reason to track whatever shipped this morning.

`docs/tui.md` covers the footer, the endpoint and the two layout traps.

2222 tests / 9760 assertions green, plus 8 toolkit tests / 35 assertions
(`jolt tui-test`). The baseline at the previous commit was confirmed green
before trusting that the eleven store-test errors were mine.

Not in here, and worth knowing: a `jolt serve` process left running since
Sep 6 answers /health normally and 503s every `POST /v1/runs` at 30s, creating
no run row, because it predates both the ebb adoption and the deadline raise
in karamazov-iev2. That is karamazov-uk77, and restarting the harness is the
fix.